### PR TITLE
[KED-3043] Add support for Python 3.10

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -481,10 +481,6 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-      - build_docker_image:
-          matrix:
-            parameters:
-              python_version: [ "3.10" ]
       - e2e_tests:
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -484,31 +484,31 @@ workflows:
       - e2e_tests:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_e2e_tests:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - unit_tests:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_unit_tests:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - lint:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - pip_compile:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_pip_compile:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - build_docs
       - docs_linkcheck
       - all_circleci_checks_succeeded:
@@ -577,11 +577,11 @@ workflows:
       - build_docker_image:
           matrix:
             parameters:
-              python_version: ["3.9"]
+              python_version: ["3.9", "3.10"]
       - build_kedro:
           matrix:
             parameters:
-              python_version: ["3.9"]
+              python_version: ["3.9", "3.10"]
           requires:
             - build_docker_image-<<matrix.python_version>>
 
@@ -591,7 +591,7 @@ workflows:
       - build_kedro:
           matrix:
             parameters:
-              python_version: ["3.7", "3.8", "3.9"]
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - publish_kedro:
           requires:
             - build_kedro

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -481,6 +481,10 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
+      - build_docker_image:
+          matrix:
+            parameters:
+              python_version: [ "3.10" ]
       - e2e_tests:
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -211,9 +211,21 @@ jobs:
       python_version: <<parameters.python_version>>
     steps:
       - setup
-      - run:
-          name: Run unit tests
-          command: make test
+      - unless:
+          condition:
+            equal: ["3.10", <<parameters.python_version>>]
+          steps:
+            - run:
+                name: Run unit tests in parallel
+                command: make test
+      - when:
+          condition:
+            equal: [ "3.10", <<parameters.python_version>> ]
+          steps:
+            - run:
+                name: Run unit tests sequentially
+                command: pytest tests --cov-config pyproject.toml
+
 
   win_unit_tests:
     parameters:
@@ -237,9 +249,20 @@ jobs:
           # Setting it to 2 or higher will suppress the warning messages totally.
           name: Set HDF5_DISABLE_VERSION_CHECK environment variable
           command: setx /m HDF5_DISABLE_VERSION_CHECK 1
-      - run:
-          name: Run unit tests without spark
-          command: conda activate kedro_builder; make test-no-spark
+      - unless:
+          condition:
+            equal: [ "3.10", <<parameters.python_version>> ]
+          steps:
+            - run:
+                name: Run unit tests without spark in parallel
+                command: conda activate kedro_builder; make test-no-spark
+      - when:
+          condition:
+            equal: [ "3.10", <<parameters.python_version>> ]
+          steps:
+            - run:
+                name: Run unit tests withou spark sequentially
+                command: conda activate kedro_builder; pytest tests --no-cov --ignore tests/extras/datasets/spark
 
   lint:
     parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -49,9 +49,8 @@ commands:
           name: Install pip setuptools
           command: make install-pip-setuptools
       - run:
-          # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks
-          command: conda install -y "virtualenv<20.0"
+          command: conda install -y virtualenv
       - run:
           name: Install requirements and test requirements
           command: pip install --upgrade -r test_requirements.txt

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -539,7 +539,12 @@ workflows:
             - win_e2e_tests
             - unit_tests
             - win_unit_tests
-            - lint
+            # lint-3.10 is not required due to inconsistent results for pylint.
+            # See: https://github.com/PyCQA/pylint/issues/5832
+            # - lint
+            - lint-3.7
+            - lint-3.8
+            - lint-3.9
             - pip_compile
             - win_pip_compile
             - build_docs

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ lint:
 	pre-commit run -a --hook-stage manual $(hook)
 
 test:
-	pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile
+	pytest tests --cov-config pyproject.toml
 
 test-no-spark:
 	pytest tests --no-cov --ignore tests/extras/datasets/spark --numprocesses 4 --dist loadfile

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 	pytest tests --cov-config pyproject.toml
 
 test-no-spark:
-	pytest tests --no-cov --ignore tests/extras/datasets/spark --numprocesses 4 --dist loadfile
+	pytest tests --no-cov --ignore tests/extras/datasets/spark
 
 e2e-tests:
 	behave

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,10 @@ lint:
 	pre-commit run -a --hook-stage manual $(hook)
 
 test:
-	pytest tests --cov-config pyproject.toml
+	pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile
 
 test-no-spark:
