### PR TITLE
fix missing comma in docs

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -278,7 +278,7 @@ class DataCatalog:
             >>>     "boats": {
             >>>         "type": "pandas.CSVDataSet",
             >>>         "filepath": "s3://aws-bucket-name/boats.csv",
-            >>>         "credentials": "boats_credentials"
+            >>>         "credentials": "boats_credentials",
             >>>         "save_args": {
             >>>             "index": False
             >>>         }


### PR DESCRIPTION
Signed-off-by: avan-sh <yembadiavaneesh@gmail.com>

## Description
Fixes a missing comma on docs example for `kedro.io.DataCatalog`

## Development notes
Adds a missing comma on docs example for `kedro.io.DataCatalog`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1383"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

