### PR TITLE
[KED-2419] Make pipeline and Pipeline consistent

### DIFF
--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -1,194 +1,26 @@
 """Helper to integrate modular pipelines into a master pipeline."""
-import copy
-from typing import AbstractSet, Dict, List, Set, Union
+from typing import Dict, Set, Union, Iterable
 
 from kedro.pipeline.node import Node
 from kedro.pipeline.pipeline import (
-    TRANSCODING_SEPARATOR,
     Pipeline,
-    _strip_transcoding,
-    _transcode_split,
 )
-
-_PARAMETER_KEYWORDS = ("params:", "parameters")
-
-
-class ModularPipelineError(Exception):
-    """Raised when a modular pipeline is not adapted and integrated
-    appropriately using the helper.
-    """
-
-    pass
-
-
-def _is_parameter(name: str) -> bool:
-    return any(name.startswith(param) for param in _PARAMETER_KEYWORDS)
-
-
-def _validate_inputs_outputs(
-    inputs: AbstractSet[str], outputs: AbstractSet[str], pipe: Pipeline
-) -> None:
-    """Safeguards to ensure that:
-    - parameters are not specified under inputs
-    - inputs are only free inputs
-    - outputs do not contain free inputs
-    """
-    inputs = {_strip_transcoding(k) for k in inputs}
-    outputs = {_strip_transcoding(k) for k in outputs}
-
-    if any(_is_parameter(i) for i in inputs):
-        raise ModularPipelineError(
-            "Parameters should be specified in the `parameters` argument"
-        )
-
-    free_inputs = {_strip_transcoding(i) for i in pipe.inputs()}
-
-    if not inputs <= free_inputs:
-        raise ModularPipelineError("Inputs should be free inputs to the pipeline")
-
-    if outputs & free_inputs:
-        raise ModularPipelineError("Outputs can't contain free inputs to the pipeline")
-
-
-def _validate_datasets_exist(
-    inputs: AbstractSet[str],
-    outputs: AbstractSet[str],
-    parameters: AbstractSet[str],
-    pipe: Pipeline,
-) -> None:
-    inputs = {_strip_transcoding(k) for k in inputs}
-    outputs = {_strip_transcoding(k) for k in outputs}
-
-    existing = {_strip_transcoding(ds) for ds in pipe.data_sets()}
-    non_existent = (inputs | outputs | parameters) - existing
-    if non_existent:
-        raise ModularPipelineError(
-            f"Failed to map datasets and/or parameters: "
-            f"{', '.join(sorted(non_existent))}"
-        )
 
 
 def pipeline(
-    pipe: Pipeline,
+    nodes: Iterable[Union[Node, Pipeline]],
     *,
+    tags: Union[str, Iterable[str]] = None,
     inputs: Union[str, Set[str], Dict[str, str]] = None,
     outputs: Union[str, Set[str], Dict[str, str]] = None,
     parameters: Dict[str, str] = None,
     namespace: str = None,
-) -> Pipeline:
-    """Create a copy of the pipeline and its nodes,
-    with some dataset names and node names modified.
-
-    Args:
-        pipe: Original modular pipeline to integrate
-        inputs: A name or collection of input names to be exposed as connection points
-            to other pipelines upstream.
-            When str or Set[str] is provided, the listed input names will stay
-            the same as they are named in the provided pipeline.
-            When Dict[str, str] is provided, current input names will be
-            mapped to new names.
-            Must only refer to the pipeline's free inputs.
-        outputs: A name or collection of names to be exposed as connection points
-            to other pipelines downstream.
-            When str or Set[str] is provided, the listed output names will stay
-            the same as they are named in the provided pipeline.
-            When Dict[str, str] is provided, current output names will be
-            mapped to new names.
-            Can refer to both the pipeline's free outputs, as well as
-            intermediate results that need to be exposed.
-        parameters: A map of existing parameter to the new one.
-        namespace: A prefix to give to all dataset names,
-            except those explicitly named with the `inputs`/`outputs`
-            arguments, and parameter references (`params:` and `parameters`).
-
-    Raises:
-        ModularPipelineError: When inputs, outputs or parameters are incorrectly
-            specified, or they do not exist on the original pipeline.
-        ValueError: When underlying pipeline nodes inputs/outputs are not
-            any of the expected types (str, dict, list, or None).
-
-    Returns:
-        A new ``Pipeline`` object with the new nodes, modified as requested.
-    """
-    # pylint: disable=protected-access
-    inputs = _to_dict(inputs)
-    outputs = _to_dict(outputs)
-    parameters = _to_dict(parameters)
-
-    _validate_datasets_exist(inputs.keys(), outputs.keys(), parameters.keys(), pipe)
-    _validate_inputs_outputs(inputs.keys(), outputs.keys(), pipe)
-
-    mapping = {**inputs, **outputs, **parameters}
-
-    def _prefix(name: str) -> str:
-        return f"{namespace}.{name}" if namespace else name
-
-    def _is_transcode_base_in_mapping(name: str) -> bool:
-        base_name, _ = _transcode_split(name)
-        return base_name in mapping
-
-    def _map_transcode_base(name: str):
-        base_name, transcode_suffix = _transcode_split(name)
-        return TRANSCODING_SEPARATOR.join((mapping[base_name], transcode_suffix))
-
-    def _rename(name: str):
-        rules = [
-            # if name mapped to new name, update with new name
-            (lambda n: n in mapping, lambda n: mapping[n]),
-            # if it's a parameter, leave as is (don't namespace)
-            (_is_parameter, lambda n: n),
-            # if transcode base is mapped to a new name, update with new base
-            (_is_transcode_base_in_mapping, _map_transcode_base),
-            # if namespace given, prefix name using that namespace
-            (lambda n: bool(namespace), _prefix),
-        ]
-
-        for predicate, processor in rules:
-            if predicate(name):
-                return processor(name)
-
-        # leave name as is
-        return name
-
-    def _process_dataset_names(
-        datasets: Union[None, str, List[str], Dict[str, str]]
-    ) -> Union[None, str, List[str], Dict[str, str]]:
-        if datasets is None:
-            return None
-        if isinstance(datasets, str):
-            return _rename(datasets)
-        if isinstance(datasets, list):
-            return [_rename(name) for name in datasets]
-        if isinstance(datasets, dict):
-            return {key: _rename(value) for key, value in datasets.items()}
-
-        raise ValueError(  # pragma: no cover
-            f"Unexpected input {datasets} of type {type(datasets)}"
-        )
-
-    def _copy_node(node: Node) -> Node:
-        new_namespace = node.namespace
-        if namespace:
-            new_namespace = (
-                f"{namespace}.{node.namespace}" if node.namespace else namespace
-            )
-
-        return node._copy(
-            inputs=_process_dataset_names(node._inputs),
-            outputs=_process_dataset_names(node._outputs),
-            namespace=new_namespace,
-        )
-
-    new_nodes = [_copy_node(n) for n in pipe.nodes]
-
-    return Pipeline(new_nodes)
-
-
-def _to_dict(element: Union[None, str, Set[str], Dict[str, str]]) -> Dict[str, str]:
-    if element is None:
-        return {}
-    if isinstance(element, str):
-        return {element: element}
-    if isinstance(element, dict):
-        return copy.deepcopy(element)
-    return {item: item for item in element}
+):
+    return Pipeline(
+        nodes,
+        tags=tags,
+        inputs=inputs,
+        outputs=outputs,
+        parameters=parameters,
+        namespace=namespace,
+    )

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -599,7 +599,7 @@ def node(
     outputs: Union[None, str, List[str], Dict[str, str]],
     *,
     name: str = None,
-    tags: Iterable[str] = None,
+    tags: Union[str, Iterable[str]] = None,
     confirms: Union[str, List[str]] = None,
     namespace: str = None,
 ) -> Node:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -70,6 +70,11 @@ class ConfirmNotUniqueError(Exception):
     pass
 
 
