### PR TITLE
Speed up Windows CI

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -50,7 +50,6 @@ commands:
       - run: which -a python
       - run: which -a pip
       - run: pip freeze
-      - run: conda info
       - run: python -m pip freeze
       - run:
           name: Install requirements and test requirements

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,7 +183,12 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-      - run: conda activate kedro_builder; pip install behave==1.2.6
+#      - restore_cache:
+#          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+#      - run:
+#          name: Install all requirements
+#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+      - run: conda activate kedro_builder; pip install psutil==5.6.7 psutil==5.6.7
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,12 +183,12 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-#      - restore_cache:
-#          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-#      - run:
-#          name: Install all requirements
-#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
-      - run: conda activate kedro_builder; pip install behave==1.2.6 psutil==5.6.7
+      - restore_cache:
+          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - run:
+          name: Install all requirements
+          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+#      - run: conda activate kedro_builder; pip install behave==1.2.6 psutil==5.6.7
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -135,9 +135,9 @@ commands:
       - run:
           name: Install Fiona
           command: conda activate kedro_builder; conda install -c conda-forge fiona -y
-#      - run:
-#          name: Install all requirements
-#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+      - run:
+          name: Install all requirements
+          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
       - run:
           name: Print Python environment
           command: conda activate kedro_builder; make print-python-env
@@ -174,6 +174,7 @@ jobs:
 
   # What if checksum changes?
   # venv in conda?
+  # Need pywin pinning?
   win_e2e_tests:
     parameters:
       python_version:
@@ -187,10 +188,9 @@ jobs:
           python_version: <<parameters.python_version>>
       - restore_cache:
           key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-#      - run:
-#          name: Install all requirements
-#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
-#      - run: conda activate kedro_builder; pip install behave==1.2.6 psutil==5.6.7
+      - run:
+          name: Install dependencies
+          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
       - run:
           name: Install 'make' command
           command: choco install make
@@ -501,10 +501,10 @@ workflows:
 #          matrix:
 #            parameters:
 #              python_version: ["3.6", "3.7", "3.8"]
-      - win_unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+#      - win_unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
 #      - lint:
 #          matrix:
 #            parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,12 +183,12 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
+      # - restore_cache:
+      #          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - win_setup_requirements
       - run:
           name: Install 'make' command
           command: choco install make
-      - run:
-          name: Install dependencies
-          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -482,51 +482,51 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-      - build_docs
-      - docs_linkcheck
-      - e2e_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+#      - build_docs
+#      - docs_linkcheck
+#      - e2e_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
       - win_e2e_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-      - unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - win_unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - lint:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - pip_compile:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - win_pip_compile:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - all_circleci_checks_succeeded:
-          requires:
-            - e2e_tests
-            # win_e2e_tests-3.6 is not required due to the error
-            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
-            # - win_e2e_tests
-            - win_e2e_tests-3.7
-            - win_e2e_tests-3.8
-            - unit_tests
-            - win_unit_tests
-            - lint
-            - pip_compile
-            - win_pip_compile
-            - build_docs
-            - docs_linkcheck
+#      - unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - win_unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - lint:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - pip_compile:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - win_pip_compile:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - all_circleci_checks_succeeded:
+#          requires:
+#            - e2e_tests
+#            # win_e2e_tests-3.6 is not required due to the error
+#            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
+#            # - win_e2e_tests
+#            - win_e2e_tests-3.7
+#            - win_e2e_tests-3.8
+#            - unit_tests
+#            - win_unit_tests
+#            - lint
+#            - pip_compile
+#            - win_pip_compile
+#            - build_docs
+#            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -49,6 +49,9 @@ commands:
           command: conda install -y "virtualenv<20.0"
       - run: which -a python
       - run: which -a pip
+      - run: pip freeze
+      - run: conda info
+      - run: python -m pip freeze
       - run:
           name: Install requirements and test requirements
           command: pip install --upgrade -r test_requirements.txt

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -48,6 +48,9 @@ commands:
           name: Install venv for some pre-commit hooks
           command: conda install -y "virtualenv<20.0"
       - run:
+          name: Pip freeze
+          command: pip freeze
+      - run:
           name: Install requirements and test requirements
           command: pip install --upgrade -r test_requirements.txt
       - run:
@@ -83,18 +86,18 @@ commands:
       python_version:
         type: string
     steps:
-      - restore_cache:
-          name: Restore package cache
-          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - restore_cache:
-          name: Restore conda environment cache
-          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
       - run:
           name: Initialize conda
           command: conda init powershell
       - run:
           name: Create 'kedro_builder' conda environment
           command: conda create -n kedro_builder python=<<parameters.python_version>> -y
