### PR TITLE
Fix 3.9 win builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,47 +455,47 @@ workflows:
   regular:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set
     jobs:
-      - e2e_tests:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+#      - e2e_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9"]
       - win_e2e_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-      - unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+#      - unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-      - lint:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9"]
-      - pip_compile:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+#      - lint:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9"]
+#      - pip_compile:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-      - build_docs
-      - docs_linkcheck
+#      - build_docs
+#      - docs_linkcheck
       - all_circleci_checks_succeeded:
           requires:
-            - e2e_tests
+#            - e2e_tests
             - win_e2e_tests
-            - unit_tests
+#            - unit_tests
             - win_unit_tests
-            - lint
-            - pip_compile
+#            - lint
+#            - pip_compile
             - win_pip_compile
-            - build_docs
-            - docs_linkcheck
+#            - build_docs
+#            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -455,47 +455,47 @@ workflows:
   regular:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set
     jobs:
-#      - e2e_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9"]
+      - e2e_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9"]
       - win_e2e_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-#      - unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9"]
+      - unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-#      - lint:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9"]
-#      - pip_compile:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9"]
+      - lint:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9"]
+      - pip_compile:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9"]
-#      - build_docs
-#      - docs_linkcheck
+      - build_docs
+      - docs_linkcheck
       - all_circleci_checks_succeeded:
           requires:
-#            - e2e_tests
+            - e2e_tests
             - win_e2e_tests
-#            - unit_tests
+            - unit_tests
             - win_unit_tests
-#            - lint
-#            - pip_compile
+            - lint
+            - pip_compile
             - win_pip_compile
-#            - build_docs
-#            - docs_linkcheck
+            - build_docs
+            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -45,7 +45,7 @@ requests-mock~=1.6
 requests~=2.20
 s3fs>=0.3.0, <0.5  # Needs to be at least 0.3.0 to make use of `cachable` attribute on S3FileSystem.
 SQLAlchemy~=1.2
-tables~=3.6.0; platform_system == "Windows"
+tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
 tensorflow>=2.0, <2.6; python_version=='3.9'
 tensorflow>=2.0, <3.0; python_version<'3.9'


### PR DESCRIPTION
## Description
The windows python 3.9 builds were failing because `pip install tables` doesn't work. 

## Development notes
I changed the test_requirements to just not install `tables` when we're using python 3.9. This is fine because we have a separate step in our setup to install it through conda. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