+# factory function.
+# user should just do pipeline, not Pipeline
+# Make Pipeline and pipeline directly interchangeable. If make them similar then no benefit in not going all the way.
+
+
 class Pipeline:  # pylint: disable=too-many-public-methods
     """A ``Pipeline`` defined as a collection of ``Node`` objects. This class
     treats nodes as part of a graph representation and provides inputs,
@@ -81,6 +86,8 @@ class Pipeline:  # pylint: disable=too-many-public-methods
         nodes: Iterable[Union[Node, "Pipeline"]],
         *,
         tags: Union[str, Iterable[str]] = None,
+        # TODO? could also put inputs/outputs/parameters in here
+        # TODO: namespace should be here
     ):
         """Initialise ``Pipeline`` with a list of ``Node`` instances.
 
@@ -157,7 +164,7 @@ class Pipeline:  # pylint: disable=too-many-public-methods
                 self._nodes_by_input[_strip_transcoding(input_)].add(node)
 
         # output -> node with output
-        self._nodes_by_output = {}  # type: Dict[str, Node]
+        self._nodes_by_output = {}  # type: Dict[str, # Node]
         for node in nodes:
             for output in node.outputs:
                 self._nodes_by_output[_strip_transcoding(output)] = node

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -135,8 +135,10 @@ class Pipeline:  # pylint: disable=too-many-public-methods
         self._set_pipeline(nodes, tags)
         if inputs or outputs or parameters or namespace:
             new_nodes = self._transform_pipeline(inputs, outputs, parameters, namespace)