+      - restore_cache:
+          name: Restore package cache
+          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - restore_cache:
+          name: Restore conda environment cache
+          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
     steps:
@@ -288,14 +291,14 @@ jobs:
           steps:
           - save_cache:
               name: Save Python package cache
-              key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+              key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
           name: Save conda environment cache
-          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
+          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
           paths:
             - c:\tools\miniconda3\envs\kedro_builder
       - run:
@@ -502,10 +505,12 @@ workflows:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-#      - unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7"]
+
+      #              python_version: ["3.6", "3.7", "3.8"]
       - win_unit_tests:
           matrix:
             parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -188,7 +188,7 @@ jobs:
 #      - run:
 #          name: Install all requirements
 #          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
-      - run: conda activate kedro_builder; pip install psutil==5.6.7 psutil==5.6.7
+      - run: conda activate kedro_builder; pip install behave==1.2.6 psutil==5.6.7
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -211,15 +211,9 @@ jobs:
       python_version: <<parameters.python_version>>
     steps:
       - setup
-      - run: which -a python
-      - run: which -a pip
-      - run: which -a pytest
       - run:
           name: Run unit tests
           command: make test
-      - run: which -a python
-      - run: which -a pip
-      - run: which -a pytest
 
   win_unit_tests:
     parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -94,12 +94,6 @@ commands:
       - run:
           name: Create 'kedro_builder' conda environment
           command: conda create -n kedro_builder python=<<parameters.python_version>> -y
-      - restore_cache:
-          name: Restore package cache
-          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - restore_cache:
-          name: Restore conda environment cache
-          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
     steps:
@@ -140,6 +134,12 @@ commands:
 
   win_setup_requirements:
     steps:
+      - restore_cache:
+          name: Restore package cache
+          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - restore_cache:
+          name: Restore conda environment cache
+          key: kedro-deps-v1-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - run:
           name: Install GDAL and Fiona
           command: conda activate kedro_builder; conda install gdal fiona -c conda-forge -y
@@ -192,6 +192,10 @@ jobs:
       - run:
           name: Install 'make' command
           command: choco install make
+      # We don't use the `win_setup` command here, which would install the full set
+      # of requirements used by unit tests. Even when those packages are cached
+      # it is faster to just install the minimal set of dependencies needed for e2e
+      # tests in a new empty environment rather than restore the cache.
       - run:
           name: Install dependencies
           command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
@@ -290,20 +294,21 @@ jobs:
       - win_setup:
           python_version: <<parameters.python_version>>
       - when:
-          # Save cache only for Python 3.7. There is no need to save it for each Python.
+          # Save Python package cache only for Python 3.7. The conda environment itself
+          # is specific to a Python version and is cached separately for each.
           condition:
             equal: ["3.7", <<parameters.python_version>>]
           steps:
           - save_cache:
               name: Save Python package cache
-              key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+              key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
           name: Save conda environment cache
-          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
+          key: kedro-deps-v1-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
           paths:
             - c:\tools\miniconda3\envs\kedro_builder
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -133,6 +133,9 @@ commands:
           command: choco install make
 
   win_setup_requirements:
+    parameters:
+      python_version:
+        type: string
     steps:
       - restore_cache:
           name: Restore package cache
@@ -162,7 +165,8 @@ commands:
       - win_setup_conda:
           python_version: <<parameters.python_version>>
       - win_setup_env
-      - win_setup_requirements
+      - win_setup_requirements:
+          python_version: <<parameters.python_version>>
 
 jobs:
   e2e_tests:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -186,9 +186,6 @@ jobs:
       - run:
           name: Install 'make' command
           command: choco install make
-      # - restore_cache:
-      #          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - win_setup_requirements
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,12 +183,12 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-      # - restore_cache:
-      #          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - win_setup_requirements
       - run:
           name: Install 'make' command
           command: choco install make
+      # - restore_cache:
+      #          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - win_setup_requirements
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -47,12 +47,11 @@ commands:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks
           command: conda install -y "virtualenv<20.0"
-      - run:
-          name: Pip freeze
-          command: pip freeze
+      - run: which -a python
+      - run: which -a pip
       - run:
           name: Install requirements and test requirements
-          command: pip install --upgrade -r test_requirements.txt
+          command: python -m pip install --upgrade -r test_requirements.txt
       - run:
           # this is needed to fix java cacerts so
           # spark can automatically download packages from mvn
@@ -207,6 +206,9 @@ jobs:
     executor:
       name: docker
       python_version: <<parameters.python_version>>
+    - run: which -a python
+    - run: which -a pip
+    - run: which -a pytest
     steps:
       - setup
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -155,7 +155,7 @@ commands:
           python_version: <<parameters.python_version>>
       - win_setup_env
       - restore_cache:
