### PR TITLE
Change ";" to os.pathsep

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -51,10 +51,8 @@ def _setup_context_with_venv(context, venv_dir):
     # this is because exe resolution in subprocess doesn't respect a passed env
     if os.name == "posix":
         bin_dir = context.venv_dir / "bin"
-        path_sep = ":"
     else:
         bin_dir = context.venv_dir / "Scripts"
-        path_sep = ";"
     context.bin_dir = bin_dir
     context.pip = str(bin_dir / "pip")
     context.python = str(bin_dir / "python")
@@ -63,11 +61,11 @@ def _setup_context_with_venv(context, venv_dir):
 
     # clone the environment, remove any condas and venvs and insert our venv
     context.env = os.environ.copy()
-    path = context.env["PATH"].split(path_sep)
+    path = context.env["PATH"].split(os.pathsep)
     path = [p for p in path if not (Path(p).parent / "pyvenv.cfg").is_file()]
     path = [p for p in path if not (Path(p).parent / "conda-meta").is_dir()]
     path = [str(bin_dir)] + path
-    context.env["PATH"] = path_sep.join(path)
+    context.env["PATH"] = os.pathsep.join(path)
 
     # Create an empty pip.conf file and point pip to it
     pip_conf_path = context.venv_dir / "pip.conf"

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -142,7 +142,7 @@ def _add_src_to_path(source_dir: Path, project_path: Path) -> None:
 
     python_path = os.getenv("PYTHONPATH") or ""
     if str(source_dir) not in python_path:
-        sep = ";" if python_path else ""
+        sep = os.pathsep if python_path else ""
         os.environ["PYTHONPATH"] = f"{str(source_dir)}{sep}{python_path}"
 
 


### PR DESCRIPTION
## Description
Fixes https://github.com/kedro-org/kedro/issues/1183.

Before this, my local `PYTHONPATH` looked like this. Note the inconsistent `;` at the beginning compared to all the other `:`. I don't know if this actually caused any problems for anyone, but it should cause even fewer problems now anyway 😅 
```
/Users/antony_milne/kedro_stuff/projects/spaceflights/src;/Users/antony_milne/kedro_stuff/projects:/Users/antony_milne/kedro_stuff/kedro:/Applications/PyCharm.app/Contents/plugins/python/helpers/pycharm_matplotlib_backend:/Applications/PyCharm.app/Contents/plugins/python/helpers/pycharm_display:/Applications/PyCharm.app/Contents/plugins/python/helpers/third_party/thriftpy:/Applications/PyCharm.app/Contents/plugins/python/helpers/pydev:/Users/antony_milne/Library/Caches/JetBrains/PyCharm2021.3/cythonExtensions:/Users/antony_milne/kedro_stuff/projects/spaceflights
```

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
