### PR TITLE
POC [KED-3023] - Enable plugins to extend starter-aliases default list

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -194,10 +194,11 @@ def list_starters():
         if directory:
             repo_url = repo_url.replace(".git", f"/tree/main/{directory}")
         # TODO: should we make "core" starters distinguishable from plugin ones?
-        # I add a "*" next to the name to make this distinction visual
+        # I add a "(*)" next to the name to make this distinction visual
+        # and at the beginning of the list
         # BEWARE: in case we allow official plugins to be overriden, below test is not valid
         starter_name_displayed = (
-            f"{starter_name}*"
+            f"(*) {starter_name}"
             if not starter_name in _STARTER_ALIASES.keys()
             else starter_name
         )

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -31,7 +31,7 @@ ENTRY_POINT_GROUPS = {
     "line_magic": "kedro.line_magic",
     "hooks": "kedro.hooks",
     "cli_hooks": "kedro.cli_hooks",
-    "starter": "kedro.starter"
+    "starters": "kedro.starters",
 }
 
 

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -31,6 +31,7 @@ ENTRY_POINT_GROUPS = {
     "line_magic": "kedro.line_magic",
     "hooks": "kedro.hooks",
     "cli_hooks": "kedro.cli_hooks",
+    "starter": "kedro.starter"
 }
 
 


### PR DESCRIPTION
## Description

This PR implements part of the suggestions described in #1040 and creates a fully functional examples on how kedro starter discovery could be modified to enable plugins to created aliased starters. 

## Development notes

- I modified the _STARTERS_ALIASES to make it a dict with the format discussed in above issue.
- I created a ``kedro.starter`` entrypoint which can is iterated over to update the _STARTERS_ALIASES constant. 
- I  updated the ``kedro new`` and ``kedro starter list`` commands to use the updated _STARTERS_ALIASES constant (with new aliases discovered in the entrypoints). 

As of now, the code is already working. You can test it with : 

```bash
conda create -n fps python=3.8 -y
conda activate fps
pip install git+https://github.com/Galileo-Galilei/kedro.git@plugins-starters
pip install git+https://github.com/Galileo-Galilei/fake-plugin-starter.git
kedro starter list
```

and see the following output:

```bash
(*) my_fake_starter: http://google.com # my extra starter
astro-airflow-iris: https://github.com/kedro-org/kedro-starters/tree/main/astro-airflow-iris
astro-iris: https://github.com/kedro-org/kedro-starters/tree/main/astro-airflow-iris
mini-kedro: https://github.com/kedro-org/kedro-starters/tree/main/mini-kedro
pandas-iris: https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris
pyspark: https://github.com/kedro-org/kedro-starters/tree/main/pyspark
pyspark-iris: https://github.com/kedro-org/kedro-starters/tree/main/pyspark-iris
spaceflights: https://github.com/kedro-org/kedro-starters/tree/main/spaceflights
```

You can **have a look at the [plugin code](https://github.com/Galileo-Galilei/fake-plugin-starter.git) if needed**.

**Some questions are still to be answered:** 
- is this a desirable implementation?
- should we add extra conversion / parsing when loading the entrypoint to check the format of the constant (I think we should, this is likely error prone right now)
- should we enable plugin authors to override "official" starters? My current code prevents this but it may be acceptable.
- should we make a visual distinction when listing the starters ? i add an extra (*) at the beginning to ensure they are listed first and identifiable at first glance.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes

As of now, **I did not add tests and documentation: I'll update them once you will confirm these changes are desirable**

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1265"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

