### PR TITLE
[Fix] Bump Pillow version to 9.0 in test_req

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -28,7 +28,7 @@ networkx~=2.4
 openpyxl>=3.0.3, <4.0
 pandas-gbq>=0.12.0, <1.0
 pandas>=0.24.0  # Needs to be at least 0.24.0 to make use of `pandas.DataFrame.to_numpy` (recommended alternative to `pandas.DataFrame.values`)
-Pillow~=8.0
+Pillow~=9.0
 plotly>=4.8.0, <6.0
 pre-commit~=1.17
 psutil==5.6.7


### PR DESCRIPTION
## Description
Fixes CVE-2022-22817, see https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22817

## Development notes
Bumped Pillow version in test_requirements.txt

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes (quick check at the changelog of Pillow does not indicate major breaking changes = should be covered by current tests)
