### PR TITLE
Pin upper pandas version requirement

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ parameters:
     default: false
 
 orbs:
-  win: circleci/windows@2.2.0
+  win: circleci/windows@2.4.1
 
 # No windows executor is listed here since windows builds use win/default and modify
 # the Python version through the conda environment.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,8 +4,9 @@
 * `pipeline` now accepts `tags` and a collection of `Node`s and/or `Pipeline`s rather than just a single `Pipeline` object. `pipeline` should be used in preference to `Pipeline` when creating a Kedro pipeline.
 
 ## Bug fixes and other changes
-* Added tutorial documentation for experiment tracking in Kedro docs (`03_tutorial/07_set_up_experiment_tracking.md`).
-* Added Plotly documentation in Kedro docs (`03_tutorial/06_visualise_pipeline.md`).
+* Added tutorial documentation for experiment tracking (`03_tutorial/07_set_up_experiment_tracking.md`).
+* Added Plotly dataset documentation (`03_tutorial/06_visualise_pipeline.md`).
+* Added the upper limit `pandas<1.4` to maintain compatibility with `xlrd~=1.0`.
 
 ## Minor breaking changes to the API
 

--- a/features/windows_reqs.txt
+++ b/features/windows_reqs.txt
@@ -2,7 +2,7 @@
 # e2e tests on Windows are slow but we don't need to install
 # everything, so just this subset will be enough for CI
 behave==1.2.6
-pandas>=0.24.0, <1.0.4
+pandas>=0.24, <1.4
 psutil==5.6.7
 requests~=2.20
 toml~=0.10.1

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ name = "kedro"
 here = path.abspath(path.dirname(__file__))
 
 
-PANDAS = "pandas>=0.24"
+PANDAS = "pandas>=0.24, <1.4"
 SPARK = "pyspark>=2.2, <4.0"
 HDFS = "hdfs>=2.5.8, <3.0"
 S3FS = "s3fs>=0.3.0, <0.5"
@@ -77,8 +77,11 @@ pandas_require = {
     "pandas.FeatherDataSet": [PANDAS],
     "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
     "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
-    "pandas.HDFDataSet": [PANDAS, "tables~=3.6.0; platform_system == 'Windows'",
-                          "tables~=3.6; platform_system != 'Windows'"],
+    "pandas.HDFDataSet": [
+        PANDAS,
+        "tables~=3.6.0; platform_system == 'Windows'",
+        "tables~=3.6; platform_system != 'Windows'",
+    ],
     "pandas.JSONDataSet": [PANDAS],
     "pandas.ParquetDataSet": [PANDAS, "pyarrow>=1.0, <7.0"],
     "pandas.SQLTableDataSet": [PANDAS, "SQLAlchemy~=1.2"],

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -27,7 +27,7 @@ nbformat~=4.4
 networkx~=2.4
 openpyxl>=3.0.3, <4.0
 pandas-gbq>=0.12.0, <1.0
-pandas>=0.24.0  # Needs to be at least 0.24.0 to make use of `pandas.DataFrame.to_numpy` (recommended alternative to `pandas.DataFrame.values`)
+pandas>=0.24, <1.4  # Needs to be at least 0.24.0 to make use of `pandas.DataFrame.to_numpy` (recommended alternative to `pandas.DataFrame.values`); needs to be less than 1.4 for compatiblity with xlrd~=1.0.
 Pillow~=8.0
 plotly>=4.8.0, <6.0
 pre-commit~=1.17


### PR DESCRIPTION
## Description
Fixes #1179. pandas have released 1.4.0, which requires `xlrd>=2.0.1` (and is only compatible with Python >=3.8). This is incompatible with our `xlrd~=1.0`.

## Development notes
Note that pandas was unpinned in August 2020 in https://github.com/quantumblacklabs/private-kedro/pull/772. In hindsight we probably should have reinstated an upper bound some time after that. I've done so now to restrict to `<1.4`.

The alternative to this was to allow pandas 1.4 and relax our requirement for xlrd to include 2.0.1. I opted not to do this since xlrd 2.0 introduced [breaking changes](https://xlrd.readthedocs.io/en/latest/changes.html#id1).

## Questions
1. Does this seem like the right thing to do? It stops people from using `pandas>=1.4` which is maybe annoying for users who want to use any new features in those releases. We could do something to make the version of xlrd installed depend on the version of pandas so that not everyone gets `xlrd>=2.0`, but that seemed like overkill to me.
1. Looking at pandas [release notes](https://pandas.pydata.org/pandas-docs/stable/whatsnew/index.html#), every 1.x release (like 1.1, 1.2, 1.3, etc.) appears to break backwards compatibility. So I wonder whether we should change the specification in develop also (currently `pandas~=1.3`)?

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
