### PR TITLE
[KED-3046] Remove "QuantumBlack Labs" from places where it doesn't belong any more

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -311,8 +311,8 @@ jobs:
       - run:
           name: Set git email and name
           command: |
-            git config --global user.email "kedro@quantumblack.com"
-            git config --global user.name "QuantumBlack Labs"
+            git config --global user.email "kedro@kedro.com"
+            git config --global user.name "Kedro"
       - run:
           name: Trigger Read The Docs build
           command: ./tools/circleci/rtd-build.sh ${RTD_TOKEN} latest

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be
-reported by contacting the project team at kedro@quantumblack.com. All
+reported by contacting the project team on [Discord](https://discord.com/invite/akJDeVaxnB). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -280,7 +280,7 @@ texinfo_documents = [
         "Kedro Documentation",
         author,
         "Kedro",
-        "Kedro is an open source Data Science framework.",
+        "Kedro is a Python framework for creating reproducible, maintainable and modular data science code.",
         "Data-Science",
     )
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,7 +30,7 @@ from kedro import __version__ as release
 # -- Project information -----------------------------------------------------
 
 project = "Kedro"
-author = "QuantumBlack"
+author = "Kedro"
 
 # The short X.Y version.
 version = re.match(r"^([0-9]+\.[0-9]+).*", release).group(1)
@@ -259,7 +259,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "Kedro.tex", "Kedro Documentation", "QuantumBlack", "manual")
+    (master_doc, "Kedro.tex", "Kedro Documentation", "Kedro", "manual")
 ]
 
 # -- Options for manual page output ------------------------------------------
@@ -280,7 +280,7 @@ texinfo_documents = [
         "Kedro Documentation",
         author,
         "Kedro",
-        "Kedro is a Data Science framework for QuantumBlack-led projects.",
+        "Kedro is an open source Data Science framework.",
         "Data-Science",
     )
 ]

--- a/docs/source/03_tutorial/07_set_up_experiment_tracking.md
+++ b/docs/source/03_tutorial/07_set_up_experiment_tracking.md
@@ -1,6 +1,6 @@
 # Set up experiment tracking
 
