### PR TITLE
Update kedro-telemetry requirement

### DIFF
--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -5,7 +5,6 @@ isort~=5.0
 jupyter~=1.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet]=={{ cookiecutter.kedro_version }}
-# kedro-telemetry~=0.2.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -5,7 +5,7 @@ isort~=5.0
 jupyter~=1.0
 jupyterlab~=3.0
 kedro[pandas.CSVDataSet]=={{ cookiecutter.kedro_version }}
-kedro-telemetry~=0.1.0; python_version < '3.9'
+# kedro-telemetry~=0.2.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -5,7 +5,6 @@ isort~=5.0
 jupyter~=1.0
 jupyterlab~=3.0
 kedro=={{ cookiecutter.kedro_version }}
-# kedro-telemetry~=0.2.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -5,7 +5,7 @@ isort~=5.0
 jupyter~=1.0
 jupyterlab~=3.0
 kedro=={{ cookiecutter.kedro_version }}
-kedro-telemetry~=0.1.0; python_version < '3.9'
+# kedro-telemetry~=0.2.0
 nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -25,8 +25,7 @@ lxml~=4.6
 matplotlib>=3.0.3, <3.4; python_version < '3.10' # 3.4.0 breaks holoviews
 matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
-moto==1.3.7; python_version < '3.10'
-moto==3.0.4; python_version == '3.10'
+moto==3.1.3
 nbconvert>=5.3.1, <6.0
 nbformat~=4.4
 networkx~=2.4


### PR DESCRIPTION
Signed-off-by: lorenabalan <lorena.balan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
When updating the kedro-telemetry requirement saw that unit tests on unix were failing, due to key error `us-east-1`.


## Development notes
<!-- What have you changed, and how has this been tested? -->
Tried updating `moto` but it only fixes for 3.9 and 3.10. The tests do pass locally for 3.7 for instance, but fail on CI. Upgrading `s3fs` to 0.6 doesn't fix the issue.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1395"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