-          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-invalid
       - win_setup_requirements
 
 jobs:
@@ -173,7 +173,6 @@ jobs:
           command: make e2e-tests
 
   # What if checksum changes?
-  # venv in conda?
   # Need pywin pinning?
   win_e2e_tests:
     parameters:
@@ -186,8 +185,6 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
-      - restore_cache:
-          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - run:
           name: Install dependencies
           command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
@@ -501,10 +498,10 @@ workflows:
 #          matrix:
 #            parameters:
 #              python_version: ["3.6", "3.7", "3.8"]
-#      - win_unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - win_unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
 #      - lint:
 #          matrix:
 #            parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -51,7 +51,7 @@ commands:
       - run: which -a pip
       - run:
           name: Install requirements and test requirements
-          command: python -m pip install --upgrade -r test_requirements.txt
+          command: pip install --upgrade -r test_requirements.txt
       - run:
           # this is needed to fix java cacerts so
           # spark can automatically download packages from mvn

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -139,7 +139,7 @@ commands:
     steps:
       - run:
           name: Install GDAL and Fiona
-          command: conda activate kedro_builder; conda install gdal fiona -c local conda-forge -y
+          command: conda activate kedro_builder; conda install gdal fiona -c local -c conda-forge -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -135,9 +135,9 @@ commands:
       - run:
           name: Install Fiona
           command: conda activate kedro_builder; conda install -c conda-forge fiona -y
-      - run:
-          name: Install all requirements
-          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+#      - run:
+#          name: Install all requirements
+#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
       - run:
           name: Print Python environment
           command: conda activate kedro_builder; make print-python-env
@@ -172,6 +172,8 @@ jobs:
           name: Run e2e tests
           command: make e2e-tests
 
+  # What if checksum changes?
+  # venv in conda?
   win_e2e_tests:
     parameters:
       python_version:
@@ -499,10 +501,10 @@ workflows:
 #          matrix:
 #            parameters:
 #              python_version: ["3.6", "3.7", "3.8"]
-#      - win_unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - win_unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
 #      - lint:
 #          matrix:
 #            parameters:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -185,9 +185,9 @@ jobs:
           python_version: <<parameters.python_version>>
       - restore_cache:
           key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - run:
-          name: Install all requirements
-          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+#      - run:
+#          name: Install all requirements
+#          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
 #      - run: conda activate kedro_builder; pip install behave==1.2.6 psutil==5.6.7
       - run:
           name: Install 'make' command

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -142,7 +142,7 @@ commands:
     steps:
       - run:
           name: Install GDAL and Fiona
-          command: conda activate kedro_builder; conda install gdal fiona -c local -c conda-forge -y
+          command: conda activate kedro_builder; conda install gdal fiona -c conda-forge -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -183,6 +183,7 @@ jobs:
       - checkout
       - win_setup_conda:
           python_version: <<parameters.python_version>>
+      - run: conda activate kedro_builder; pip install behave==1.2.6
       - run:
           name: Install 'make' command
           command: choco install make

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -90,8 +90,10 @@ commands:
           name: Create 'kedro_builder' conda environment
           command: conda create -n kedro_builder python=<<parameters.python_version>> -y
       - restore_cache:
+          #name:
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - restore_cache:
+          #name:
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
@@ -287,12 +289,14 @@ jobs:
             equal: ["3.7", <<parameters.python_version>>]
           steps:
           - save_cache:
+              # name:
               key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
+          # name
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
           paths:
             - c:\tools\miniconda3\envs\kedro_builder

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -47,10 +47,6 @@ commands:
           # Virtualenv 20.0.20 broke pre-commit, capped for now
           name: Install venv for some pre-commit hooks
           command: conda install -y "virtualenv<20.0"
-      - run: which -a python
-      - run: which -a pip
-      - run: pip freeze
-      - run: python -m pip freeze
       - run:
           name: Install requirements and test requirements
           command: pip install --upgrade -r test_requirements.txt
@@ -508,12 +504,12 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-#      - build_docs
-#      - docs_linkcheck
-#      - e2e_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - build_docs
+      - docs_linkcheck
+      - e2e_tests:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
       - win_e2e_tests:
           matrix:
             parameters:
@@ -521,40 +517,38 @@ workflows:
       - unit_tests:
           matrix:
             parameters:
