### PR TITLE
[KED-3049] Streamline DCO sign-off a bit

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,0 +1,2 @@
+require:
+  members: false

--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ auto-sign-off:
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg
 	chmod +x .git/hooks/commit-msg
 
+test
 #git interpret-trailers --if-exists doNothing --trailer \
 #    "Signed-off-by: $NAME <$EMAIL>" \
 #    --in-place "$1"

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,6 @@ auto-sign-off:
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg
 	chmod +x .git/hooks/commit-msg
 
-test
 #git interpret-trailers --if-exists doNothing --trailer \
 #    "Signed-off-by: $NAME <$EMAIL>" \
 #    --in-place "$1"

--- a/Makefile
+++ b/Makefile
@@ -61,7 +61,3 @@ auto-sign-off:
 	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg
 	chmod +x .git/hooks/commit-msg
-
-#git interpret-trailers --if-exists doNothing --trailer \
-#    "Signed-off-by: $NAME <$EMAIL>" \
-#    --in-place "$1"

--- a/Makefile
+++ b/Makefile
@@ -55,3 +55,13 @@ uninstall-pre-commit:
 
 print-python-env:
 	@./tools/print_env.sh
+
+auto-sign-off:
+	echo "git interpret-trailers --if-exists doNothing \c" >> .git/hooks/commit-msg
+	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
+	echo '--in-place "$$1"' >> .git/hooks/commit-msg
+	chmod +x .git/hooks/commit-msg
+
+#git interpret-trailers --if-exists doNothing --trailer \
+#    "Signed-off-by: $NAME <$EMAIL>" \
+#    --in-place "$1"

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ uninstall-pre-commit:
 print-python-env:
 	@./tools/print_env.sh
 
-auto-sign-off:
+sign-off:
 	echo "git interpret-trailers --if-exists doNothing \c" >> .git/hooks/commit-msg
 	echo '--trailer "Signed-off-by: $$(git config user.name) <$$(git config user.email)>" \c' >> .git/hooks/commit-msg
 	echo '--in-place "$$1"' >> .git/hooks/commit-msg

--- a/docs/source/14_contribution/02_developer_contributor_guidelines.md
+++ b/docs/source/14_contribution/02_developer_contributor_guidelines.md
@@ -180,7 +180,7 @@ The sign-off can be added automatically to your commit message using the `-s` op
 git commit -s -m "This is my commit message"
 ```
 
-To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`.
+To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) that you make.
 
 If your PR is blocked due to unsigned commits then you will need to follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.
 

--- a/docs/source/14_contribution/02_developer_contributor_guidelines.md
+++ b/docs/source/14_contribution/02_developer_contributor_guidelines.md
@@ -180,7 +180,7 @@ The sign-off can be added automatically to your commit message using the `-s` op
 git commit -s -m "This is my commit message"
 ```
 
-To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) you make.
+To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) you make while working on the Kedro repository.
 
 If your PR is blocked due to unsigned commits then you will need to follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.
 

--- a/docs/source/14_contribution/02_developer_contributor_guidelines.md
+++ b/docs/source/14_contribution/02_developer_contributor_guidelines.md
@@ -180,7 +180,7 @@ The sign-off can be added automatically to your commit message using the `-s` op
 git commit -s -m "This is my commit message"
 ```
 
-To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) that you make.
+To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) you make.
 
 If your PR is blocked due to unsigned commits then you will need to follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.
 

--- a/docs/source/14_contribution/02_developer_contributor_guidelines.md
+++ b/docs/source/14_contribution/02_developer_contributor_guidelines.md
@@ -180,7 +180,7 @@ The sign-off can be added automatically to your commit message using the `-s` op
 git commit -s -m "This is my commit message"
 ```
 
-To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make auto-sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) you make while working on the Kedro repository.
+To avoid needing to remember the `-s` flag on every commit, you might like to set up an [alias](https://git-scm.com/book/en/v2/Git-Basics-Git-Aliases) for `git commit -s`. Alternatively, run `make sign-off` to setup a [`commit-msg` Git hook](https://git-scm.com/docs/githooks#_commit_msg) that automatically signs off all commits (including merge commits) you make while working on the Kedro repository.
 
 If your PR is blocked due to unsigned commits then you will need to follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.
 


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/pull/1167 added some tips to our contributors guide to help users navigate the new DCO sign-off requirement. After spending waaaaaay too much time on this, I now have two further improvements:

1. `make sign-off`: this creates a git hook that will add the Signed-off-by line to all commit message. This is a better solution than aliasing git commit for various reasons
2. `require: members: false` for the DCO GitHub app configuration. This means that [signed commits](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits) (i.e. GPG or S/MIME signed, _not_ signed-off) by members of kedro-org do not need to have the Signed-off-by line. In practice, this is very helpful because it  means that any commits maintainers make on GitHub (applying code review suggestions, merging in `main`, etc.) will get ✅  for DCO check. Without this our builds for `main` will be constantly failing unless you manually add the Signed-off-by line when you do the squash merge 🤦  

## Possible future improvements
- Enable `allowRemediationCommits` to make it easier for users to retroactively sign off commits
- Maybe fork DCO app so that the "Set DCO to pass" button is available to all? (Might defeat the point of the check though...)


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