-            self._set_pipeline(new_nodes, tags)
-            # TODO: don't really need to carry around tags here?
+            self._set_pipeline(
+                new_nodes, tags
+            )  # TODO: don't really need to carry around tags here?
+            # Or neater to do self.__init__(nodes, tags)?
 
     def _set_pipeline(self, nodes, tags):
         if nodes is None:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -132,6 +132,13 @@ class Pipeline:  # pylint: disable=too-many-public-methods
             >>>
 
         """
+        self._set_pipeline(nodes, tags)
+        if inputs or outputs or parameters or namespace:
+            new_nodes = self._transform_pipeline(inputs, outputs, parameters, namespace)
+            self._set_pipeline(new_nodes, tags)
+            # TODO: don't really need to carry around tags here?
+
+    def _set_pipeline(self, nodes, tags):
         if nodes is None:
             raise ValueError(
                 "`nodes` argument of `Pipeline` is None. It must be an "
@@ -161,13 +168,126 @@ class Pipeline:  # pylint: disable=too-many-public-methods
                 self._nodes_by_input[_strip_transcoding(input_)].add(node)
 
         # output -> node with output
-        self._nodes_by_output = {}  # type: Dict[str, # Node]
+        self._nodes_by_output = {}  # type: Dict[str, Node]
         for node in nodes:
             for output in node.outputs:
                 self._nodes_by_output[_strip_transcoding(output)] = node
 
         self._nodes = nodes
         self._topo_sorted_nodes = _topologically_sorted(self.node_dependencies)
+
+    def _transform_pipeline(
+        self,
+        inputs: Union[str, Set[str], Dict[str, str]],
+        outputs: Union[str, Set[str], Dict[str, str]],
+        parameters: Dict[str, str],
+        namespace: str,
+    ):
+        """Create a copy of the pipeline and its nodes,
+        with some dataset names and node names modified.
+
+        Args:
+            inputs: A name or collection of input names to be exposed as connection points
+                to other pipelines upstream.
+                When str or Set[str] is provided, the listed input names will stay
+                the same as they are named in the provided pipeline.
+                When Dict[str, str] is provided, current input names will be
+                mapped to new names.
+                Must only refer to the pipeline's free inputs.
+            outputs: A name or collection of names to be exposed as connection points
+                to other pipelines downstream.
+                When str or Set[str] is provided, the listed output names will stay
+                the same as they are named in the provided pipeline.
+                When Dict[str, str] is provided, current output names will be
+                mapped to new names.
+                Can refer to both the pipeline's free outputs, as well as
+                intermediate results that need to be exposed.
+            parameters: A map of existing parameter to the new one.
+            namespace: A prefix to give to all dataset names,
+                except those explicitly named with the `inputs`/`outputs`
+                arguments, and parameter references (`params:` and `parameters`).
+
+        Raises:
+            ModularPipelineError: When inputs, outputs or parameters are incorrectly
+                specified, or they do not exist on the original pipeline.
+            ValueError: When underlying pipeline nodes inputs/outputs are not
+                any of the expected types (str, dict, list, or None).
+
+        Returns:
+            A new ``Pipeline`` object with the new nodes, modified as requested.
+        """
+        # pylint: disable=protected-access
+        inputs = _to_dict(inputs)
+        outputs = _to_dict(outputs)
+        parameters = _to_dict(parameters)
+
+        _validate_datasets_exist(inputs.keys(), outputs.keys(), parameters.keys(), self)
+        _validate_inputs_outputs(inputs.keys(), outputs.keys(), self)
+
+        mapping = {**inputs, **outputs, **parameters}
+
+        def _prefix(name: str) -> str:
+            return f"{namespace}.{name}" if namespace else name
+
+        def _is_transcode_base_in_mapping(name: str) -> bool:
+            base_name, _ = _transcode_split(name)
+            return base_name in mapping
+
+        def _map_transcode_base(name: str):
+            base_name, transcode_suffix = _transcode_split(name)
+            return TRANSCODING_SEPARATOR.join((mapping[base_name], transcode_suffix))
+
+        def _rename(name: str):
+            rules = [
+                # if name mapped to new name, update with new name
+                (lambda n: n in mapping, lambda n: mapping[n]),
+                # if it's a parameter, leave as is (don't namespace)
+                (_is_parameter, lambda n: n),
+                # if transcode base is mapped to a new name, update with new base
+                (_is_transcode_base_in_mapping, _map_transcode_base),
+                # if namespace given, prefix name using that namespace
+                (lambda n: bool(namespace), _prefix),
+            ]
+
+            for predicate, processor in rules:
+                if predicate(name):
+                    return processor(name)
+
+            # leave name as is
+            return name
+
+        def _process_dataset_names(
+            datasets: Union[None, str, List[str], Dict[str, str]]
+        ) -> Union[None, str, List[str], Dict[str, str]]:
+            if datasets is None:
+                return None
+            if isinstance(datasets, str):
+                return _rename(datasets)
+            if isinstance(datasets, list):
+                return [_rename(name) for name in datasets]
+            if isinstance(datasets, dict):
+                return {key: _rename(value) for key, value in datasets.items()}
+
+            raise ValueError(  # pragma: no cover
+                f"Unexpected input {datasets} of type {type(datasets)}"
+            )
+
+        def _copy_node(node: Node) -> Node:
+            new_namespace = node.namespace
+            if namespace:
+                new_namespace = (
+                    f"{namespace}.{node.namespace}" if node.namespace else namespace
+                )
+
+            return node._copy(
+                inputs=_process_dataset_names(node._inputs),
+                outputs=_process_dataset_names(node._outputs),
+                namespace=new_namespace,
+            )
+
+        # TODO: maybe change copy logic to just update?
+        new_nodes = [_copy_node(n) for n in self.nodes]
+        return new_nodes
 
     def __repr__(self):  # pragma: no cover
         """Pipeline ([node1, ..., node10 ...], name='pipeline_name')"""
@@ -901,122 +1021,6 @@ def _validate_datasets_exist(
             f"Failed to map datasets and/or parameters: "
             f"{', '.join(sorted(non_existent))}"
         )
-
-
-def _transform_pipeline(
-    pipe: Pipeline,
-    *,
-    inputs: Union[str, Set[str], Dict[str, str]] = None,
-    outputs: Union[str, Set[str], Dict[str, str]] = None,
-    parameters: Dict[str, str] = None,
-    namespace: str = None,
-) -> Pipeline:
-    """Create a copy of the pipeline and its nodes,
-    with some dataset names and node names modified.
-
-    Args:
-        pipe: Original modular pipeline to integrate
-        inputs: A name or collection of input names to be exposed as connection points
-            to other pipelines upstream.
-            When str or Set[str] is provided, the listed input names will stay
-            the same as they are named in the provided pipeline.
-            When Dict[str, str] is provided, current input names will be
-            mapped to new names.
-            Must only refer to the pipeline's free inputs.
-        outputs: A name or collection of names to be exposed as connection points
-            to other pipelines downstream.
-            When str or Set[str] is provided, the listed output names will stay
-            the same as they are named in the provided pipeline.
-            When Dict[str, str] is provided, current output names will be
-            mapped to new names.
-            Can refer to both the pipeline's free outputs, as well as
-            intermediate results that need to be exposed.
-        parameters: A map of existing parameter to the new one.
-        namespace: A prefix to give to all dataset names,
-            except those explicitly named with the `inputs`/`outputs`
-            arguments, and parameter references (`params:` and `parameters`).
-
-    Raises:
-        ModularPipelineError: When inputs, outputs or parameters are incorrectly
-            specified, or they do not exist on the original pipeline.
-        ValueError: When underlying pipeline nodes inputs/outputs are not
-            any of the expected types (str, dict, list, or None).
-
-    Returns:
-        A new ``Pipeline`` object with the new nodes, modified as requested.
-    """
-    # pylint: disable=protected-access
-    inputs = _to_dict(inputs)
-    outputs = _to_dict(outputs)
-    parameters = _to_dict(parameters)
-
-    _validate_datasets_exist(inputs.keys(), outputs.keys(), parameters.keys(), pipe)
-    _validate_inputs_outputs(inputs.keys(), outputs.keys(), pipe)
-
-    mapping = {**inputs, **outputs, **parameters}
-
-    def _prefix(name: str) -> str:
-        return f"{namespace}.{name}" if namespace else name
-
-    def _is_transcode_base_in_mapping(name: str) -> bool:
-        base_name, _ = _transcode_split(name)
-        return base_name in mapping
-
-    def _map_transcode_base(name: str):
-        base_name, transcode_suffix = _transcode_split(name)
-        return TRANSCODING_SEPARATOR.join((mapping[base_name], transcode_suffix))
-
-    def _rename(name: str):
-        rules = [
-            # if name mapped to new name, update with new name
-            (lambda n: n in mapping, lambda n: mapping[n]),
-            # if it's a parameter, leave as is (don't namespace)
-            (_is_parameter, lambda n: n),
-            # if transcode base is mapped to a new name, update with new base
-            (_is_transcode_base_in_mapping, _map_transcode_base),
-            # if namespace given, prefix name using that namespace
-            (lambda n: bool(namespace), _prefix),
-        ]
-
-        for predicate, processor in rules:
-            if predicate(name):
-                return processor(name)
-
-        # leave name as is
-        return name
-
-    def _process_dataset_names(
-        datasets: Union[None, str, List[str], Dict[str, str]]
-    ) -> Union[None, str, List[str], Dict[str, str]]:
-        if datasets is None:
-            return None
-        if isinstance(datasets, str):
-            return _rename(datasets)
-        if isinstance(datasets, list):
-            return [_rename(name) for name in datasets]
-        if isinstance(datasets, dict):
-            return {key: _rename(value) for key, value in datasets.items()}
-
-        raise ValueError(  # pragma: no cover
-            f"Unexpected input {datasets} of type {type(datasets)}"
-        )
-
-    def _copy_node(node: Node) -> Node:
-        new_namespace = node.namespace
-        if namespace:
-            new_namespace = (
-                f"{namespace}.{node.namespace}" if node.namespace else namespace
-            )
-
-        return node._copy(
-            inputs=_process_dataset_names(node._inputs),
-            outputs=_process_dataset_names(node._outputs),
-            namespace=new_namespace,
-        )
-
-    new_nodes = [_copy_node(n) for n in pipe.nodes]
-
-    return Pipeline(new_nodes)
 
 
 def _to_dict(element: Union[None, str, Set[str], Dict[str, str]]) -> Dict[str, str]:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -7,7 +7,7 @@ import copy
 import json
 from collections import Counter, defaultdict
 from itertools import chain
-from typing import Callable, Dict, Iterable, List, Set, Tuple, Union
+from typing import Callable, Dict, Iterable, List, Set, Tuple, Union, AbstractSet
 from warnings import warn
 
 from toposort import CircularDependencyError as ToposortCircleError
@@ -70,11 +70,6 @@ class ConfirmNotUniqueError(Exception):
     pass
 
 
-# factory function.
-# user should just do pipeline, not Pipeline
-# Make Pipeline and pipeline directly interchangeable. If make them similar then no benefit in not going all the way.
-
-
 class Pipeline:  # pylint: disable=too-many-public-methods
     """A ``Pipeline`` defined as a collection of ``Node`` objects. This class
     treats nodes as part of a graph representation and provides inputs,