-              python_version: ["3.7"]
-
-      #              python_version: ["3.6", "3.7", "3.8"]
+              python_version: ["3.6", "3.7", "3.8"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-#      - lint:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
-#      - pip_compile:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - lint:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
+      - pip_compile:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-#      - all_circleci_checks_succeeded:
-#          requires:
-#            - e2e_tests
-#            # win_e2e_tests-3.6 is not required due to the error
-#            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
-#            # - win_e2e_tests
-#            - win_e2e_tests-3.7
-#            - win_e2e_tests-3.8
-#            - unit_tests
-#            - win_unit_tests
-#            - lint
-#            - pip_compile
-#            - win_pip_compile
-#            - build_docs
-#            - docs_linkcheck
+      - all_circleci_checks_succeeded:
+          requires:
+            - e2e_tests
+            # win_e2e_tests-3.6 is not required due to the error
+            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
+            # - win_e2e_tests
+            - win_e2e_tests-3.7
+            - win_e2e_tests-3.8
+            - unit_tests
+            - win_unit_tests
+            - lint
+            - pip_compile
+            - win_pip_compile
+            - build_docs
+            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -93,10 +93,10 @@ commands:
           command: conda create -n kedro_builder python=<<parameters.python_version>> -y
       - restore_cache:
           name: Restore package cache
-          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - restore_cache:
           name: Restore conda environment cache
-          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
+          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
     steps:
@@ -138,11 +138,8 @@ commands:
   win_setup_requirements:
     steps:
       - run:
-          name: Install GDAL
-          command: conda activate kedro_builder; conda install gdal -y
-      - run:
-          name: Install Fiona
-          command: conda activate kedro_builder; conda install fiona -y
+          name: Install GDAL and Fiona
+          command: conda activate kedro_builder; conda install gdal fiona -c local conda-forge -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U
@@ -206,14 +203,17 @@ jobs:
     executor:
       name: docker
       python_version: <<parameters.python_version>>
-    - run: which -a python
-    - run: which -a pip
-    - run: which -a pytest
     steps:
       - setup
+      - run: which -a python
+      - run: which -a pip
+      - run: which -a pytest
       - run:
           name: Run unit tests
           command: make test
+      - run: which -a python
+      - run: which -a pip
+      - run: which -a pytest
 
   win_unit_tests:
     parameters:
@@ -293,14 +293,14 @@ jobs:
           steps:
           - save_cache:
               name: Save Python package cache
-              key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+              key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
           name: Save conda environment cache
-          key: kedro-deps-vtest1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
+          key: kedro-deps-vtest2-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
           paths:
             - c:\tools\miniconda3\envs\kedro_builder
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -83,18 +83,18 @@ commands:
       python_version:
         type: string
     steps:
+      - restore_cache:
+          name: Restore package cache
+          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - restore_cache:
+          name: Restore conda environment cache
+          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
       - run:
           name: Initialize conda
           command: conda init powershell
       - run:
           name: Create 'kedro_builder' conda environment
           command: conda create -n kedro_builder python=<<parameters.python_version>> -y
-      - restore_cache:
-          #name:
-          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - restore_cache:
-          #name:
-          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
     steps:
@@ -137,10 +137,10 @@ commands:
     steps:
       - run:
           name: Install GDAL
-          command: conda activate kedro_builder; conda install -c conda-forge gdal -y
+          command: conda activate kedro_builder; conda install gdal -y
       - run:
           name: Install Fiona
-          command: conda activate kedro_builder; conda install -c conda-forge fiona -y
+          command: conda activate kedro_builder; conda install fiona -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U
@@ -160,8 +160,6 @@ commands:
       - win_setup_conda:
           python_version: <<parameters.python_version>>
       - win_setup_env
-#      - restore_cache:
-#          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - win_setup_requirements
 
 jobs:
@@ -289,14 +287,14 @@ jobs:
             equal: ["3.7", <<parameters.python_version>>]
           steps:
           - save_cache:
-              # name:
+              name: Save Python package cache
               key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
-          # name
+          name: Save conda environment cache
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
           paths:
             - c:\tools\miniconda3\envs\kedro_builder

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -88,7 +88,7 @@ commands:
           command: conda init powershell
       - run:
           name: Create 'kedro_builder' conda environment
-          command: conda create -n kedro_builder_<<parameters.python_version>> python=<<parameters.python_version>> -y
+          command: conda create -n kedro_builder python=<<parameters.python_version>> -y
       - restore_cache:
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - restore_cache:
@@ -133,24 +133,21 @@ commands:
 
   win_setup_requirements:
     steps:
-      parameters:
-        python_version:
-          type: string
       - run:
           name: Install GDAL
-          command: conda activate kedro_builder_<<parameters.python_version>>; conda install -c conda-forge gdal -y
+          command: conda activate kedro_builder; conda install -c conda-forge gdal -y
       - run:
           name: Install Fiona
-          command: conda activate kedro_builder_<<parameters.python_version>>; conda install -c conda-forge fiona -y
+          command: conda activate kedro_builder; conda install -c conda-forge fiona -y
       - run:
           name: Install all requirements
-          command: conda activate kedro_builder_<<parameters.python_version>>; pip install -r test_requirements.txt -U
+          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
       - run:
           name: Print Python environment
-          command: conda activate kedro_builder_<<parameters.python_version>>; make print-python-env
+          command: conda activate kedro_builder; make print-python-env
       - run:
           name: Pip freeze
-          command: conda activate kedro_builder_<<parameters.python_version>>; pip freeze
+          command: conda activate kedro_builder; pip freeze
 
   win_setup:
     parameters:
@@ -163,9 +160,7 @@ commands:
       - win_setup_env
 #      - restore_cache:
 #          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - win_setup_requirements:
-          python_version: <<parameters.python_version>>
-
+      - win_setup_requirements
 
 jobs:
   e2e_tests:
@@ -197,10 +192,10 @@ jobs:
           command: choco install make
       - run:
           name: Install dependencies
-          command: conda activate kedro_builder_<<parameters.python_version>>; pip install -r features/windows_reqs.txt
+          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
       - run:
           name: Run e2e tests
-          command: conda activate kedro_builder_<<parameters.python_version>>; make e2e-tests
+          command: conda activate kedro_builder; make e2e-tests
 
   unit_tests:
     parameters:
@@ -243,14 +238,14 @@ jobs:
           steps:
             - run:
                 name: Run unit tests without spark
-                command: conda activate kedro_builder_<<parameters.python_version>>; make test-no-spark
+                command: conda activate kedro_builder; make test-no-spark
       - when:
           condition:
             equal: ["3.6", <<parameters.python_version>>]
           steps:
             - run:
                 name: Run unit tests without spark or tensorflow
-                command: conda activate kedro_builder_<<parameters.python_version>>; pytest tests --no-cov --ignore tests/extras/datasets/spark --ignore tests/extras/datasets/tensorflow --numprocesses 4 --dist loadfile
+                command: conda activate kedro_builder; pytest tests --no-cov --ignore tests/extras/datasets/spark --ignore tests/extras/datasets/tensorflow --numprocesses 4 --dist loadfile
 
   lint:
     parameters:
@@ -289,7 +284,7 @@ jobs:
       - when:
           # Save cache only for Python 3.7. There is no need to save it for each Python.
           condition:
-            equal: [ "3.7", <<parameters.python_version>> ]
+            equal: ["3.7", <<parameters.python_version>>]
           steps:
           - save_cache:
               key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
@@ -300,10 +295,10 @@ jobs:
       - save_cache:
           key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
           paths:
-            - c:\tools\miniconda3\envs\kedro_builder_<<parameters.python_version>>
+            - c:\tools\miniconda3\envs\kedro_builder
       - run:
           name: Pip-compile requirements file
-          command: conda activate kedro_builder_<<parameters.python_version>>; make pip-compile
+          command: conda activate kedro_builder; make pip-compile
 
   build_docs:
     executor:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -155,7 +155,7 @@ commands:
           python_version: <<parameters.python_version>>
       - win_setup_env
       - restore_cache:
-          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-invalid
+          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - win_setup_requirements
 
 jobs:
@@ -172,8 +172,6 @@ jobs:
           name: Run e2e tests
           command: make e2e-tests
 
-  # What if checksum changes?
-  # Need pywin pinning?
   win_e2e_tests:
     parameters:
       python_version:
@@ -186,11 +184,11 @@ jobs:
       - win_setup_conda:
           python_version: <<parameters.python_version>>
       - run:
-          name: Install dependencies
-          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
-      - run:
           name: Install 'make' command
           command: choco install make
+      - run:
+          name: Install dependencies
+          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
       - run:
           name: Run e2e tests
           command: conda activate kedro_builder; make e2e-tests

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -88,7 +88,11 @@ commands:
           command: conda init powershell
       - run:
           name: Create 'kedro_builder' conda environment
-          command: conda create -n kedro_builder python=<<parameters.python_version>> -y
+          command: conda create -n kedro_builder_<<parameters.python_version>> python=<<parameters.python_version>> -y
+      - restore_cache:
+          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - restore_cache:
+          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
 
   win_setup_env:
     steps:
@@ -129,21 +133,24 @@ commands:
 
   win_setup_requirements:
     steps:
+      parameters:
+        python_version:
+          type: string
       - run:
           name: Install GDAL
-          command: conda activate kedro_builder; conda install -c conda-forge gdal -y
+          command: conda activate kedro_builder_<<parameters.python_version>>; conda install -c conda-forge gdal -y
       - run:
           name: Install Fiona
-          command: conda activate kedro_builder; conda install -c conda-forge fiona -y
+          command: conda activate kedro_builder_<<parameters.python_version>>; conda install -c conda-forge fiona -y
       - run:
           name: Install all requirements
-          command: conda activate kedro_builder; pip install -r test_requirements.txt -U
+          command: conda activate kedro_builder_<<parameters.python_version>>; pip install -r test_requirements.txt -U
       - run:
           name: Print Python environment
-          command: conda activate kedro_builder; make print-python-env
+          command: conda activate kedro_builder_<<parameters.python_version>>; make print-python-env
       - run:
           name: Pip freeze
-          command: conda activate kedro_builder; pip freeze
+          command: conda activate kedro_builder_<<parameters.python_version>>; pip freeze
 
   win_setup:
     parameters:
@@ -154,9 +161,11 @@ commands:
       - win_setup_conda:
           python_version: <<parameters.python_version>>
       - win_setup_env
-      - restore_cache:
-          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-      - win_setup_requirements
+#      - restore_cache:
+#          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+      - win_setup_requirements:
+          python_version: <<parameters.python_version>>
+
 
 jobs:
   e2e_tests:
@@ -188,10 +197,10 @@ jobs:
           command: choco install make
       - run:
           name: Install dependencies
-          command: conda activate kedro_builder; pip install -r features/windows_reqs.txt
+          command: conda activate kedro_builder_<<parameters.python_version>>; pip install -r features/windows_reqs.txt
       - run:
           name: Run e2e tests
-          command: conda activate kedro_builder; make e2e-tests
+          command: conda activate kedro_builder_<<parameters.python_version>>; make e2e-tests
 
   unit_tests:
     parameters:
@@ -234,14 +243,14 @@ jobs:
           steps:
             - run:
                 name: Run unit tests without spark
-                command: conda activate kedro_builder; make test-no-spark
+                command: conda activate kedro_builder_<<parameters.python_version>>; make test-no-spark
       - when:
           condition:
             equal: ["3.6", <<parameters.python_version>>]
           steps:
             - run:
                 name: Run unit tests without spark or tensorflow
-                command: conda activate kedro_builder; pytest tests --no-cov --ignore tests/extras/datasets/spark --ignore tests/extras/datasets/tensorflow --numprocesses 4 --dist loadfile
+                command: conda activate kedro_builder_<<parameters.python_version>>; pytest tests --no-cov --ignore tests/extras/datasets/spark --ignore tests/extras/datasets/tensorflow --numprocesses 4 --dist loadfile
 
   lint:
     parameters:
@@ -280,17 +289,21 @@ jobs:
       - when:
           # Save cache only for Python 3.7. There is no need to save it for each Python.
           condition:
-            equal: ["3.7", <<parameters.python_version>>]
+            equal: [ "3.7", <<parameters.python_version>> ]
           steps:
-            - save_cache:
-                key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-                paths:
-                  # Cache pip cache and conda packages directories
-                  - c:\tools\miniconda3\pkgs
-                  - c:\users\circleci\appdata\local\pip\cache
+          - save_cache:
+              key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+              paths:
+                # Cache pip cache and conda packages directories
+                - c:\tools\miniconda3\pkgs
+                - c:\users\circleci\appdata\local\pip\cache
+      - save_cache:
+          key: kedro-deps-vtest-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}-<<parameters.python_version>>
+          paths:
+            - c:\tools\miniconda3\envs\kedro_builder_<<parameters.python_version>>
       - run:
           name: Pip-compile requirements file
