### PR TITLE
[KED-3070] Bump ipython version to avoid security vulnerability

### DIFF
--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,6 +1,7 @@
 black==21.5b1
 flake8>=3.7.9, <4.0
-ipython~=7.10
+ipython~=7.16.3; python_version == '3.6'
+ipython>=7.31.1, <8.0; python_version > '3.6'
 isort~=5.0
 jupyter~=1.0
 jupyter_client>=5.1, <7.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,6 +1,8 @@
 black==21.5b1
 flake8>=3.7.9, <4.0
 ipython~=7.10
+ipython~=7.16.3; python_version == '3.6'
+ipython>=7.31.1, <8.0; python_version > '3.6'
 isort~=5.0
 jupyter~=1.0
 jupyter_client>=5.1, <7.0

--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,10 @@ extras_require = {
         "ipykernel>=5.3, <7.0",
     ],
     "geopandas": _collect_requirements(geopandas_require),
-    "ipython": ["ipython~=7.10"],
+    "ipython": [
+        "ipython~=7.16.3; python_version == '3.6'",
+        "ipython>=7.31.1, <8.0; python_version > '3.6'",
+    ],
     "matplotlib": _collect_requirements(matplotlib_require),
     "holoviews": _collect_requirements(holoviews_require),
     "networkx": _collect_requirements(networkx_require),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -16,7 +16,8 @@ geopandas>=0.6.0, <1.0
 hdfs>=2.5.8, <3.0
 holoviews~=1.13.0
 import-linter[toml]==1.2.6
-ipython~=7.10
+ipython>=7.31.1, <8.0; python_version > '3.6'
+ipython~=7.16.3; python_version == '3.6'
 joblib>=0.14
 lxml~=4.6.3
 matplotlib>=3.0.3, <3.4  # 3.4.0 breaks holoviews


### PR DESCRIPTION
Signed-off-by: lorenabalan <lorena.balan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Addressing https://github.com/advisories/GHSA-pq7m-3gw7-gq5x 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
