### PR TITLE
[KED-3055] Update docs to use `pipeline` rather than `Pipeline`

### DIFF
--- a/docs/source/02_get_started/03_hello_kedro.md
+++ b/docs/source/02_get_started/03_hello_kedro.md
@@ -48,10 +48,10 @@ A pipeline organises the dependencies and execution order of a collection of nod
 In this example the pipeline executes `return_greeting_node` before it executes `join_statements_node`:
 
 ```python
-from kedro.pipeline import Pipeline
+from kedro.pipeline import pipeline
 
 # Assemble nodes into a pipeline
-pipeline = Pipeline([return_greeting_node, join_statements_node])
+greeting_pipeline = pipeline([return_greeting_node, join_statements_node])
 ```
 
 ## DataCatalog
@@ -84,7 +84,7 @@ It's now time to stitch the code together. Here is the full example:
 ```python
 """Contents of hello_kedro.py"""
 from kedro.io import DataCatalog, MemoryDataSet
-from kedro.pipeline import node, Pipeline
+from kedro.pipeline import node, pipeline
 from kedro.runner import SequentialRunner
 
 # Prepare a data catalog
@@ -107,13 +107,13 @@ join_statements_node = node(
 )
 
 # Assemble nodes into a pipeline
-pipeline = Pipeline([return_greeting_node, join_statements_node])
+greeting_pipeline = pipeline([return_greeting_node, join_statements_node])
 
 # Create a runner to run the pipeline
 runner = SequentialRunner()
 
 # Run the pipeline
-print(runner.run(pipeline, data_catalog))
+print(runner.run(greeting_pipeline, data_catalog))
 ```
 Then open a terminal and run the following command:
 

--- a/docs/source/03_tutorial/05_visualise_pipeline.md
+++ b/docs/source/03_tutorial/05_visualise_pipeline.md
@@ -180,7 +180,7 @@ def compare_shuttle_speed(shuttle_data):
 
 def create_pipeline(**kwargs) -> Pipeline:
     """This is a simple pipeline which generates a plot"""
