### PR TITLE
Correct model tracking pipeline

### DIFF
--- a/docs/source/03_tutorial/07_set_up_experiment_tracking.md
+++ b/docs/source/03_tutorial/07_set_up_experiment_tracking.md
@@ -61,7 +61,7 @@ companies_columns:
 
 Now that you have set up the tracking datasets to log experiment tracking data, the next step is to ensure that the data is returned from your nodes.
 
-Set up the data to be logged for the metrics dataset - under `nodes.py` of your `data_processing` pipeline (`/src/kedro-experiment-tracking-tutorial/pipelines/data_processing/nodes.py`), modify your `evaluate_model` function by adding in three different metrics: `score` to log your r2 score, `mae` to log your mean absolute error, and `me` to log your max error, and returning those 3 metrics as a key value pair.
+Set up the data to be logged for the metrics dataset - under `nodes.py` of your `data_science` pipeline (`/src/kedro-experiment-tracking-tutorial/pipelines/data_science/nodes.py`), modify your `evaluate_model` function by adding in three different metrics: `score` to log your r2 score, `mae` to log your mean absolute error, and `me` to log your max error, and returning those 3 metrics as a key value pair.
 
 The new `evaluate_model` function would look like this:
 
@@ -85,7 +85,7 @@ def evaluate_model(
     return {"r2_score": score, "mae": mae, "max_error": me}
 ```
 
-The next step is to ensure that the dataset is also specified as an output of your `evaluate_model` node. Under `src/kedro-experiment-tracking-tutorial/pipelines/data_processing/pipeline.py`, specify the `output` of your `evaluate_model` to be the `metrics` dataset. Note that it is crucial that the output dataset exactly matches the name of the tracking dataset specified in the catalog file.
+The next step is to ensure that the dataset is also specified as an output of your `evaluate_model` node. Under `src/kedro-experiment-tracking-tutorial/pipelines/data_science/pipeline.py`, specify the `output` of your `evaluate_model` to be the `metrics` dataset. Note that it is crucial that the output dataset exactly matches the name of the tracking dataset specified in the catalog file.
 
 The node of the `evaluate_model` on the pipeline should look like this:
 


### PR DESCRIPTION
The pipeline for the `evaluate_model` function is the `data_science` pipeline and not the `data_preprocessing`.

The change has to be made at a couple of places in the tutorial (text in bold):

_First location:_

Set up the data to be logged for the metrics dataset - under `nodes.py` of your **`data_preprocessing`** pipeline (**`/src/kedro-experiment-tracking-tutorial/pipelines/data_preprocessing/nodes.py`**), modify your `evaluate_model` function by adding in three different metrics: `score` to log your r2 score, `mae` to log your mean absolute error, and `me` to log your max error, and returning those 3 metrics as a key value pair.

_Second location:_

The next step is to ensure that the dataset is also specified as an output of your `evaluate_model` node. Under **`src/kedro-experiment-tracking-tutorial/pipelines/data_preprocessing/pipeline.py`**, specify the `output` of your `evaluate_model` to be the `metrics` dataset. Note that it is crucial that the output dataset exactly matches the name of the tracking dataset specified in the catalog file.

Both of these should point to the `data_science` pipeline instead of the `data_preprocessing` pipeline.

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1370"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

