### PR TITLE
Updated ConfigLoader param in docs

### DIFF
--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -16,7 +16,7 @@ Kedro-specific configuration (e.g., `DataCatalog` configuration for IO) is loade
 ```python
 from kedro.config import ConfigLoader
 
-conf_loader = ConfigLoader(conf_root="conf", env="local")
+conf_loader = ConfigLoader(conf_source="conf", env="local")
 conf_catalog = conf_loader.get("catalog*", "catalog*/**")
 ```
 


### PR DESCRIPTION
## Description
Updating the ConfigLoader param from `conf_root` to `conf_source` in the docs, as encouraged after raising issue #1404.

## Development notes
`docs/source/kedro_project_setup/configuration.md` has been updated to reflect the parameter name change. No change to `RELEASE.md`, as line 71 states that the parameter has been renamed.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1405"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

