### PR TITLE
Update isort command

### DIFF
--- a/docs/source/09_development/04_lint.md
+++ b/docs/source/09_development/04_lint.md
@@ -16,7 +16,7 @@ Alternatively, you can opt to use it as a plugin to your Kedro project. To do th
 @cli.command()
 def lint():
     """Check the Python code quality."""
-    python_call("isort", ["-rc", "src/<your_project>", "src/tests"])
+    python_call("isort", ["src/<your_project>", "src/tests"])
     python_call("pylint", ["-j", "0", "src/<your_project>"])
     python_call(
         "pylint",

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -132,6 +132,7 @@ def lint(
     python_call("flake8", files)
     python_call("isort", ("--check",) + files if check_only else files)
 
+
 @project_group.command()
 @click.option(
     "--build-reqs/--no-build-reqs",

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -130,10 +130,7 @@ def lint(
 
     python_call("black", ("--check",) + files if check_only else files)
     python_call("flake8", files)
-
-    check_flag = ("-c",) if check_only else ()
-    python_call("isort", (*check_flag, "-rc") + files)  # type: ignore
-
+    python_call("isort", ("--check",) + files if check_only else files)
 
 @project_group.command()
 @click.option(

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -166,7 +166,7 @@ class TestLintCommand:
         expected_calls = [
             mocker.call("black", expected_files),
             mocker.call("flake8", expected_files),
-            mocker.call("isort", ("-rc",) + expected_files),
+            mocker.call("isort", expected_files),
         ]
 
         assert python_call_mock.call_args_list == expected_calls
@@ -203,7 +203,7 @@ class TestLintCommand:
         expected_calls = [
             mocker.call("black", ("--check",) + expected_files),
             mocker.call("flake8", expected_files),
-            mocker.call("isort", ("-c", "-rc") + expected_files),
+            mocker.call("isort", ("--check",) + expected_files),
         ]
 
         assert python_call_mock.call_args_list == expected_calls


### PR DESCRIPTION
## Description
Playing around with something I realised that `kedro lint` is using a deprecated option on `isort` and was giving this message:
```
/home/gitpod/.pyenv/versions/3.8.12/lib/python3.8/site-packages/isort/main.py:1233: UserWarning: W0501: The following deprecated CLI flags were used and ignored: -rc!
```
Since 5.0.0, the `-rc` (recursive) option has been removed. By default all directories given are treated recursively now. All starter requirements have `isort~=5.0` so I've removed the `-rc` flag.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes