### PR TITLE
Fix iframe in docs to use `https`

### DIFF
--- a/docs/source/06_nodes_and_pipelines/03_modular_pipelines.md
+++ b/docs/source/06_nodes_and_pipelines/03_modular_pipelines.md
@@ -30,7 +30,7 @@ In this section you will learn about how to take advantage of modular pipelines,
    * ``Kedro-Viz`` is able to accelerate development by [rendering namespaced](../03_tutorial/05_visualise_pipeline.md) pipelines as collapsible 'super nodes'.
 
 <iframe
-    src="http://demo.kedro.org"
+    src="https://demo.kedro.org"
     width="850",
     height="600"
 ></iframe>


### PR DESCRIPTION
## Description
Noticed that the iframe in the new docs doesn't work on readthedocs.io because it's configured to use `http` not `https`

## Development notes
The latest build of the docs doesn't render Viz because of this [see here](https://kedro.readthedocs.io/en/latest/06_nodes_and_pipelines/03_modular_pipelines.html).

![image](https://user-images.githubusercontent.com/35801847/153279370-59350b70-4c60-4e2c-8608-efc3de4a95ff.png)

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [N/A] Added tests to cover my changes
