### PR TITLE
Remove the `init_kedro` line magic from the Kedro IPython extension

### DIFF
--- a/tests/extras/extensions/test_ipython.py
+++ b/tests/extras/extensions/test_ipython.py
@@ -1,11 +1,7 @@
 # pylint: disable=import-outside-toplevel,reimported
 import pytest
 
-from kedro.extras.extensions.ipython import (
-    init_kedro,
-    load_ipython_extension,
-    reload_kedro,
-)
+from kedro.extras.extensions.ipython import load_ipython_extension, reload_kedro
 from kedro.framework.session.session import _deactivate_session
 from kedro.framework.startup import ProjectMetadata
 from kedro.pipeline import Pipeline
@@ -30,40 +26,6 @@ def cleanup_session():
     _deactivate_session()
 
 
-class TestInitKedro:
-    def test_init_kedro(self, tmp_path, caplog):
-        from kedro.extras.extensions.ipython import project_path
-
-        assert project_path == tmp_path
-
-        kedro_path = tmp_path / "here"
-        init_kedro(str(kedro_path))
-        expected_path = kedro_path.expanduser().resolve()
-        expected_message = f"Updated path to Kedro project: {expected_path}"
-
-        log_messages = [record.getMessage() for record in caplog.records]
-        assert expected_message in log_messages
-        from kedro.extras.extensions.ipython import project_path
-
-        # make sure global variable updated
-        assert project_path == expected_path
-
-    def test_init_kedro_no_path(self, tmp_path, caplog):
-        from kedro.extras.extensions.ipython import project_path
-
-        assert project_path == tmp_path
-
-        init_kedro()
-        expected_message = f"No path argument was provided. Using: {tmp_path}"
-
-        log_messages = [record.getMessage() for record in caplog.records]
-        assert expected_message in log_messages
-        from kedro.extras.extensions.ipython import project_path
-
-        # make sure global variable stayed the same
-        assert project_path == tmp_path
-
-
 @pytest.fixture()
 def pipeline_cleanup():
     yield
@@ -74,7 +36,15 @@ def pipeline_cleanup():
 
 class TestLoadKedroObjects:
     @pytest.mark.usefixtures("pipeline_cleanup")
