### PR TITLE
Add a debug log line when reading config files

### DIFF
--- a/kedro/config/common.py
+++ b/kedro/config/common.py
@@ -145,6 +145,7 @@ def _load_config_file(config_file: Path, ac_template: bool = False) -> Dict[str,
     try:
         # Default to UTF-8, which is Python 3 default encoding, to decode the file
         with open(config_file, encoding="utf8") as yml:
+            _config_logger.debug("loading config file: '%s'", config_file)
             return {
                 k: v
                 for k, v in anyconfig.load(yml, ac_template=ac_template).items()

--- a/kedro/config/common.py
+++ b/kedro/config/common.py
@@ -145,7 +145,7 @@ def _load_config_file(config_file: Path, ac_template: bool = False) -> Dict[str,
     try:
         # Default to UTF-8, which is Python 3 default encoding, to decode the file
         with open(config_file, encoding="utf8") as yml:
-            _config_logger.debug("loading config file: '%s'", config_file)
+            _config_logger.debug("Loading config file: '%s'", config_file)
             return {
                 k: v
                 for k, v in anyconfig.load(yml, ac_template=ac_template).items()


### PR DESCRIPTION
## Description
If a parameter file has an unparsable YAML error you get an unpleasant error like this that doesn't give you much context. 

```
kedro.framework.cli.utils.KedroCliError: while scanning a simple key
  in "<file>", line 253, column 1
could not find expected ':'
  in "<file>", line 254, column 1
Run with --verbose to see the full exception
Error: while scanning a simple key
  in "<file>", line 253, column 1
could not find expected ':'
  in "<file>", line 254, column 1
```

In a project where there are many config files this can be very difficult to debug.

## Development notes
I've added one `DEBUG` level log line that would allow users to work out where things are failing.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1333"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

