### PR TITLE
Add list of official starters to error message

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -282,7 +282,12 @@ def _get_cookiecutter_dir(
                 f" Specified tag {checkout}. The following tags are available: "
                 + ", ".join(_get_available_tags(template_path))
             )
-        raise KedroCliError(error_message) from exc
+        official_starters = sorted(_STARTER_ALIASES)
+
+        raise KedroCliError(
+            f"{error_message}. The aliases for the official Kedro starters are: \n"
+            f"{yaml.safe_dump(official_starters)}"
+        ) from exc
 
     return Path(cookiecutter_dir)
 


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
When a user calls `kedro new --starter` with a wrong entry (e.g. no custom template or official starter name) they'll get the following error: 
`Kedro project template not found at ...`

## Development notes
Added another sentence to the error message with the list of official starters, so in case the user was trying to use an official starter but entered a wrong name, they don't have to separately call `kedro starter list` to find out all correct names. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
