### PR TITLE
Make it easier for people to run Kedro projects by simply importing them

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,12 @@
 * Bumped the minimum version of `pandas` to 1.3. Any `storage_options` should continue to be specified under `fs_args` and/or `credentials`.
 * Refactored the `load` and `save` operations for `pandas` datasets in order to leverage `pandas` own API and delegate `fsspec` operations to them. This reduces the need to have our own `fsspec` wrappers.
 * Removed `cli.py` from the Kedro project template. By default, all CLI commands, including `kedro run`, are now defined on the Kedro framework side. These can be overridden in turn by a plugin or a `cli.py` file in your project. A packaged Kedro project will respect the same hierarchy when executed with `python -m my_package`.
+* A packaged Kedro project can now be imported and run from another Python project as following:
+```python
+from my_package.__main__ import main
+
+main(["--pipleine", "my_pipeline"])  # or just main() if no parameters are needed for the run
+```
 * Merged `pandas.AppendableExcelDataSet` into `pandas.ExcelDataSet`.
 * Added `save_args` to `feather.FeatherDataSet`.
 * The default `kedro` environment names can now be set in `settings.py` with the help of the `CONFIG_LOADER_ARGS` variable. The relevant keys to be supplied are `base_env` and `default_run_env`. These values are set to `base` and `local` respectively as a default.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,7 +22,9 @@
 ```python
 from my_package.__main__ import main
 
-main(["--pipleine", "my_pipeline"])  # or just main() if no parameters are needed for the run
+main(
+    ["--pipleine", "my_pipeline"]
+)  # or just main() if no parameters are needed for the run
 ```
 * Merged `pandas.AppendableExcelDataSet` into `pandas.ExcelDataSet`.
 * Added `save_args` to `feather.FeatherDataSet`.

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -37,6 +37,15 @@ python -m kedro_spaceflights
 
 An executable, `kedro-spaceflights`, is also placed in the `bin/` subfolder of the Python installation location.
 
+Once you have your project installed, you can run your pipelines from any Python code by simply importing it as follows:
+
+```python
+from kedro_spaceflights.__main__ import main
+
+main(["--pipeline", "__default__"]) # or simply main() if you don't want to provide any arguments
+```
+
+This is equivalent to running `kedro run` and you can provide all the parameters described by `kedro run --help`.
 
 ### Docker, Airflow and Deployment
 

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -42,7 +42,9 @@ Once you have your project installed, you can run your pipelines from any Python
 ```python
 from kedro_spaceflights.__main__ import main
 
-main(["--pipeline", "__default__"]) # or simply main() if you don't want to provide any arguments
+main(
+    ["--pipeline", "__default__"]
+)  # or simply main() if you don't want to provide any arguments
 ```
 
 This is equivalent to running `kedro run` and you can provide all the parameters described by `kedro run --help`.

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -36,11 +36,11 @@ def _find_run_command_in_plugins(plugins):
             return group.commands["run"]
 
 
-def main():
+def main(*args, **kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
-    run()
+    run(*args, **kwargs)
 
 
 if __name__ == "__main__":

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -36,11 +36,11 @@ def _find_run_command_in_plugins(plugins):
             return group.commands["run"]
 
 
-def main():
+def main(*args, **kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
-    run()
+    run(*args, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description

In many deployment scenarios users want to be able to easily run their Kedro projects by simply importing them. After the change, here's how a packaged Kedro project can be run:

```
from my_project.__main__ import main

main(['--pipeline', 'my_pipeline']) # or just main() if default pipeline is needed
```

## Development notes

The change is only in the template and need to be done in all other official templates accordingly. This is just a minor change before 0.18, but future releases should hide all the custom logic for finding the run from the user.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1364"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