@@ -86,8 +81,10 @@ class Pipeline:  # pylint: disable=too-many-public-methods
         nodes: Iterable[Union[Node, "Pipeline"]],
         *,
         tags: Union[str, Iterable[str]] = None,
-        # TODO? could also put inputs/outputs/parameters in here
-        # TODO: namespace should be here
+        inputs: Union[str, Set[str], Dict[str, str]] = None,
+        outputs: Union[str, Set[str], Dict[str, str]] = None,
+        parameters: Dict[str, str] = None,
+        namespace: str = None,
     ):
         """Initialise ``Pipeline`` with a list of ``Node`` instances.
 
@@ -846,3 +843,187 @@ class CircularDependencyError(Exception):
     """
 
     pass
+
+
+_PARAMETER_KEYWORDS = ("params:", "parameters")
+
+
+class ModularPipelineError(Exception):
+    """Raised when a modular pipeline is not adapted and integrated
+    appropriately using the helper.
+    """
+
+    pass
+
+
+def _is_parameter(name: str) -> bool:
+    return any(name.startswith(param) for param in _PARAMETER_KEYWORDS)
+
+
+def _validate_inputs_outputs(
+    inputs: AbstractSet[str], outputs: AbstractSet[str], pipe: Pipeline
+) -> None:
+    """Safeguards to ensure that:
+    - parameters are not specified under inputs
+    - inputs are only free inputs
+    - outputs do not contain free inputs
+    """
+    inputs = {_strip_transcoding(k) for k in inputs}
+    outputs = {_strip_transcoding(k) for k in outputs}
+
+    if any(_is_parameter(i) for i in inputs):
+        raise ModularPipelineError(
+            "Parameters should be specified in the `parameters` argument"
+        )
+
+    free_inputs = {_strip_transcoding(i) for i in pipe.inputs()}
+
+    if not inputs <= free_inputs:
+        raise ModularPipelineError("Inputs should be free inputs to the pipeline")
+
+    if outputs & free_inputs:
+        raise ModularPipelineError("Outputs can't contain free inputs to the pipeline")
+
+
+def _validate_datasets_exist(
+    inputs: AbstractSet[str],
+    outputs: AbstractSet[str],
+    parameters: AbstractSet[str],
+    pipe: Pipeline,
+) -> None:
+    inputs = {_strip_transcoding(k) for k in inputs}
+    outputs = {_strip_transcoding(k) for k in outputs}
+
+    existing = {_strip_transcoding(ds) for ds in pipe.data_sets()}
+    non_existent = (inputs | outputs | parameters) - existing
+    if non_existent:
+        raise ModularPipelineError(
+            f"Failed to map datasets and/or parameters: "
+            f"{', '.join(sorted(non_existent))}"
+        )
+
+
+def _transform_pipeline(
+    pipe: Pipeline,
+    *,
+    inputs: Union[str, Set[str], Dict[str, str]] = None,
+    outputs: Union[str, Set[str], Dict[str, str]] = None,
+    parameters: Dict[str, str] = None,
+    namespace: str = None,
+) -> Pipeline:
+    """Create a copy of the pipeline and its nodes,
+    with some dataset names and node names modified.
+
+    Args:
+        pipe: Original modular pipeline to integrate
+        inputs: A name or collection of input names to be exposed as connection points
+            to other pipelines upstream.
+            When str or Set[str] is provided, the listed input names will stay
+            the same as they are named in the provided pipeline.
+            When Dict[str, str] is provided, current input names will be
+            mapped to new names.
+            Must only refer to the pipeline's free inputs.
+        outputs: A name or collection of names to be exposed as connection points
+            to other pipelines downstream.
+            When str or Set[str] is provided, the listed output names will stay
+            the same as they are named in the provided pipeline.
+            When Dict[str, str] is provided, current output names will be
+            mapped to new names.
+            Can refer to both the pipeline's free outputs, as well as
+            intermediate results that need to be exposed.
+        parameters: A map of existing parameter to the new one.
+        namespace: A prefix to give to all dataset names,
+            except those explicitly named with the `inputs`/`outputs`
+            arguments, and parameter references (`params:` and `parameters`).
+
+    Raises:
+        ModularPipelineError: When inputs, outputs or parameters are incorrectly
+            specified, or they do not exist on the original pipeline.
+        ValueError: When underlying pipeline nodes inputs/outputs are not
+            any of the expected types (str, dict, list, or None).
+
+    Returns:
+        A new ``Pipeline`` object with the new nodes, modified as requested.
+    """
+    # pylint: disable=protected-access
+    inputs = _to_dict(inputs)
+    outputs = _to_dict(outputs)
+    parameters = _to_dict(parameters)
+
+    _validate_datasets_exist(inputs.keys(), outputs.keys(), parameters.keys(), pipe)
+    _validate_inputs_outputs(inputs.keys(), outputs.keys(), pipe)
+
+    mapping = {**inputs, **outputs, **parameters}
+
+    def _prefix(name: str) -> str:
+        return f"{namespace}.{name}" if namespace else name
+
+    def _is_transcode_base_in_mapping(name: str) -> bool:
+        base_name, _ = _transcode_split(name)
+        return base_name in mapping
+
+    def _map_transcode_base(name: str):
+        base_name, transcode_suffix = _transcode_split(name)
+        return TRANSCODING_SEPARATOR.join((mapping[base_name], transcode_suffix))
+
+    def _rename(name: str):
+        rules = [
+            # if name mapped to new name, update with new name
+            (lambda n: n in mapping, lambda n: mapping[n]),
+            # if it's a parameter, leave as is (don't namespace)
+            (_is_parameter, lambda n: n),
+            # if transcode base is mapped to a new name, update with new base
+            (_is_transcode_base_in_mapping, _map_transcode_base),
+            # if namespace given, prefix name using that namespace
+            (lambda n: bool(namespace), _prefix),
+        ]
+
+        for predicate, processor in rules:
+            if predicate(name):
+                return processor(name)
+
+        # leave name as is
+        return name
+
+    def _process_dataset_names(
+        datasets: Union[None, str, List[str], Dict[str, str]]
+    ) -> Union[None, str, List[str], Dict[str, str]]:
+        if datasets is None:
+            return None
+        if isinstance(datasets, str):
+            return _rename(datasets)
+        if isinstance(datasets, list):
+            return [_rename(name) for name in datasets]
+        if isinstance(datasets, dict):
+            return {key: _rename(value) for key, value in datasets.items()}
+
+        raise ValueError(  # pragma: no cover
+            f"Unexpected input {datasets} of type {type(datasets)}"
+        )
+
+    def _copy_node(node: Node) -> Node:
+        new_namespace = node.namespace
+        if namespace:
+            new_namespace = (
+                f"{namespace}.{node.namespace}" if node.namespace else namespace
+            )
+
+        return node._copy(
+            inputs=_process_dataset_names(node._inputs),
+            outputs=_process_dataset_names(node._outputs),
+            namespace=new_namespace,
+        )
+
+    new_nodes = [_copy_node(n) for n in pipe.nodes]
+
+    return Pipeline(new_nodes)
+
+
+def _to_dict(element: Union[None, str, Set[str], Dict[str, str]]) -> Dict[str, str]:
+    if element is None:
+        return {}
+    if isinstance(element, str):
+        return {element: element}
+    if isinstance(element, dict):
+        return copy.deepcopy(element)
+    return {item: item for item in element}

