### PR TITLE
Alias `astro-iris` to `astro-airflow-iris`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 * Bumped the `Pillow` minimum version requirement to 9.0 (Python 3.7+ only) following [CVE-2022-22817](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-22817).
 * Fixed `PickleDataSet` to be copyable and hence work with the parallel runner.
 * Upgraded `pip-tools`, which is used by `kedro build-reqs`, to 6.5 (Python 3.7+ only). This `pip-tools` version is compatible with `pip>=21.2`, including the most recent releases of `pip`. Python 3.6 users should continue to use `pip-tools` 6.4 and `pip<22`.
+* Added `astro-iris` as alias for `astro-airlow-iris`, so that old tutorials can still be followed.
 
 ## Minor breaking changes to the API
 

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -91,6 +91,9 @@ def new(
             "Cannot use the --directory flag without a --starter value."
         )
 
+    starter_name = (
+        "astro-airflow-iris" if starter_name == "astro-iris" else starter_name
+    )
     if starter_name in _STARTER_ALIASES:
         if directory:
             raise KedroCliError(

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -91,6 +91,9 @@ def new(
             "Cannot use the --directory flag without a --starter value."
         )
 
+    # The `astro-iris` was renamed to `astro-airflow-iris`, but old (external) documentation
+    # and tutorials still refer to `astro-iris`. The below line checks if a user has entered old
+    # `astro-iris` as the starter name and changes it to `astro-airflow-iris`.
     starter_name = (
         "astro-airflow-iris" if starter_name == "astro-iris" else starter_name
     )


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Creating a project with `kedro new --starter astro-iris` doesn't work since `astro-iris` was renamed to `astro-airflow-iris`

We should support both `astro-iris` and `astro-airflow-iris` or at least give a warning to the user that the starter is now renamed. 

## Development notes
Check if a user has entered `astro-iris` as the starter name and change it to `astro-airflow-iris`. 

While working on this I was thinking whether it would make sense to make a generic change where if no template or known starter is found we print an error message with the official starter names. I'll create another PR for that change. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
