### PR TITLE
Experiment Tracking: Store username in the session store

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 * Documented distribution of Kedro pipelines with Dask.
 
 ## Bug fixes and other changes
+* Added `username` to Session store for logging during Experiment Tracking.
 
 ## Upcoming deprecations for Kedro 0.18.0
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -190,6 +190,8 @@ class KedroSession:
         if extra_params:
             session_data["extra_params"] = extra_params
 
+        session_data["username"] = os.getlogin()
+
         session._store.update(session_data)
 
         # we need a ConfigLoader registered in order to be able to set up logging

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -1,5 +1,6 @@
 # pylint: disable=invalid-name,global-statement
 """This module implements Kedro session responsible for project lifecycle."""
+import getpass
 import logging
 import logging.config
 import os
@@ -190,7 +191,7 @@ class KedroSession:
         if extra_params:
             session_data["extra_params"] = extra_params
 
-        session_data["username"] = os.environ.get("USER") or os.environ.get("USERNAME")
+        session_data["username"] = getpass.getuser()
 
         session._store.update(session_data)
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -190,7 +190,7 @@ class KedroSession:
         if extra_params:
             session_data["extra_params"] = extra_params
 
-        session_data["username"] = os.getlogin()
+        session_data["username"] = os.environ.get("USER") or os.environ.get("USERNAME")
 
         session._store.update(session_data)
 

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -52,7 +52,7 @@ class _SharedMemoryDataSet:
             # Checks if the error is due to serialisation or not
             try:
                 pickle.dumps(data)
-            except Exception as exc:  # SKIP_IF_NO_SPARK
+            except Exception as exc:  # SKIP_IF_NO_SPARK, pylint: disable=redefined-outer-name
                 raise DataSetError(
                     f"{str(data.__class__)} cannot be serialized. ParallelRunner "
                     "implicit memory datasets can only be used with serializable data"

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -205,9 +205,10 @@ def fake_project(tmp_path, local_logging_config, mock_package_name):
 
 
 @pytest.fixture
-def fake_username(mocker):
+def fake_username(monkeypatch, mocker):
     username = "user1"
     mocker.patch("kedro.framework.session.session.os.getlogin", return_value=username)
+    monkeypatch.setenv('USERNAME', 'user1')
     return username
 
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -205,7 +205,7 @@ def fake_project(tmp_path, local_logging_config, mock_package_name):
 
 
 @pytest.fixture
-def fake_username(monkeypatch, mocker):
+def fake_username(monkeypatch):
     username = "user1"
     monkeypatch.setenv("USER", username)
     return username

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -207,8 +207,7 @@ def fake_project(tmp_path, local_logging_config, mock_package_name):
 @pytest.fixture
 def fake_username(monkeypatch, mocker):
     username = "user1"
-    mocker.patch("kedro.framework.session.session.os.getlogin", return_value=username)
-    monkeypatch.setenv('USERNAME', 'user1')
+    monkeypatch.setenv("USER", username)
     return username
 
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -205,9 +205,11 @@ def fake_project(tmp_path, local_logging_config, mock_package_name):
 
 
 @pytest.fixture
-def fake_username(monkeypatch):
+def fake_username(mocker):
     username = "user1"
-    monkeypatch.setenv("USER", username)
+    mocker.patch(
+        "kedro.framework.session.session.getpass.getuser", return_value=username
+    )
     return username
 
 
@@ -255,8 +257,8 @@ class TestKedroSession:
             expected_store["env"] = env
         if extra_params:
             expected_store["extra_params"] = extra_params
-        if fake_username:
-            expected_store["username"] = fake_username
+
+        expected_store["username"] = fake_username
 
         assert session.store == expected_store
         # called for logging setup
@@ -295,8 +297,7 @@ class TestKedroSession:
             "cli": expected_cli_data,
         }
 
-        if fake_username:
-            expected_store["username"] = fake_username
+        expected_store["username"] = fake_username
 
         assert session.store == expected_store
         mock_context_class.assert_called_once_with(

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -204,6 +204,13 @@ def fake_project(tmp_path, local_logging_config, mock_package_name):
     return fake_project_dir
 
 
+@pytest.fixture
+def fake_username(mocker):
+    username = "user1"
+    mocker.patch("kedro.framework.session.session.os.getlogin", return_value=username)
+    return username
+
+
 class FakeException(Exception):
     """Fake exception class for testing purposes"""
 
@@ -225,6 +232,7 @@ class TestKedroSession:
         mocker,
         env,
         extra_params,
+        fake_username,
     ):
         mock_click_ctx = mocker.patch("click.get_current_context").return_value
         session = KedroSession.create(
@@ -247,6 +255,8 @@ class TestKedroSession:
             expected_store["env"] = env
         if extra_params:
             expected_store["extra_params"] = extra_params
+        if fake_username:
+            expected_store["username"] = fake_username
 
         assert session.store == expected_store
         # called for logging setup
@@ -267,6 +277,7 @@ class TestKedroSession:
         fake_session_id,
         mock_package_name,
         mocker,
+        fake_username,
     ):
         mock_click_ctx = mocker.patch("click.get_current_context").return_value
         session = KedroSession.create(mock_package_name, fake_project)
@@ -283,6 +294,9 @@ class TestKedroSession:
             "package_name": mock_package_name,
             "cli": expected_cli_data,
         }
+
+        if fake_username:
+            expected_store["username"] = fake_username
 
         assert session.store == expected_store
         mock_context_class.assert_called_once_with(


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->
https://github.com/kedro-org/kedro/issues/1298

As part of Experiment Tracking, users have indicated that it's important for them to be able to log the username of the person executing the run.

These fields already appear on the UI, so we just need to make sure they're stored in the Session store.


## Development notes
<!-- What have you changed, and how has this been tested? -->
Using `getpass.getuser()` to get the username from environment.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1366"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