-    return Pipeline(
+    return pipeline(
         [
             node(
                 func=compare_shuttle_speed,

--- a/docs/source/05_data/01_data_catalog.md
+++ b/docs/source/05_data/01_data_catalog.md
@@ -466,7 +466,7 @@ my_dataframe@pandas:
 These entries are used in the pipeline like this:
 
 ```python
-Pipeline(
+pipeline(
     [
         node(func=my_func1, inputs="spark_input", outputs="my_dataframe@spark"),
         node(func=my_func2, inputs="my_dataframe@pandas", outputs="pipeline_output"),

--- a/docs/source/05_data/02_kedro_io.md
+++ b/docs/source/05_data/02_kedro_io.md
@@ -541,9 +541,9 @@ node(
 Alternatively, confirmation can be deferred to one of the nodes downstream, allowing you to implement extra validations before the loaded partitions are considered successfully processed:
 
 ```python
-from kedro.pipeline import Pipeline, node
+from kedro.pipeline import node, pipeline
 
-Pipeline(
+pipeline(
     [
         node(
             func=process_partitions,

--- a/docs/source/06_nodes_and_pipelines/02_pipeline_introduction.md
+++ b/docs/source/06_nodes_and_pipelines/02_pipeline_introduction.md
@@ -25,7 +25,7 @@ def variance(m, m2):
     return m2 - m * m
 
 
-pipeline = Pipeline(
+variance_pipeline = pipeline(
     [
         node(len, "xs", "n"),
         node(mean, ["xs", "n"], "m", name="mean_node"),
@@ -42,7 +42,7 @@ You can use `describe` to understand what nodes are part of the pipeline:
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.describe())
+print(variance_pipeline.describe())
 ```
 
 The output is as follows:
@@ -67,7 +67,7 @@ Outputs: v
 You can also tag your pipeline by providing the `tags` argument, which will tag all of the pipeline's nodes. In the following example, both nodes are tagged with `pipeline_tag`.
 
 ```python
-pipeline = Pipeline(
+pipeline = pipeline(
     [node(..., name="node1"), node(..., name="node2")], tags="pipeline_tag"
 )
 ```
@@ -75,7 +75,7 @@ pipeline = Pipeline(
 You can combine pipeline tagging with node tagging. In the following example, `node1` and `node2` are tagged with `pipeline_tag`, while `node2` also has a `node_tag`.
 
 ```python
-pipeline = Pipeline(
+pipeline = pipeline(
     [node(..., name="node1"), node(..., name="node2", tags="node_tag")],
     tags="pipeline_tag",
 )
@@ -91,15 +91,15 @@ You can merge multiple pipelines as shown below. Note that, in this case, `pipel
 
 
 ```python
-pipeline_de = Pipeline([node(len, "xs", "n"), node(mean, ["xs", "n"], "m")])
+pipeline_de = pipeline([node(len, "xs", "n"), node(mean, ["xs", "n"], "m")])
 
-pipeline_ds = Pipeline(
+pipeline_ds = pipeline(
     [node(mean_sos, ["xs", "n"], "m2"), node(variance, ["m", "m2"], "v")]
 )
 
 last_node = node(print, "v", None)
 
-pipeline_all = Pipeline([pipeline_de, pipeline_ds, last_node])
+pipeline_all = pipeline([pipeline_de, pipeline_ds, last_node])
 print(pipeline_all.describe())
 ```
 
@@ -130,7 +130,7 @@ Pipelines provide access to their nodes in a topological order to enable custom 
 <summary><b>Click to expand</b></summary>
 
 ```python
-nodes = pipeline.nodes
+nodes = variance_pipeline.nodes
 nodes
 ```
 
@@ -162,7 +162,7 @@ You should see the following:
 In a similar way to the above, you can use `inputs()` and `outputs()` to check the inputs and outputs of a pipeline:
 
 ```python
-pipeline.inputs()
+variance_pipeline.inputs()
 ```
 
 Gives the following:
@@ -172,7 +172,7 @@ Out[7]: {'xs'}
 ```
 
 ```python
-pipeline.outputs()
+variance_pipeline.outputs()
 ```
 
 Displays the output:
@@ -195,7 +195,7 @@ In this case we have a pipeline consisting of a single node with no input and ou
 
 ```python
 try:
-    Pipeline([node(lambda: print("!"), None, None)])
+    pipeline([node(lambda: print("!"), None, None)])
 except Exception as e:
     print(e)
 ```
@@ -220,7 +220,7 @@ The first node captures the relationship of how to calculate `y` from `x` and th
 
 ```python
 try:
-    Pipeline(
+    pipeline(
         [
             node(lambda x: x + 1, "x", "y", name="first node"),
             node(lambda y: y - 1, "y", "x", name="second node"),

--- a/docs/source/06_nodes_and_pipelines/03_modular_pipelines.md
+++ b/docs/source/06_nodes_and_pipelines/03_modular_pipelines.md
@@ -139,14 +139,14 @@ Sometimes two pipelines need to be connected, but do not share any catalog depen
 In this example, there is a `lunch_pipeline` which makes us lunch. The 'verbs', `defrost` and `eat`, are Python functions and the inputs/outputs are food at different points of the process (`frozen`, `thawed` and `food`).
 
 ```python
-cook_pipeline = Pipeline(
+cook_pipeline = pipeline(
     [
         node(func=defrost, inputs="frozen_veg", outputs="veg"),
         node(func=grill, inputs="veg", outputs="grilled_veg"),
     ]
 )
 
-lunch_pipeline = Pipeline([node(func=eat, inputs="food", outputs=None)])
+lunch_pipeline = pipeline([node(func=eat, inputs="food", outputs=None)])
 
 cook_pipeline + lunch_pipeline
 ```
@@ -173,7 +173,7 @@ Providing this input/output override will join up the pipeline nicely:
 ![joined](../meta/images/cook_joined.png)
 
 ```eval_rst
-.. note:: In this example we have used the ``+`` operator to join two pipelines. Remember you can also use ``sum()`` or pass a list of pipelines to the ``Pipeline()`` constructor as well.
+.. note:: In this example we have used the ``+`` operator to join two pipelines. Remember you can also use ``sum()`` or pass a list of pipelines to the `pipe` argument as well.
 ```
 
 </details>
@@ -190,17 +190,17 @@ Reusing pipelines for slightly different purposes can be a real accelerator for 
 <summary>Click here to see a worked example</summary>
 
 ```python
-cook_pipeline = Pipeline(
+cook_pipeline = pipeline(
     [
         node(func=defrost, inputs="frozen_veg", outputs="veg", name="defrost_node"),
         node(func=grill, inputs="veg", outputs="grilled_veg"),
     ]
 )
 
-eat_breakfast_pipeline = Pipeline(
+eat_breakfast_pipeline = pipeline(
     [node(func=eat_breakfast, inputs="breakfast_food", outputs=None)]
 )
-eat_lunch_pipeline = Pipeline([node(func=eat_lunch, inputs="lunch_food", outputs=None)])
+eat_lunch_pipeline = pipeline([node(func=eat_lunch, inputs="lunch_food", outputs=None)])
 
 cook_pipeline + eat_breakfast_pipeline + eat_lunch_pipeline
 ```
@@ -268,17 +268,17 @@ final_pipeline = (
 * Providing a namespace isolates the intermediate operation and visualises nicely.
 
 ```python
-template_pipeline = Pipeline(
+template_pipeline = pipeline(
     [
         node(
             func=node_func1,
             inputs=["input1", "input2", "params:override_me"],
-            outputs="intermediary_output"
+            outputs="intermediary_output",
         ),
         node(
             func=node_func2,
             inputs="intermediary_output",
-            outputs="output"
+            outputs="output",
         ),
     ]
 )
@@ -286,8 +286,8 @@ template_pipeline = Pipeline(
 alpha_pipeline = pipeline(
     pipe=template_pipeline,
     inputs={"input1", "input2"},
-    parameters={"params:override_me": "params:alpha"}
-    namespace="alpha"
+    parameters={"params:override_me": "params:alpha"},
+    namespace="alpha",
 )
 
 beta_pipeline = pipeline(

--- a/docs/source/06_nodes_and_pipelines/05_run_a_pipeline.md
+++ b/docs/source/06_nodes_and_pipelines/05_run_a_pipeline.md
@@ -168,7 +168,7 @@ def register_pipelines():
 
     data_engineering_pipeline = de.create_pipeline()
     data_science_pipeline = ds.create_pipeline()
-    my_pipeline = Pipeline(
+    my_pipeline = pipeline(
         [
             # your definition goes here
         ]

--- a/docs/source/06_nodes_and_pipelines/06_slice_a_pipeline.md
+++ b/docs/source/06_nodes_and_pipelines/06_slice_a_pipeline.md
@@ -21,7 +21,7 @@ def variance(m, m2):
     return m2 - m * m
 
 
-pipeline = Pipeline(
+full_pipeline = pipeline(
     [
         node(len, "xs", "n"),
         node(mean, ["xs", "n"], "m", name="mean_node", tags="mean"),
@@ -32,7 +32,7 @@ pipeline = Pipeline(
 ```
 </details>
 
-The `pipeline.describe()` method returns the following output:
+The `Pipeline.describe()` method returns the following output:
 
 <details>
 <summary><b>Click to expand</b></summary>
@@ -63,7 +63,7 @@ One way to slice a pipeline is to provide a set of pre-calculated inputs which s
 
 
 ```python
-print(pipeline.from_inputs("m2").describe())
+print(full_pipeline.from_inputs("m2").describe())
 ```
 
 `Output`:
@@ -86,7 +86,7 @@ Slicing the pipeline from inputs `m` and `xs` results in the following pipeline:
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.from_inputs("m", "xs").describe())
+print(full_pipeline.from_inputs("m", "xs").describe())
 ```
 
 `Output`:
@@ -115,7 +115,7 @@ Another way of slicing a pipeline is to specify the nodes which should be used a
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.from_nodes("mean_node").describe())
+print(full_pipeline.from_nodes("mean_node").describe())
 ```
 
 `Output`:
@@ -149,7 +149,7 @@ Similarly, you can specify the nodes which should be used to end a pipeline. For
 
 
 ```python
-print(pipeline.to_nodes("mean_node").describe())
+print(full_pipeline.to_nodes("mean_node").describe())
 ```
 
 `Output`:
@@ -192,7 +192,7 @@ You can also slice a pipeline from the nodes that have specific tags attached to
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.only_nodes_with_tags("mean", "variance").describe())
+print(full_pipeline.only_nodes_with_tags("mean", "variance").describe())
 ```
 
 `Output`:
@@ -216,9 +216,9 @@ To slice a pipeline from nodes that have tag `mean` *OR* tag `variance`:
 
 
 ```python
-sliced_pipeline = pipeline.only_nodes_with_tags("mean") + pipeline.only_nodes_with_tags(
-    "variance"
-)
+sliced_pipeline = full_pipeline.only_nodes_with_tags(
+    "mean"
+) + full_pipeline.only_nodes_with_tags("variance")
 print(sliced_pipeline.describe())
 ```
 
@@ -244,7 +244,7 @@ Sometimes you might need to run only some of the nodes in a pipeline, as follows
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.only_nodes("mean_node", "mean_sos").describe())
+print(full_pipeline.only_nodes("mean_node", "mean_sos").describe())
 ```
 
 `Output`:
@@ -276,7 +276,7 @@ Kedro can automatically generate a sliced pipeline from existing node outputs. T
 <summary><b>Click to expand</b></summary>
 
 ```python
-print(pipeline.describe())
+print(full_pipeline.describe())
 ```
 
 `Output`:
@@ -333,7 +333,7 @@ Running the pipeline calculates `n` and saves the result to disk:
 <summary><b>Click to expand</b></summary>
 
 ```python
-SequentialRunner().run(pipeline, io)
+SequentialRunner().run(full_pipeline, io)
 ```
 
 `Output`:
@@ -359,7 +359,7 @@ We can avoid re-calculating `n` (and all other results that have already been sa
 <summary><b>Click to expand</b></summary>
 
 ```python
-SequentialRunner().run_only_missing(pipeline, io)
+SequentialRunner().run_only_missing(full_pipeline, io)
 ```
 
 `Ouput`:

--- a/docs/source/07_extend_kedro/07_decorators.md
+++ b/docs/source/07_extend_kedro/07_decorators.md
@@ -102,7 +102,7 @@ Decorators can also be useful for monitoring your pipeline. You can apply one or
 For example, if you want to apply the decorator above to all pipeline nodes simultaneously:
 
 ```python
-hello_pipeline = Pipeline(
+hello_pipeline = pipeline(
     [node(say_hello, "name1", None), node(say_hello, "name2", None)]
 ).decorate(apply_g, apply_h)
 

--- a/docs/source/08_logging/02_experiment_tracking.md
+++ b/docs/source/08_logging/02_experiment_tracking.md
@@ -43,7 +43,7 @@ Add the node to your pipeline and ensure that the output name matches the name o
 ```python
 # pipeline.py
 def create_pipeline(**kwargs):
-    return Pipeline(
+    return pipeline(
         [
             node(
                 report_accuracy,

--- a/docs/source/08_logging/02_experiment_tracking.md
+++ b/docs/source/08_logging/02_experiment_tracking.md
@@ -42,7 +42,7 @@ Add the node to your pipeline and ensure that the output name matches the name o
 
 ```python
 # pipeline.py
-def create_pipeline(**kwargs):
+def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
         [
             node(

--- a/docs/source/10_deployment/09_aws_sagemaker.md
+++ b/docs/source/10_deployment/09_aws_sagemaker.md
@@ -225,7 +225,7 @@ from .nodes import (
 
 
 def create_pipeline(**kwargs):
-    return Pipeline(
+    return pipeline(
         [
             node(
                 func=split_data,

--- a/docs/source/10_deployment/09_aws_sagemaker.md
+++ b/docs/source/10_deployment/09_aws_sagemaker.md
@@ -224,7 +224,7 @@ from .nodes import (
 )
 
 
-def create_pipeline(**kwargs):
+def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
         [
             node(

--- a/docs/source/11_tools_integration/01_pyspark.md
+++ b/docs/source/11_tools_integration/01_pyspark.md
@@ -159,7 +159,7 @@ The `DeltaTableDataSet` does not support `save()` operation, as the updates happ
 > Note: If you have defined an implementation for the Kedro `before_dataset_saved`/`after_dataset_saved` hook, the hook will not be triggered. This is because the save operation happens within the `node` itself, via the DeltaTable API.
 
 ```python
-Pipeline(
+pipeline(
     [
         node(
             func=process_barometer_data, inputs="temperature", outputs="weather@spark"
@@ -181,7 +181,7 @@ Pipeline(
 `first_operation_complete` is a `MemoryDataSet` and it signals that any Delta operations which occur "outside" the Kedro DAG are complete. This can be used as input to a downstream node, to preserve the shape of the DAG. Otherwise, if no downstream nodes need to run after this, the node can simply not return anything:
 
 ```python
-Pipeline(
+pipeline(
     [
         node(func=..., inputs="temperature", outputs="weather@spark"),
         node(func=..., inputs="weather@delta", outputs=None),
@@ -206,7 +206,7 @@ Sometimes, you might want to use Spark objects that aren't `DataFrame` as inputs
 ```python
 from typing import Any, Dict
 
-from kedro.pipeline import Pipeline, node
+from kedro.pipeline import node, pipeline
 from pyspark.ml.classification import RandomForestClassifier
 from pyspark.sql import DataFrame
 
@@ -224,7 +224,7 @@ def predict(model: RandomForestClassifier, testing_data: DataFrame) -> DataFrame
 
 
 def create_pipeline(**kwargs):
-    return Pipeline(
+    return pipeline(
         [
             node(train_model, inputs=["training_data"], outputs="example_classifier"),
             node(

--- a/docs/source/11_tools_integration/01_pyspark.md
+++ b/docs/source/11_tools_integration/01_pyspark.md
@@ -223,7 +223,7 @@ def predict(model: RandomForestClassifier, testing_data: DataFrame) -> DataFrame
     return predictions
 
 
-def create_pipeline(**kwargs):
+def create_pipeline(**kwargs) -> Pipeline:
     return pipeline(
         [
             node(train_model, inputs=["training_data"], outputs="example_classifier"),


### PR DESCRIPTION
Signed-off-by: lorenabalan <lorena.balan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Fixes https://github.com/kedro-org/kedro/issues/1299 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1302"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

