### PR TITLE
[Draft] - Fix `kedro new` default python package name

### DIFF
--- a/features/steps/test_starter/cookiecutter.json
+++ b/features/steps/test_starter/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/kedro/templates/project/cookiecutter.json
+++ b/kedro/templates/project/cookiecutter.json
@@ -1,6 +1,6 @@
 {
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.replace(' ', '-').lower().strip('-') }}",
-    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').lower().strip('-') }}",
+    "python_package": "{{ cookiecutter.project_name.replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}"
 }


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
To fix the issue that kedro new generate invalid package name when hyphen user provide program names with hyphens.
Resolve #1272

## Development notes
* Fix the default name logic and removed unnecessary striping 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
