### PR TITLE
Bump click version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 anyconfig~=0.10.0
 cachetools~=4.1
-click<8.0
+click<9.0
 cookiecutter~=1.7.0
 dynaconf>=3.1.2,<4.0.0
 fsspec>=2021.04, <2022.01  # Upper bound set arbitrarily, to be reassessed in early 2022


### PR DESCRIPTION
Bump click version - main difference between 7.x and 8.x is they "dropped support for Python 2 and 3.5" which wont affect Kedro anyway 

https://click.palletsprojects.com/en/8.0.x/changes/