-    def test_load_kedro_objects(self, tmp_path, mocker):
+    def test_load_kedro_objects(
+        self, tmp_path, mocker, caplog
+    ):  # pylint: disable=too-many-locals
+        from kedro.extras.extensions.ipython import project_path
+
+        assert project_path == tmp_path
+
+        kedro_path = tmp_path / "here"
+
         fake_metadata = ProjectMetadata(
             source_dir=tmp_path / "src",  # default
             config_file=tmp_path / "pyproject.toml",
@@ -96,8 +66,7 @@ class TestLoadKedroObjects:
         mocker.patch("kedro.framework.session.session.validate_settings")
         mocker.patch("kedro.framework.session.KedroSession._get_config_loader")
         mocker.patch(
-            "kedro.framework.startup.bootstrap_project",
-            return_value=fake_metadata,
+            "kedro.framework.startup.bootstrap_project", return_value=fake_metadata
         )
         mock_line_magic = mocker.MagicMock()
         mock_line_magic.__name__ = "abc"
@@ -110,7 +79,7 @@ class TestLoadKedroObjects:
         mock_context = mocker.patch("kedro.framework.session.KedroSession.load_context")
         mock_ipython = mocker.patch("kedro.extras.extensions.ipython.get_ipython")
 
-        reload_kedro(tmp_path)
+        reload_kedro(kedro_path)
 
         mock_ipython().push.assert_called_once_with(
             variables={
@@ -121,6 +90,16 @@ class TestLoadKedroObjects:
             }
         )
         mock_register_line_magic.assert_called_once()
+
+        expected_path = kedro_path.expanduser().resolve()
+        expected_message = f"Updated path to Kedro project: {expected_path}"
+
+        log_messages = [record.getMessage() for record in caplog.records]
+        assert expected_message in log_messages
+        from kedro.extras.extensions.ipython import project_path
+
+        # make sure global variable updated
+        assert project_path == expected_path
 
     def test_load_kedro_objects_extra_args(self, tmp_path, mocker):
         fake_metadata = ProjectMetadata(
@@ -133,8 +112,7 @@ class TestLoadKedroObjects:
         )
         mocker.patch("kedro.framework.project.configure_project")
         mocker.patch(
-            "kedro.framework.startup.bootstrap_project",
-            return_value=fake_metadata,
+            "kedro.framework.startup.bootstrap_project", return_value=fake_metadata
         )
         mock_line_magic = mocker.MagicMock()
         mock_line_magic.__name__ = "abc"
@@ -166,8 +144,7 @@ class TestLoadKedroObjects:
 
     def test_load_kedro_objects_not_in_kedro_project(self, tmp_path, mocker):
         mocker.patch(
-            "kedro.framework.startup._get_project_metadata",
-            side_effect=RuntimeError,
+            "kedro.framework.startup._get_project_metadata", side_effect=RuntimeError
         )
         mock_ipython = mocker.patch("kedro.extras.extensions.ipython.get_ipython")
 
@@ -175,6 +152,55 @@ class TestLoadKedroObjects:
             reload_kedro(tmp_path)
         assert not mock_ipython().called
         assert not mock_ipython().push.called
+
+    @pytest.mark.usefixtures("pipeline_cleanup")
+    def test_load_kedro_objects_no_path(self, tmp_path, caplog, mocker):
+        from kedro.extras.extensions.ipython import project_path
+
+        assert project_path == tmp_path
+
+        fake_metadata = ProjectMetadata(
+            source_dir=tmp_path / "src",  # default
+            config_file=tmp_path / "pyproject.toml",
+            package_name="fake_package_name",
+            project_name="fake_project_name",
+            project_version="0.1",
+            project_path=tmp_path,
+        )
+        my_pipelines = {"ds": Pipeline([])}
+
+        def my_register_pipeline():
+            return my_pipelines
+
+        mocker.patch(
+            "kedro.framework.project._ProjectPipelines._get_pipelines_registry_callable",
+            return_value=my_register_pipeline,
+        )
+        mocker.patch("kedro.framework.project.settings.configure")
+        mocker.patch("kedro.framework.session.session.validate_settings")
+        mocker.patch("kedro.framework.session.KedroSession._get_config_loader")
+        mocker.patch(
+            "kedro.framework.startup.bootstrap_project", return_value=fake_metadata
+        )
+        mock_line_magic = mocker.MagicMock()
+        mock_line_magic.__name__ = "abc"
+        mocker.patch(
+            "kedro.framework.cli.load_entry_points", return_value=[mock_line_magic]
+        )
+        mocker.patch("kedro.extras.extensions.ipython.register_line_magic")
+        mocker.patch("kedro.framework.session.KedroSession.load_context")
+        mocker.patch("kedro.extras.extensions.ipython.get_ipython")
+
+        reload_kedro()
+
+        expected_message = f"No path argument was provided. Using: {tmp_path}"
+        log_messages = [record.getMessage() for record in caplog.records]
+        assert expected_message in log_messages
+
+        from kedro.extras.extensions.ipython import project_path
+
+        # make sure global variable stayed the same
+        assert project_path == tmp_path
 
 
 class TestLoadIPythonExtension:
@@ -186,21 +212,13 @@ class TestLoadIPythonExtension:
                 "Kedro appears not to be installed in your current environment.",
                 "ERROR",
             ),
-            (
-                RuntimeError,
-                "Kedro extension was registered. Make sure you pass the project path to "
-                "`%reload_kedro` or set it using `%init_kedro`.",
-                "WARNING",
-            ),
+            (RuntimeError, "Kedro extension was registered.", "WARNING"),
         ],
     )
     def test_load_extension_not_in_kedro_env_or_project(
         self, error, expected_log_message, level, mocker, caplog
     ):
-        mocker.patch(
-            "kedro.framework.startup._get_project_metadata",
-            side_effect=error,
-        )
+        mocker.patch("kedro.framework.startup._get_project_metadata", side_effect=error)
         mock_ipython = mocker.patch("kedro.extras.extensions.ipython.get_ipython")
 
         load_ipython_extension(mocker.MagicMock())


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fixes https://github.com/kedro-org/kedro/issues/1336

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