-	pytest tests --no-cov --ignore tests/extras/datasets/spark
+	pytest tests --no-cov --ignore tests/extras/datasets/spark --numprocesses 4 --dist loadfile
 
 e2e-tests:
 	behave

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ![Kedro Logo Banner](https://raw.githubusercontent.com/kedro-org/kedro/develop/static/img/kedro_banner.png)
-[![Python version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg)](https://pypi.org/project/kedro/)
+[![Python version](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg)](https://pypi.org/project/kedro/)
 [![PyPI version](https://badge.fury.io/py/kedro.svg)](https://pypi.org/project/kedro/)
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/kedro.svg)](https://anaconda.org/conda-forge/kedro)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/kedro-org/kedro/blob/main/LICENSE.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Upcoming Release 0.18.0
 
 ## Major features and improvements
-* Added support for Python 3.9, dropped support for Python 3.6.
+* Added support for Python 3.9 and 3.10, dropped support for Python 3.6.
 * Support specifying parameters mapping in `pipeline()` without the `params:` prefix.
 * Added new API `Pipeline.filter()` (previously in `KedroContext._filter_pipeline()`) to filter parts of a pipeline.
 * Added `partitionBy` support and exposed `save_args` for `SparkHiveDataSet`.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -23,9 +23,9 @@ Welcome to Kedro's documentation!
     :target: https://opensource.org/licenses/Apache-2.0
     :alt: License is Apache 2.0
 
-.. image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue.svg
+.. image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg
     :target: https://pypi.org/project/kedro/
-    :alt: Python version 3.7, 3.8, 3.9
+    :alt: Python version 3.7, 3.8, 3.9, 3.10
 
 .. image:: https://badge.fury.io/py/kedro.svg
     :target: https://pypi.org/project/kedro/

--- a/features/environment.py
+++ b/features/environment.py
@@ -130,7 +130,7 @@ def _install_project_requirements(context):
     # (e.g. 3xx, to which jupyterlab~=3.0 defaults) have a bug that prevents
     # JupyterLab from running, hence the version is forcefully set to 225.
     # More details: https://github.com/mhammond/pywin32/issues/1431
-    if sys.platform.startswith("win"):
+    if sys.platform.startswith("win") and sys.version.split(".")[1] < "10":
         install_reqs.append("pywin32==225")
 
     call([context.pip, "install", *install_reqs], env=context.env)

--- a/features/environment.py
+++ b/features/environment.py
@@ -130,6 +130,7 @@ def _install_project_requirements(context):
     # (e.g. 3xx, to which jupyterlab~=3.0 defaults) have a bug that prevents
     # JupyterLab from running, hence the version is forcefully set to 225.
     # More details: https://github.com/mhammond/pywin32/issues/1431
+    # This isn't needed for Python 3.10.
     if sys.platform.startswith("win") and sys.version.split(".")[1] < "10":
         install_reqs.append("pywin32==225")
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -131,7 +131,7 @@ def _install_project_requirements(context):
     # JupyterLab from running, hence the version is forcefully set to 225.
     # More details: https://github.com/mhammond/pywin32/issues/1431
     # This isn't needed for Python 3.10.
-    if sys.platform.startswith("win") and sys.version.split(".")[1] < "10":
+    if sys.platform.startswith("win") and sys.version_info < (3, 10):
         install_reqs.append("pywin32==225")
 
     call([context.pip, "install", *install_reqs], env=context.env)

--- a/features/environment.py
+++ b/features/environment.py
@@ -131,7 +131,7 @@ def _install_project_requirements(context):
     # JupyterLab from running, hence the version is forcefully set to 225.
     # More details: https://github.com/mhammond/pywin32/issues/1431
     # This isn't needed for Python 3.10.
-    if sys.platform.startswith("win") and sys.version_info < (3, 10):
+    if sys.platform.startswith("win") and sys.version_info.minor < 10:
         install_reqs.append("pywin32==225")
 
     call([context.pip, "install", *install_reqs], env=context.env)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ min-public-methods = 1
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-omit = ["kedro/templates/*", "kedro/framework/cli/hooks/specs.py", "kedro/framework/hooks/specs.py", "kedro/extras/datasets/tensorflow/*"]
+omit = ["kedro/templates/*", "kedro/framework/cli/hooks/specs.py", "kedro/framework/hooks/specs.py", "kedro/extras/datasets/tensorflow/*", "kedro/extras/datasets/holoviews/*"]
 exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ min-public-methods = 1
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-omit = ["kedro/templates/*", "kedro/framework/cli/hooks/specs.py", "kedro/framework/hooks/specs.py", "kedro/extras/datasets/tensorflow/*", "kedro/extras/datasets/holoviews/*"]
+omit = ["kedro/templates/*", "kedro/framework/cli/hooks/specs.py", "kedro/framework/hooks/specs.py", "kedro/extras/datasets/tensorflow/*", "kedro/extras/datasets/holoviews/*", "tests/*"]
 exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.pytest.ini_options]

--- a/setup.py
+++ b/setup.py
@@ -159,7 +159,7 @@ setup(
     long_description=readme,
     long_description_content_type="text/markdown",
     url="https://github.com/kedro-org/kedro",
-    python_requires=">=3.7, <3.10",
+    python_requires=">=3.7, <3.11",
     packages=find_packages(exclude=["docs*", "tests*", "tools*", "features*"]),
     include_package_data=True,
     tests_require=test_requires,
@@ -176,6 +176,7 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
     extras_require=extras_require,
 )

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -20,7 +20,8 @@ ipython>=7.31.1, <8.0; python_version > '3.6'
 ipython~=7.16.3; python_version == '3.6'
 joblib>=0.14
 lxml~=4.6
-matplotlib>=3.0.3, <3.6  # 3.4.0 breaks holoviews
+matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
+matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
 moto==1.3.7
 nbconvert>=5.3.1, <6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -48,8 +48,7 @@ s3fs>=0.3.0, <0.5  # Needs to be at least 0.3.0 to make use of `cachable` attrib
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow>=2.0, <2.6; python_version>='3.9'
-tensorflow>=2.0, <3.0; python_version<'3.9'
+tensorflow>=2.0, <3.0
 trufflehog~=2.1
 wheel~=0.35
 xlsxwriter~=1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -20,7 +20,7 @@ ipython>=7.31.1, <8.0; python_version > '3.6'
 ipython~=7.16.3; python_version == '3.6'
 joblib>=0.14
 lxml~=4.6
-matplotlib>=3.0.3, <3.4  # 3.4.0 breaks holoviews
+matplotlib>=3.0.3, <3.6  # 3.4.0 breaks holoviews
 memory_profiler>=0.50.0, <1.0
 moto==1.3.7
 nbconvert>=5.3.1, <6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -34,7 +34,7 @@ plotly>=4.8.0, <6.0
 pre-commit~=1.17
 psutil==5.8.0
 pyarrow>=1.0, <7.0
-pylint>=2.5.2, <2.11; python_version=='3.9'
+pylint>=2.5.2, <2.11; python_version>='3.9'
 pylint>=2.5.2, <3.0; python_version<'3.9'
 pyproj~=3.0
 pyspark>=2.2, <4.0
@@ -48,7 +48,7 @@ s3fs>=0.3.0, <0.5  # Needs to be at least 0.3.0 to make use of `cachable` attrib
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow>=2.0, <2.6; python_version=='3.9'
+tensorflow>=2.0, <2.6; python_version>='3.9'
 tensorflow>=2.0, <3.0; python_version<'3.9'
 trufflehog~=2.1
 wheel~=0.35

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -23,7 +23,8 @@ lxml~=4.6
 matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
 matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
-moto==3.0.4
+moto==3.0.4; python_version == '3.10'
+moto==2.0.3; python_version < '3.10'
 nbconvert>=5.3.1, <6.0
 nbformat~=4.4
 networkx~=2.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -23,7 +23,7 @@ lxml~=4.6
 matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
 matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
-moto==1.3.7
+moto==3.0.4
 nbconvert>=5.3.1, <6.0
 nbformat~=4.4
 networkx~=2.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -23,8 +23,7 @@ lxml~=4.6
 matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
 matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
-moto==3.0.4; python_version == '3.10'
-moto==2.0.3; python_version < '3.10'
+moto==3.0.4
 nbconvert>=5.3.1, <6.0
 nbformat~=4.4
 networkx~=2.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -23,7 +23,8 @@ lxml~=4.6
 matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
 matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
-moto==3.0.4
+moto==1.3.7; python_version < '3.10'
+moto==3.0.4; python_version == '3.10'
 nbconvert>=5.3.1, <6.0
 nbformat~=4.4
 networkx~=2.4

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -35,8 +35,7 @@ plotly>=4.8.0, <6.0
 pre-commit~=1.17
 psutil==5.8.0
 pyarrow>=1.0, <7.0
-pylint>=2.5.2, <2.11; python_version>='3.9'
-pylint>=2.5.2, <3.0; python_version<'3.9'
+pylint>=2.5.2, <3.0
 pyproj~=3.0
 pyspark>=2.2, <4.0
 pytest-cov~=3.0

--- a/tests/extras/datasets/holoviews/test_holoviews_writer.py
+++ b/tests/extras/datasets/holoviews/test_holoviews_writer.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path, PurePosixPath
 
 import holoviews as hv
@@ -33,6 +34,10 @@ def versioned_hv_writer(filepath_png, load_version, save_version):
     return HoloviewsWriter(filepath_png, version=Version(load_version, save_version))
 
 
+@pytest.mark.skipif(
+    sys.version.split(".")[1] == "10",
+    reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
+)
 class TestHoloviewsWriter:
     def test_save_data(self, tmp_path, dummy_hv_object, hv_writer):
         """Test saving Holoviews object."""
@@ -112,6 +117,10 @@ class TestHoloviewsWriter:
         assert isinstance(data_set._filepath, PurePosixPath)
 
 
+@pytest.mark.skipif(
+    sys.version.split(".")[1] == "10",
+    reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
+)
 class TestHoloviewsWriterVersioned:
     def test_version_str_repr(self, hv_writer, versioned_hv_writer):
         """Test that version is in string representation of the class instance

--- a/tests/extras/datasets/holoviews/test_holoviews_writer.py
+++ b/tests/extras/datasets/holoviews/test_holoviews_writer.py
@@ -35,7 +35,7 @@ def versioned_hv_writer(filepath_png, load_version, save_version):
 
 
 @pytest.mark.skipif(
-    sys.version.split(".")[1] == "10",
+    sys.version_info == (3, 10),
     reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
 )
 class TestHoloviewsWriter:
@@ -118,7 +118,7 @@ class TestHoloviewsWriter:
 
 
 @pytest.mark.skipif(
-    sys.version.split(".")[1] == "10",
+   sys.version_info == (3, 10),
     reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
 )
 class TestHoloviewsWriterVersioned:

--- a/tests/extras/datasets/holoviews/test_holoviews_writer.py
+++ b/tests/extras/datasets/holoviews/test_holoviews_writer.py
@@ -35,7 +35,7 @@ def versioned_hv_writer(filepath_png, load_version, save_version):
 
 
 @pytest.mark.skipif(
-    sys.version_info == (3, 10),
+    sys.version_info.minor == 10,
     reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
 )
 class TestHoloviewsWriter:
@@ -118,7 +118,7 @@ class TestHoloviewsWriter:
 
 
 @pytest.mark.skipif(
-   sys.version_info == (3, 10),
+    sys.version_info.minor == 10,
     reason="Python 3.10 needs matplotlib>=3.5 which breaks holoviews.",
 )
 class TestHoloviewsWriterVersioned:

--- a/tests/io/test_incremental_dataset.py
+++ b/tests/io/test_incremental_dataset.py
@@ -350,6 +350,7 @@ def mocked_s3_bucket():
     with mock_s3():
         conn = boto3.client(
             "s3",
+            region_name="us-east-1",
             aws_access_key_id="fake_access_key",
             aws_secret_access_key="fake_secret_key",
         )

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -417,6 +417,7 @@ def mocked_s3_bucket():
     with mock_s3():
         conn = boto3.client(
             "s3",
+            region_name="us-east-1",
             aws_access_key_id="fake_access_key",
             aws_secret_access_key="fake_secret_key",
         )


### PR DESCRIPTION
## Description
Add support for Python 3.10

## Development notes
Significant things to note:

1. `moto` had to be updated to a newer version, however when the tests are run in parallel either `test_incremental_dataset` or `test_partioned_dataset` would fail intermittently, so I changed the tests to not be run in parallel anymore. This might not be an ideal solution, because it adds run time of about 4 mins to each unit test build. The lower version of `moto` could still be used for Python versions < 3.10, but the 3.10 build would then still fail if run in parallel. 
2. For Python 3.10 `matplotlib>=3.5` is needed, which breaks `holoviews`. I've disabled the holoviews tests for Python 3.10, but also had to ignore that dataset from the test coverage check in `pyproject.toml`. 
3. Pylint gives different results for python versions < 3.10 compared to python 3.10. I've opened an issue on the `pylint` repo: https://github.com/PyCQA/pylint/issues/5832 My suggestion for now is just mark the `lint-3.10` build as not required. 

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1275"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