-          command: conda activate kedro_builder; make pip-compile
+          command: conda activate kedro_builder_<<parameters.python_version>>; make pip-compile
 
   build_docs:
     executor:
@@ -482,51 +495,51 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-      - build_docs
-      - docs_linkcheck
-      - e2e_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+#      - build_docs
+#      - docs_linkcheck
+#      - e2e_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
       - win_e2e_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-      - unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+#      - unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-      - lint:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
-      - pip_compile:
-          matrix:
-            parameters:
-              python_version: ["3.6", "3.7", "3.8"]
+#      - lint:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
+#      - pip_compile:
+#          matrix:
+#            parameters:
+#              python_version: ["3.6", "3.7", "3.8"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-      - all_circleci_checks_succeeded:
-          requires:
-            - e2e_tests
-            # win_e2e_tests-3.6 is not required due to the error
-            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
-            # - win_e2e_tests
-            - win_e2e_tests-3.7
-            - win_e2e_tests-3.8
-            - unit_tests
-            - win_unit_tests
-            - lint
-            - pip_compile
-            - win_pip_compile
-            - build_docs
-            - docs_linkcheck
+#      - all_circleci_checks_succeeded:
+#          requires:
+#            - e2e_tests
+#            # win_e2e_tests-3.6 is not required due to the error
+#            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
+#            # - win_e2e_tests
+#            - win_e2e_tests-3.7
+#            - win_e2e_tests-3.8
+#            - unit_tests
+#            - win_unit_tests
+#            - lint
+#            - pip_compile
+#            - win_pip_compile
+#            - build_docs
+#            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -482,51 +482,51 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-#      - build_docs
-#      - docs_linkcheck
-#      - e2e_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - build_docs
+      - docs_linkcheck
+      - e2e_tests:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
       - win_e2e_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-#      - unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
