### PR TITLE
Correct type hint for preprocess_companies return value

### DIFF
--- a/docs/source/03_tutorial/07_set_up_experiment_tracking.md
+++ b/docs/source/03_tutorial/07_set_up_experiment_tracking.md
@@ -101,7 +101,7 @@ node(
 You have to repeat the same steps for setting up the `companies_column` dataset. For this dataset you should log the column that contains the list of companies as outlined in `companies.csv` under `/data/01_raw`. Modify the `preprocess_companies` node under the `data_processing` pipeline (`src/kedro-experiment-tracking-tutorial/pipelines/data_processing/nodes.py`) to return the data under a key value pair, as shown below:
 
 ```python
-def preprocess_companies(companies: pd.DataFrame) -> pd.DataFrame:
+def preprocess_companies(companies: pd.DataFrame) -> Tuple[pd.DataFrame, Dict]:
     """Preprocesses the data for companies.
 
     Args:


### PR DESCRIPTION
## Description
In the [Set Up experiment tracking tutorial](https://kedro.readthedocs.io/en/stable/03_tutorial/07_set_up_experiment_tracking.html#set-up-your-nodes-and-pipelines-to-log-metrics), the return value of the `preprocess_companies` function is modified but not its type hint.

## Context
__Before updating the example__ to include tracking, the code looks like this:

```python
def preprocess_companies(companies: pd.DataFrame) -> pd.DataFrame:
    """Preprocesses the data for companies.

    Args:
        companies: Raw data.
    Returns:
        Preprocessed data, with `company_rating` converted to a float and
        `iata_approved` converted to boolean.
    """
    companies["iata_approved"] = _is_true(companies["iata_approved"])
    companies["company_rating"] = _parse_percentage(companies["company_rating"])
    return companies
```

__After updating the example__ to take into account the tracking functionality, the code looks like this:

```python
def preprocess_companies(companies: pd.DataFrame) -> pd.DataFrame:
    """Preprocesses the data for companies.

    Args:
        companies: Raw data.
    Returns:
        Preprocessed data, with `company_rating` converted to a float and
        `iata_approved` converted to boolean.
    """
    companies["iata_approved"] = _is_true(companies["iata_approved"])
    companies["company_rating"] = _parse_percentage(companies["company_rating"])
    return companies, {"columns": companies.columns.tolist(), "data_type": "companies"}
```

In the updated example, the return value changed but not the type hint. The new return value should have a type of `tuple[pd.DataFrame, dict]` (or `Tuple[pd.DataFrame, Dict]` for versions of Python prior to 3.9).

Thanks

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1360"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

