### PR TITLE
Fix bad link within rst block

### DIFF
--- a/docs/source/05_data/01_data_catalog.md
+++ b/docs/source/05_data/01_data_catalog.md
@@ -316,7 +316,7 @@ dev_abs:
 Example 16: Loading a CSV file stored in a remote location through SSH
 
 ```eval_rst
-.. note::  This example requires [Paramiko](https://www.paramiko.org) to be installed (`pip install paramiko`).
+.. note::  This example requires `Paramiko <https://www.paramiko.org>`_ to be installed (``pip install paramiko``).
 ```
 ```yaml
 cool_dataset:


### PR DESCRIPTION
## Description
Noticed within example 16 of the data catalog that link provided uses a markdown style link instead of an RST style one:
![image](https://user-images.githubusercontent.com/35801847/152129575-d630e466-9028-45ca-9dad-7f514a8bef4b.png)

## Development notes
<!-- What have you changed, and how has this been tested? -->
Updated `01_data_catalog.md`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