+      - unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.6", "3.7", "3.8"]
-#      - lint:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
-#      - pip_compile:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
-#      - win_pip_compile:
-#          matrix:
-#            parameters:
-#              python_version: ["3.6", "3.7", "3.8"]
-#      - all_circleci_checks_succeeded:
-#          requires:
-#            - e2e_tests
-#            # win_e2e_tests-3.6 is not required due to the error
-#            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
-#            # - win_e2e_tests
-#            - win_e2e_tests-3.7
-#            - win_e2e_tests-3.8
-#            - unit_tests
-#            - win_unit_tests
-#            - lint
-#            - pip_compile
-#            - win_pip_compile
-#            - build_docs
-#            - docs_linkcheck
+      - lint:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
+      - pip_compile:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
+      - win_pip_compile:
+          matrix:
+            parameters:
+              python_version: ["3.6", "3.7", "3.8"]
+      - all_circleci_checks_succeeded:
+          requires:
+            - e2e_tests
+            # win_e2e_tests-3.6 is not required due to the error
+            # `Cargo, the Rust package manager, is not installed or is not on PATH`.
+            # - win_e2e_tests
+            - win_e2e_tests-3.7
+            - win_e2e_tests-3.8
+            - unit_tests
+            - win_unit_tests
+            - lint
+            - pip_compile
+            - win_pip_compile
+            - build_docs
+            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ clean:
 	pre-commit clean || true
 
 install-pip-setuptools:
-	python -m pip install -U "pip>=21.2" "setuptools>=38.0" wheel
+	pip install -U "pip>=21.2" "setuptools>=38.0" wheel
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)

--- a/features/environment.py
+++ b/features/environment.py
@@ -3,7 +3,6 @@
 
 import os
 import shutil
-import sys
 import tempfile
 import venv
 from pathlib import Path

--- a/features/environment.py
+++ b/features/environment.py
@@ -125,13 +125,5 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req]
     install_reqs.append(".[pandas.CSVDataSet]")
-
-    # JupyterLab indirectly depends on pywin32 on Windows. Newer versions of pywin32
-    # (e.g. 3xx, to which jupyterlab~=3.0 defaults) have a bug that prevents
-    # JupyterLab from running, hence the version is forcefully set to 225.
-    # More details: https://github.com/mhammond/pywin32/issues/1431
-    if sys.platform.startswith("win"):
-        install_reqs.append("pywin32==225")
-
     call([context.pip, "install", *install_reqs], env=context.env)
     return context

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -174,48 +174,6 @@ def exec_kedro_target_checked(context, command):
         assert False
 
 
-@given('I have created new environment "{}"')
-def create_new_env(context, env_name):
-    env_path = context.root_project_dir / "conf" / env_name
-    env_path.mkdir()
-
-    for config_name in ("catalog", "parameters", "credentials"):
-        path = env_path / f"{config_name}.yml"
-        with path.open("w") as config_file:
-            yaml.dump({}, config_file, default_flow_style=False)
-
-    # overwrite the log level for anyconfig from WARNING to INFO
-    logging_path = env_path / "logging.yml"
-    logging_json = {
-        "loggers": {
-            "anyconfig": {
-                "level": "INFO",
-                "handlers": ["console", "info_file_handler", "error_file_handler"],
-                "propagate": "no",
-            },
-            "kedro.io": {
-                "level": "INFO",
-                "handlers": ["console", "info_file_handler", "error_file_handler"],
-                "propagate": "no",
-            },
-            "kedro.pipeline": {
-                "level": "INFO",
-                "handlers": ["console", "info_file_handler", "error_file_handler"],
-                "propagate": "no",
-            },
-        }
-    }
-    with logging_path.open("w") as config_file:
-        yaml.dump(logging_json, config_file, default_flow_style=False)
-
-
-@given('the python package "{package}" has been uninstalled')
-def uninstall_package_via_pip(context, package):
-    """Uninstall a python package using pip."""
-    run([context.pip, "uninstall", "-y", package], env=context.env)
-
-
-@given("I have installed the project's python package")
 @when("I install the project's python package")
 def install_project_package_via_pip(context):
     """Install a python package using pip."""
