### PR TITLE
Call `Path.resolve()` before walking up `.parents`

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -539,12 +539,7 @@ workflows:
             - win_e2e_tests
             - unit_tests
             - win_unit_tests
-            # lint-3.10 is not required due to inconsistent results for pylint.
-            # See: https://github.com/PyCQA/pylint/issues/5832
-            # - lint
-            - lint-3.7
-            - lint-3.8
-            - lint-3.9
+            - lint
             - pip_compile
             - win_pip_compile
             - build_docs

--- a/tests/framework/cli/conftest.py
+++ b/tests/framework/cli/conftest.py
@@ -116,7 +116,7 @@ def fake_project_cli(
     fake_repo_path: Path, dummy_config: Path, fake_kedro_cli: click.CommandCollection
 ):
     old_settings = settings.as_dict()
-    starter_path = Path(__file__).parents[3].resolve()
+    starter_path = Path(__file__).resolve().parents[3]
     starter_path = starter_path / "features" / "steps" / "test_starter"
     CliRunner().invoke(
         fake_kedro_cli, ["new", "-c", str(dummy_config), "--starter", str(starter_path)]


### PR DESCRIPTION
If you want to walk an arbitrary filesystem path upwards, it is recommended to first call `Path.resolve()`. This fixes the lint error on 3.10.

Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1306"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