--- a/tests/pipeline/test_pipeline_helper.py
+++ b/tests/pipeline/test_pipeline_helper.py
@@ -1,7 +1,8 @@
 import pytest
 
 from kedro.pipeline import Pipeline, node, pipeline
-from kedro.pipeline.modular_pipeline import ModularPipelineError
+from kedro.pipeline.pipeline import ModularPipelineError
+
 
 # Different dummy func based on the number of arguments
 


### PR DESCRIPTION
## Description
Currently we have `node` and `Node`, which are exactly equivalent. We encourage users to do `node`, which just instantiates `Node`.

We also have `pipeline` and `Pipeline`, which are quite different. `Pipeline` is the underlying class used to create a pipeline; then `pipeline` is then used to _transform_ that according to a namespace and dataset input/output mapping. The current use would be:
```
initial_pipeline = Pipeline([node1, node2, node3], tags=...)
transformed_pipeline = pipeline(initial_pipeline, inputs=..., outputs=..., namespace=...)
```
(Of course you don't have to transform the pipeline if the `initial_pipeline` is all you need.)

To be consistent with `node/Node` and reduce confusion we want to make `pipeline` and `Pipeline` equivalent. We would then encourage users to just use `pipeline`. This would mean no need for the `pipeline(Pipeline())` construction as users would instead just do `pipeline([node1, node2, node3], tag=..., input=..., outputs=..., namespace=...)`.

## Implementation
This is a bit tricky because:
* Both `pipeline` and `Pipeline` do various bits of validation, which I want to keep working exactly the same way for now so that we're still flagging the same errors as before
* the pipeline transformation itself depends on `Pipeline`. So we can't just immediately make `pipeline` a wrapper for `Pipeline` like we do for `node/Node`, because that would be circular

Let me try to explain what I've done using diagrams...

### Before
![image](https://user-images.githubusercontent.com/49395058/148526683-2d027166-7be7-4da1-9316-b86440b98939.png)

### After
![image](https://user-images.githubusercontent.com/49395058/148526720-cab9e97b-4643-421a-a3be-edee6ffadfc6.png)

Crucially the `Pipeline()` flow is the same as before, and the `pipeline(Pipeline())` flow is equivalent to before - it just has an extra "Validation A, set instance attributes" at the beginning which is unnecessary.
| Flow                                                    | Before                                                                                                | After                                                                                                                                        |
|---------------------------------------------------------|-------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------|
| `Pipeline()` without its new arguments (`inputs` etc.)  | Validation A, set instance attributes                                                                 | Validation A, set instance attributes                                                                                                        |
| `Pipeline()` with new arguments                         | Not possible                                                                                          | Validation A, set instance attributes, Validation B, transform, Validation A, set instance attributes                                        |
| `pipeline(Pipeline())` without `Pipeline` new arguments | Validation A, set instance attributes, Validation B, transform, Validation A, set instance attributes | Validation A, set instance attributes, Validation A, set instance attributes, Validation B, transform, Validation A, set instance attributes |

**I know this is confusing and I'm not totally happy with it! Please do say if there's an easier way of doing this or if nothing I wrote here makes sense. However, note that the last row of that table will no longer be encouraged (instead you'd just do `pipeline()`), and that this is meant to be a temporary state of affairs before future tickets can hopefully simplify the validation.**

Note that everything here is actually a non-breaking change, since the only arguments added to `pipeline/Pipeline` are keyword only and optional.

## TODO
### This PR
- [ ] Update docstrings, tests

### This ticket, new PR(s)
- [ ] Update our docs to do `pipeline` rather than `Pipeline`
- [ ] Update our project template and starters similarly

### Separate tickets

- [ ] Simplify the validation - do we actually need to repeat Validation A after Validation B like we currently do?
- [ ] Refactor pipeline.py since it's huge
- [ ] Move `pipeline` from `modular_pipeline.py` to `pipeline.py` and delete `modular_pipeline.py`. This would break any imports `from kedro.pipeline.modular_pipeline import pipeline` but not `from kedro.pipeline import pipeline`

## Checklist

- [ ] Read the [contributing](https://github.com/quantumblacklabs/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/quantumblacklabs/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