@@ -298,13 +256,6 @@ def create_project_without_starter(context):
     telemetry_file.write_text("consent: false", encoding="utf-8")
 
 
-@given("I have deleted the credentials file")
-def delete_credentials_file(context):
-    """Delete configuration file from project"""
-    path_to_config_file = context.root_project_dir / "conf" / "base" / "credentials.yml"
-    path_to_config_file.unlink()
-
-
 @given("I have added the project directory to staging")
 @when("I add the project directory to staging")
 def add_proj_dir_to_staging(context):
@@ -339,21 +290,6 @@ def exec_project(context):
     # We take care to delete with `delete_unnecessary_assets` to simulate the behaviour
     # of a installed package in a fresh environment.
     context.result = run(cmd, env=context.env, cwd=str(context.root_project_dir))
-
-
-@when('with tags {tags:CSV}, I execute the kedro command "{cmd}"')
-def exec_kedro_run_with_tag(context, cmd, tags):
-    """Execute `kedro run` with tags"""
-    kedro_args = shlex.split(cmd)
-    context.logfile_count = util.get_logline_count(
-        util.get_logfile_path(context.root_project_dir)
-    )
-
-    tag_list = [["--tag", t] for t in tags]
-    tag_args = list(itertools.chain.from_iterable(tag_list))
-    run_cmd = [context.kedro] + kedro_args + tag_args
-
-    context.result = run(run_cmd, env=context.env, cwd=str(context.root_project_dir))
 
 
 @when("I ask the CLI for a version")
@@ -552,16 +488,6 @@ def check_failed_status_code(context):
             f"but got {context.result.returncode}"
         )
         assert False, error_msg
-
-
-@then("the relevant packages should be created")
-def check_python_packages_created(context):
-    """Check that egg and whl files exist in dist dir."""
-    dist_dir = context.root_project_dir / "src" / "dist"
-    egg_file = dist_dir.glob("*.egg")
-    whl_file = dist_dir.glob("*.whl")
-    assert any(egg_file)
-    assert any(whl_file)
 
 
 @then('I should get a message including "{msg}"')

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -1,8 +1,6 @@
 """Behave step definitions for the cli_scenarios feature."""
 
-import itertools
 import json
-import shlex
 import shutil
 from pathlib import Path
 from time import time


### PR DESCRIPTION
## Description
I've reviewed our Windows CircleCI setup.
* the general scheme, including a separate windows_reqs.txt file, already seems pretty good. I experimented with various possible improvements but found that the current setup actually worked best so have left it largely unchanged
* installing dependencies was taking up a lot of time. I've added the conda environment to our cache and this speeds things up _a lot_... 
  * Windows unit tests have gone from ~20mins to ~14mins ⚡ 
  * Windows pip compile from ~17 mins to ~9mins 💥 
  * Windows e2e tests similar to before
* while working on this, I also noticed that the Docker images for the Unix jobs are not actually working as we think (quite aside from the build cron jobs not currently running): they do not have the right requirements pre-installed on them so we are actually installing requirements on to them again in CI. This is ok but kind of defeats the point of the pre-build, and means that there's potential for speedup there. I think I know why this is happening - will follow up in a separate ticket after checking some stuff with @limdauto

Handy refs from the old repo that helped me figure out how the e2e tests were working:
https://github.com/quantumblacklabs/private-kedro/pull/1048
https://github.com/quantumblacklabs/private-kedro/pull/1126
Note that e2e tests use the `kedro_builder` conda environment to control Python version and then venv inside that to install project requirements (see environment.py). This seems like a reasonable setup, and the only thing I could cleanup here was remove an old hacky fix that's no longer required.

## Development notes

### What are we caching on Windows?
1. The conda and pip package caches. This is saved once for Python 3.7 and then used for all Python versions. Nothing has changed here in this PR.
2. The actual `kedro_builder` conda environment files (`c:\tools\miniconda3\envs\kedro_builder`). This is saved separately for each Python version. This is the new thing I've introduced in this PR that speeds things up a lot.

### Will there be contamination between different Python versions if they all have the same conda environment name `kedro_builder`?
No, because the caching key includes the Python version. This means that `c:\tools\miniconda3\envs\kedro_builder` is saved and loaded completely separately for different Python versions.

### Does this caching risk the integrity of our tests?
No, because:
1. the caching key includes the checksum of test_requirements.txt and requirements.txt, so if one of those files change then there will be no cache found and so nothing reused
2. we do `pip install -U test_requirements.txt` anyway, so dependencies in the environment are always what they should be and not something from an old environment

**Overall this approach is now analogous to what we do on Unix, where we have a Docker image for each Python version, with a pre-built `kedro_builder` conda env inside there.**

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1342"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

