### PR TITLE
Fix windows 3.10 builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -138,10 +138,10 @@ commands:
     steps:
       - restore_cache:
           name: Restore package cache
-          key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+          key: kedro-deps-Merel-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - restore_cache:
           name: Restore conda environment cache
-          key: kedro-deps-v1-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+          key: kedro-deps-Merel-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U
@@ -307,14 +307,14 @@ jobs:
           steps:
           - save_cache:
               name: Save Python package cache
-              key: kedro-deps-v1-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+              key: kedro-deps-Merel-win-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
               paths:
                 # Cache pip cache and conda packages directories
                 - c:\tools\miniconda3\pkgs
                 - c:\users\circleci\appdata\local\pip\cache
       - save_cache:
           name: Save conda environment cache
-          key: kedro-deps-v1-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
+          key: kedro-deps-Merel-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
           paths:
             - c:\tools\miniconda3\envs\kedro_builder
       - run:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -146,9 +146,9 @@ commands:
         # are best handled by conda-installing instead of pip-installing them.
         # Dependency resolution works best when installing these altogether in one
         # `conda install` command rather than one at a time in several sequential `conda install`s.
-      - run:
-          name: Install GDAL, Fiona and pytables
-          command: conda activate kedro_builder; conda install gdal fiona pytables -c conda-forge -y
+#      - run:
+#          name: Install GDAL, Fiona and pytables
+#          command: conda activate kedro_builder; conda install gdal fiona pytables -c conda-forge -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U
@@ -518,47 +518,47 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-      - e2e_tests:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10"]
-      - win_e2e_tests:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10"]
-      - unit_tests:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10"]
+#      - e2e_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9", "3.10"]
+#      - win_e2e_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9", "3.10"]
+#      - unit_tests:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
-      - lint:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10"]
-      - pip_compile:
-          matrix:
-            parameters:
-              python_version: ["3.7", "3.8", "3.9", "3.10"]
+#      - lint:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9", "3.10"]
+#      - pip_compile:
+#          matrix:
+#            parameters:
+#              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
-      - build_docs
-      - docs_linkcheck
-      - all_circleci_checks_succeeded:
-          requires:
-            - e2e_tests
-            - win_e2e_tests
-            - unit_tests
-            - win_unit_tests
-            - lint
-            - pip_compile
-            - win_pip_compile
-            - build_docs
-            - docs_linkcheck
+#      - build_docs
+#      - docs_linkcheck
+#      - all_circleci_checks_succeeded:
+#          requires:
+#            - e2e_tests
+#            - win_e2e_tests
+#            - unit_tests
+#            - win_unit_tests
+#            - lint
+#            - pip_compile
+#            - win_pip_compile
+#            - build_docs
+#            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -142,13 +142,6 @@ commands:
       - restore_cache:
           name: Restore conda environment cache
           key: kedro-deps-v1-win-<<parameters.python_version>>-{{ checksum "requirements.txt" }}-{{ checksum "test_requirements.txt" }}
-        # pytables and Fiona have a series of binary dependencies under Windows that
-        # are best handled by conda-installing instead of pip-installing them.
-        # Dependency resolution works best when installing these altogether in one
-        # `conda install` command rather than one at a time in several sequential `conda install`s.
-#      - run:
-#          name: Install GDAL, Fiona and pytables
-#          command: conda activate kedro_builder; conda install gdal fiona pytables -c conda-forge -y
       - run:
           name: Install all requirements
           command: conda activate kedro_builder; pip install -r test_requirements.txt -U
@@ -269,7 +262,7 @@ jobs:
             equal: [ "3.10", <<parameters.python_version>> ]
           steps:
             - run:
-                name: Run unit tests withou spark sequentially
+                name: Run unit tests without spark sequentially
                 command: conda activate kedro_builder; pytest tests --no-cov --ignore tests/extras/datasets/spark
 
   lint:
@@ -518,47 +511,47 @@ workflows:
         - <<pipeline.parameters.code_change>>
         - not: <<pipeline.parameters.release_kedro>>
     jobs:
-#      - e2e_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9", "3.10"]
-#      - win_e2e_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9", "3.10"]
-#      - unit_tests:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9", "3.10"]
+      - e2e_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
+      - win_e2e_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
+      - unit_tests:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_unit_tests:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
-#      - lint:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9", "3.10"]
-#      - pip_compile:
-#          matrix:
-#            parameters:
-#              python_version: ["3.7", "3.8", "3.9", "3.10"]
+      - lint:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
+      - pip_compile:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - win_pip_compile:
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
-#      - build_docs
-#      - docs_linkcheck
-#      - all_circleci_checks_succeeded:
-#          requires:
-#            - e2e_tests
-#            - win_e2e_tests
-#            - unit_tests
-#            - win_unit_tests
-#            - lint
-#            - pip_compile
-#            - win_pip_compile
-#            - build_docs
-#            - docs_linkcheck
+      - build_docs
+      - docs_linkcheck
+      - all_circleci_checks_succeeded:
+          requires:
+            - e2e_tests
+            - win_e2e_tests
+            - unit_tests
+            - win_unit_tests
+            - lint
+            - pip_compile
+            - win_pip_compile
+            - build_docs
+            - docs_linkcheck
 
   main_updated:
     unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set


### PR DESCRIPTION
## Description
The windows unit test and pip compile build for python 3.10 are failing on https://github.com/kedro-org/kedro/pull/1328

## Development notes
There's no error on the build, just `exit code 1` and I couldn't ssh into the box. I just tried removing the `conda install` step before the `pip install` step and this seems to solve the issue. I'm a bit suspicious because this fix seems a bit too good to be true 🤔  It does clean up our windows build steps. I'll keep an eye out on the builds, but for now let's merge this in if we don't have any other solutions.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1368"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

