### PR TITLE
Include release_kedro parameter in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,10 @@
 version: 2.1
 
+parameters:
+  release_kedro:
+    type: boolean
+    default: false
+
 setup: true
 
 orbs:


### PR DESCRIPTION
## Description
We are getting `Unexpected argument(s): release_kedro` from the release script. Based on [this](https://discuss.circleci.com/t/how-to-pass-pipeline-parameters-when-using-path-filtering-orb/42053/5) I think we need to define this parameter in the config.yml file as well as continue_config.yml.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1276"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

