### PR TITLE
Upper bound pip in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,6 @@ jobs:
       - run:
           name: Install dependencies
           command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
-      - run: Write-Host "BLAH $PIP_DISABLE_PIP_VERSION_CHECK"
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -168,6 +168,8 @@ jobs:
       python_version:
         type: string
     executor: win/default
+    environment:
+      PIP_DISABLE_PIP_VERSION_CHECK: 1
     steps:
       - checkout
       - win_setup_conda:
@@ -178,6 +180,7 @@ jobs:
       - run:
           name: Install dependencies
           command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
+      - run: Write-Host "BLAH $PIP_DISABLE_PIP_VERSION_CHECK"
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	pre-commit clean || true
 
 install-pip-setuptools:
-	python -m pip install -U "pip>=20.0" "setuptools>=38.0" wheel
+	python -m pip install -U "pip>=20.0,<22" "setuptools>=38.0" wheel
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	pre-commit clean || true
 
 install-pip-setuptools:
-	python -m pip install -U "pip>=20.0,<22" "setuptools>=38.0" wheel
+	python -m pip install -U "pip~=21.2" "setuptools>=38.0" wheel
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)

--- a/features/environment.py
+++ b/features/environment.py
@@ -107,7 +107,7 @@ def _setup_minimal_env(context):
             "pip",
             "install",
             "-U",
-            "pip>=20.0",
+            "pip>=20.0,<22",
             "setuptools>=38.0",
             "wheel",
         ],

--- a/features/environment.py
+++ b/features/environment.py
@@ -107,7 +107,7 @@ def _setup_minimal_env(context):
             "pip",
             "install",
             "-U",
-            "pip>=20.0,<22",
+            "pip~=21.2",
             "setuptools>=38.0",
             "wheel",
         ],

--- a/tools/circleci/requirements.txt
+++ b/tools/circleci/requirements.txt
@@ -1,3 +1,3 @@
-pip>=20.0
+pip>=20.0,<22
 setuptools>=38.0
 twine~=3.0

--- a/tools/circleci/requirements.txt
+++ b/tools/circleci/requirements.txt
@@ -1,3 +1,3 @@
-pip>=20.0,<22
+pip~=21.2
 setuptools>=38.0
 twine~=3.0


### PR DESCRIPTION
## Description
[`pip 22` was released ](https://pip.pypa.io/en/stable/news/) and everything broke. So I put in the bound `pip<22`, which fixed the pip compile issues but broke the Windows e2e tests 🤦

After much digging, I figured out that the warning you get to upgrade pip on the Windows e2e tests for some reason gets interpreted as an error by behave. So in order for these tests to pass we need to use `PIP_DISABLE_PIP_VERSION_CHECK`.

Everything is now working again apart from (a) Windows 3.6 e2e tests which are still broken with the mysterious Rust error, (b) the forked PRs environment variable issue that we have a ticket for.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes