### PR TITLE
Fix broken anchors and make absolute links relative

### DIFF
--- a/docs/source/03_tutorial/06_namespace_pipelines.md
+++ b/docs/source/03_tutorial/06_namespace_pipelines.md
@@ -5,10 +5,10 @@ This section covers the following:
 * A brief introduction to namespaces and modular pipelines
 * How to convert the existing spaceflights project into a namespaced one
 
-Adding namespaces to [modular pipelines](../06_nodes_and_pipelines/03_modular_pipelines.md#modular-pipelines) unlocks some sophisticated functionality in Kedro
+Adding namespaces to [modular pipelines](../06_nodes_and_pipelines/03_modular_pipelines.md) unlocks some sophisticated functionality in Kedro
 
 1. You are able to [instantiate the same pipeline structure multiple times](../06_nodes_and_pipelines/03_modular_pipelines.md#using-a-modular-pipeline-multiple-times), but provide different inputs/outputs.
-2. You can unlock the full power of [micro-packaging](../06_nodes_and_pipelines/03_modular_pipelines.md#how-to-share-a-modular-pipeline).
+2. You can unlock the full power of [micro-packaging](../06_nodes_and_pipelines/04_micro_packaging.md).
 3. You can de-clutter your mental model with Kedro-Viz rendering collapsible components.
 
     ![collapsible](../meta/images/collapsible.gif)

--- a/docs/source/03_tutorial/06_namespace_pipelines.md
+++ b/docs/source/03_tutorial/06_namespace_pipelines.md
@@ -5,10 +5,10 @@ This section covers the following:
 * A brief introduction to namespaces and modular pipelines
 * How to convert the existing spaceflights project into a namespaced one
 
-Adding namespaces to [modular pipelines](https://kedro.readthedocs.io/en/stable/06_nodes_and_pipelines/03_modular_pipelines.html#modular-pipelines) unlocks some sophisticated functionality in Kedro
+Adding namespaces to [modular pipelines](../06_nodes_and_pipelines/03_modular_pipelines.md#modular-pipelines) unlocks some sophisticated functionality in Kedro
 
-1. You are able to [instantiate the same pipeline structure multiple times](https://kedro.readthedocs.io/en/stable/06_nodes_and_pipelines/03_modular_pipelines.html#how-to-use-a-modular-pipeline-twice), but provide different inputs/outputs.
-2. You can unlock the full power of [micro-packaging](https://kedro.readthedocs.io/en/stable/06_nodes_and_pipelines/03_modular_pipelines.html#how-to-share-a-modular-pipeline).
+1. You are able to [instantiate the same pipeline structure multiple times](../06_nodes_and_pipelines/03_modular_pipelines.md#using-a-modular-pipeline-multiple-times), but provide different inputs/outputs.
+2. You can unlock the full power of [micro-packaging](../06_nodes_and_pipelines/03_modular_pipelines.md#how-to-share-a-modular-pipeline).
 3. You can de-clutter your mental model with Kedro-Viz rendering collapsible components.
 
     ![collapsible](../meta/images/collapsible.gif)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
To fix broken anchors (`#how-to-use-a-modular-pipeline-twice` -> `#using-a-modular-pipeline-multiple-times`, `#how-to-share-a-modular-pipeline` to separate micro-packaging page), and make some docs improvements in parallel.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1277"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