-Experiment tracking is the process of saving all machine-learning related experiment information so that it is easy to find and compare past runs. [Kedro-Viz](https://github.com/quantumblacklabs/kedro-viz) supports native experiment tracking from [version 4.1.1](https://github.com/quantumblacklabs/kedro-viz/releases/tag/v4.1.1) onwards. When experiment tracking is enabled in your Kedro project, you will be able to access, edit and compare your experiments directly from the Kedro-Viz web app.
+Experiment tracking is the process of saving all machine-learning related experiment information so that it is easy to find and compare past runs. [Kedro-Viz](https://github.com/kedro-org/kedro-viz) supports native experiment tracking from [version 4.1.1](https://github.com/kedro-org/kedro-viz/releases/tag/v4.1.1) onwards. When experiment tracking is enabled in your Kedro project, you will be able to access, edit and compare your experiments directly from the Kedro-Viz web app.
 
 ![](../meta/images/experiment-tracking_demo_small.gif)
 
@@ -160,4 +160,4 @@ You will now be able to access, compare and pin your runs by toggling the `Compa
 
 ![](../meta/images/experiment-tracking_demo.gif)
 
-Keep an eye out on the [Kedro-Viz release page](https://github.com/quantumblacklabs/kedro-viz/releases) for the upcoming releases on this experiment tracking functionality.
+Keep an eye out on the [Kedro-Viz release page](https://github.com/kedro-org/kedro-viz/releases) for the upcoming releases on this experiment tracking functionality.

--- a/docs/source/09_development/03_commands_reference.md
+++ b/docs/source/09_development/03_commands_reference.md
@@ -117,9 +117,9 @@ Returns output similar to the following, depending on the version of Kedro used 
 |_|\_\___|\__,_|_|  \___/
 v0.17.6
 
-kedro allows teams to create analytics
-projects. It is developed as part of
-the Kedro initiative.
+Kedro is a Python framework for
+creating reproducible, maintainable
+and modular data science code.
 
 Installed plugins:
 kedro_viz: 3.4.0 (hooks:global,line_magic)

--- a/docs/source/09_development/03_commands_reference.md
+++ b/docs/source/09_development/03_commands_reference.md
@@ -119,7 +119,7 @@ v0.17.6
 
 kedro allows teams to create analytics
 projects. It is developed as part of
-the Kedro initiative at QuantumBlack.
+the Kedro initiative.
 
 Installed plugins:
 kedro_viz: 3.4.0 (hooks:global,line_magic)

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -249,7 +249,7 @@ def init_git_repo(context):
     with util.chdir(context.root_project_dir):
         check_run("git init")
         check_run("git config user.name 'Tester'")
-        check_run("git config user.email 'tester.kedro@quantumblack.com'")
+        check_run("git config user.email 'tester.kedro@kedro.com'")
 
 
 @given("I have added a test jupyter notebook")

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -26,7 +26,7 @@ from kedro.framework.cli.utils import find_stylesheets
 # -- Project information -----------------------------------------------------
 
 project = "{{ cookiecutter.python_package }}"
-author = "QuantumBlack"
+author = "Kedro"
 
 # The short X.Y version.
 version = re.match(r"^([0-9]+\.[0-9]+).*", release).group(1)
@@ -149,7 +149,7 @@ latex_documents = [
         master_doc,
         "{{ cookiecutter.python_package }}.tex",
         "{{ cookiecutter.python_package }} Documentation",
-        "QuantumBlack",
+        "Kedro",
         "manual",
     )
 ]

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -61,9 +61,9 @@ def info():
     """Get more information about kedro."""
     click.secho(LOGO, fg="green")
     click.echo(
-        "kedro allows teams to create analytics\n"
-        "projects. It is developed as part of\n"
-        "the Kedro initiative."
+        "Kedro is a Python framework for\n"
+        "creating reproducible, maintainable\n"
+        "and modular data science code."
     )
 
     plugin_versions = {}

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -63,7 +63,7 @@ def info():
     click.echo(
         "kedro allows teams to create analytics\n"
         "projects. It is developed as part of\n"
-        "the Kedro initiative at QuantumBlack."
+        "the Kedro initiative."
     )
 
     plugin_versions = {}

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -27,7 +27,7 @@ from {{ cookiecutter.python_package }} import __version__ as release
 # -- Project information -----------------------------------------------------
 
 project = "{{ cookiecutter.python_package }}"
-author = "QuantumBlack"
+author = "Kedro"
 
 # The short X.Y version.
 version = re.match(r"^([0-9]+\.[0-9]+).*", release).group(1)
@@ -150,7 +150,7 @@ latex_documents = [
         master_doc,
         "{{ cookiecutter.python_package }}.tex",
         "{{ cookiecutter.python_package }} Documentation",
-        "QuantumBlack",
+        "Kedro",
         "manual",
     )
 ]

--- a/setup.py
+++ b/setup.py
@@ -163,7 +163,7 @@ setup(
     include_package_data=True,
     tests_require=test_requires,
     install_requires=requires,
-    author="QuantumBlack Labs",
+    author="Kedro",
     entry_points={"console_scripts": ["kedro = kedro.framework.cli:main"]},
     package_data={
         name: ["py.typed", "test_requirements.txt"] + template_files + doc_html_files

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -109,14 +109,6 @@ class TestCliCommands:
         assert result_abr.exit_code == 0
         assert version in result_abr.output
 
-    def test_info_contains_qb(self):
-        """Check that `kedro info` output contains
-        reference to QuantumBlack."""
-        result = CliRunner().invoke(cli, ["info"])
-
-        assert result.exit_code == 0
-        assert "QuantumBlack" in result.output
-
     def test_info_contains_plugin_versions(self, entry_point, mocker):
         get_distribution = mocker.patch("pkg_resources.get_distribution")
         get_distribution().version = "1.0.2"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
There's a few mentions that kedro is authored by QuantumBlack Labs (e.g. in kedro docs, setup.,py, `kedro info`). Following the migration to LF these shouldn't be there any more.

Best way to find them is just to search "quantumblack" in the codebase - there's not that many results to check through.

Additionally you will also have to update URLs for Kedro-Airflow, Kedro-Docker and Kedro-Telemetry as they have completely changed repo location.

As well as kedro repository, you should check kedro-community, kedro-plugins, kedro-viz and kedro-training. kedro-starters has already been updated.

https://jira.quantumblack.com/browse/KED-3046

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
