### PR TITLE
Improve kedro run as a package

### DIFF
--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -41,6 +41,13 @@ def main(**kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
+    # This is what happens under the hood of run.__call__. The click context contains
+    # arguments coming from the CLI command (sys.argv, e.g. ["--pipeline", "ds"]) and
+    # default values of arguments that are not supplied. We forward the context to the
+    # invocation of run. Any **kwargs supplied (e.g. `main(pipeline="ds")` will
+    # overwrite the arguments supplied by the context. Overall this means we have a
+    # system where the same main function can handle both arguments coming from CLI and
+    # a Python API.
     with run.make_context("run", sys.argv[1:]) as ctx:
         return ctx.forward(run, **kwargs)
 

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,6 +3,7 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import importlib
 from pathlib import Path
+import sys
 
 from kedro.framework.cli.utils import KedroCliError, load_entry_points
 from kedro.framework.project import configure_project
@@ -36,11 +37,12 @@ def _find_run_command_in_plugins(plugins):
             return group.commands["run"]
 
 
-def main(*args, **kwargs):
+def main(**kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
-    run(*args, **kwargs)
+    with run.make_context("run", sys.argv[1:]) as ctx:
+        return ctx.forward(run, **kwargs)
 
 
 if __name__ == "__main__":

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -349,7 +349,7 @@ def run(
     node_names = _get_values_as_tuple(node_names) if node_names else node_names
 
     with KedroSession.create(env=env, extra_params=params) as session:
-        session.run(
+        return session.run(
             tags=tag,
             runner=runner(is_async=is_async),
             node_names=node_names,

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -9,7 +9,7 @@ import importlib
 import logging.config
 import operator
 from collections.abc import MutableMapping
-from typing import Any, Dict, Optional, Callable
+from typing import Any, Dict, Optional, Callable, List
 
 from dynaconf import LazySettings
 from dynaconf.validator import ValidationError, Validator
@@ -222,7 +222,7 @@ class _Run(Callable):
         # NEED ALL THREE OF THESE??
 
     @_load_callable_wrapper
-    def __call__(self, args=None, **kwargs):
+    def __call__(self, args: Optional[List[str]] = None, **kwargs):
         # This is what happens under the hood of click. The click context contains
         # a list of arguments (e.g. ["--pipeline", "ds"]) and default values of
         # arguments that are not supplied. We forward the context to the

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -1,6 +1,8 @@
 """``kedro.framework.project`` module provides utitlity to
 configure a Kedro project and access its settings."""
 # pylint: disable=redefined-outer-name,unused-argument,global-statement
+import logging
+
 import sys
 
 import inspect
@@ -234,6 +236,8 @@ class _Run(Callable):
         # NOTE args rather than *args. So do run(["-p", "ds"]), not run("-p", "ds").
         # TRY ON DATABRICKS entrypoints
         args = args or []
+        logging.info(args)
+        logging.info(kwargs)
         with self._callable.make_context("run", args) as ctx:
             return ctx.forward(self._callable, **kwargs)
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -234,7 +234,6 @@ class _Run(Callable):
         # (when invoked from a packaged project through the main entry point) and
         # using a Python API.
         # NOTE args rather than *args. So do run(["-p", "ds"]), not run("-p", "ds").
-        # TRY ON DATABRICKS entrypoints
         args = args or []
         logging.info(args)
         logging.info(kwargs)
@@ -245,69 +244,6 @@ class _Run(Callable):
     __repr__ = _load_callable_wrapper(repr)
     __str__ = _load_callable_wrapper(str)
     __doc__ = _load_callable_wrapper(__doc__)
-
-
-#
-# class _Run:
-#     def __init__(self):
-#         pass
-#
-#     # self._pipelines_module: Optional[str] = None
-#     # self._is_data_loaded = False
-#     # self._content: Dict[str, Pipeline] = {}
-#
-#     def _find_run_command(self):
-#         from kedro.framework.cli.utils import (
-#             KedroCliError,
-#             load_entry_points,
-#         )  ### needs to go in here to avoid circular imports
-#
-#         try:
-#             project_cli = importlib.import_module(self._cli_module)
-#             # fail gracefully if cli.py does not exist
-#         except ModuleNotFoundError as exc:
-#             if self._cli_module not in str(exc):
-#                 raise
-#             plugins = load_entry_points("project")
-#             run = self._find_run_command_in_plugins(plugins) if plugins else None
-#             if run:
-#                 # use run command from installed plugin if it exists
-#                 return run
-#             # use run command from the framework project
-#             from kedro.framework.cli.project import run
-#
-#             return run
-#         # fail badly if cli.py exists, but has no `cli` in it
-#         if not hasattr(project_cli, "cli"):
-#             raise KedroCliError(f"Cannot load commands from {self._cli_module}")
-#         return project_cli.run
-#
-#     @staticmethod
-#     def _find_run_command_in_plugins(plugins):
-#         for group in plugins:
-#             if "run" in group.commands:
-#                 return group.commands["run"]
-#
-#     def configure(self, cli_module: str):
-#         self._cli_module = cli_module
-#         self._run_cmd = self._find_run_command()
-#
-#         self.__call__.__func__.__name__ = self._run_cmd.callback.__name__
-#         self.__call__.__func__.__signature__ = inspect.signature(self._run_cmd.callback)
-#         self.__call__.__func__.__annotations__ = self._run_cmd.callback.__annotations__
-#
-#     def __call__(self, *args, **kwargs):
-#         # This is what happens under the hood of click. The click context contains
-#         # a list of arguments (e.g. ["--pipeline", "ds"]) and default values of
-#         # arguments that are not supplied. We forward the context to the
-#         # invocation of run. Any **kwargs supplied (e.g. `pipeline="ds"` will
-#         # overwrite the arguments supplied by the context. Overall this means
-#         # that an instantiation of _Run can handle both arguments from the CLI
-#         # (when invoked from a packaged project through the main entry point) and
-#         # using a Python API.
-#         args = list(args) or sys.argv[1:]
-#         with self._run_cmd.make_context("run", args) as ctx:
-#             return ctx.forward(self._run_cmd, **kwargs)
 
 
 PACKAGE_NAME = None

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -41,6 +41,13 @@ def main(**kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
+    # This is what happens under the hood of run.__call__. The click context contains
+    # arguments coming from the CLI command (sys.argv, e.g. ["--pipeline", "ds"]) and
+    # default values of arguments that are not supplied. We forward the context to the
+    # invocation of run. Any **kwargs supplied (e.g. `main(pipeline="ds")` will
+    # overwrite the arguments supplied by the context. Overall this means we have a
+    # system where the same main function can handle both arguments coming from CLI and
+    # a Python API.ß
     with run.make_context("run", sys.argv[1:]) as ctx:
         return ctx.forward(run, **kwargs)
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,6 +3,7 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import importlib
 from pathlib import Path
+import sys
 
 from kedro.framework.cli.utils import KedroCliError, load_entry_points
 from kedro.framework.project import configure_project
@@ -36,11 +37,12 @@ def _find_run_command_in_plugins(plugins):
             return group.commands["run"]
 
 
-def main(*args, **kwargs):
+def main(**kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
-    run(*args, **kwargs)
+    with run.make_context("run", sys.argv[1:]) as ctx:
+        return ctx.forward(run, **kwargs)
 
 
 if __name__ == "__main__":

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -1,56 +1,28 @@
 """{{ cookiecutter.project_name }} file for ensuring the package is executable
 as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package }}`
 """
-import importlib
-from pathlib import Path
 import sys
+from pathlib import Path
 
-from kedro.framework.cli.utils import KedroCliError, load_entry_points
-from kedro.framework.project import configure_project
-
-
-def _find_run_command(package_name):
-    try:
-        project_cli = importlib.import_module(f"{package_name}.cli")
-        # fail gracefully if cli.py does not exist
-    except ModuleNotFoundError as exc:
-        if f"{package_name}.cli" not in str(exc):
-            raise
-        plugins = load_entry_points("project")
-        run = _find_run_command_in_plugins(plugins) if plugins else None
-        if run:
-            # use run command from installed plugin if it exists
-            return run
-        # use run command from `kedro.framework.cli.project`
-        from kedro.framework.cli.project import run
-
-        return run
-    # fail badly if cli.py exists, but has no `cli` in it
-    if not hasattr(project_cli, "cli"):
-        raise KedroCliError(f"Cannot load commands from {package_name}.cli")
-    return project_cli.run
+from kedro.framework.project import configure_project, run
 
 
-def _find_run_command_in_plugins(plugins):
-    for group in plugins:
-        if "run" in group.commands:
-            return group.commands["run"]
+# def main(args=None, **kwargs):
+#     package_name = Path(__file__).parent.name
+#     configure_project(package_name)
+#     run(args or sys.argv[1:], **kwargs)
+#     return 0
 
 
 def main(**kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
-    run = _find_run_command(package_name)
-    # This is what happens under the hood of run.__call__. The click context contains
-    # arguments coming from the CLI command (sys.argv, e.g. ["--pipeline", "ds"]) and
-    # default values of arguments that are not supplied. We forward the context to the
-    # invocation of run. Any **kwargs supplied (e.g. `main(pipeline="ds")` will
-    # overwrite the arguments supplied by the context. Overall this means we have a
-    # system where the same main function can handle both arguments coming from CLI and
-    # a Python API.ß
-    with run.make_context("run", sys.argv[1:]) as ctx:
-        return ctx.forward(run, **kwargs)
+    if kwargs:
+        run(**kwargs)
+    else:
+        run(sys.argv[1:])
+    return 0
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
⚠️ This is a huge description because I spent ages figuring this out and I thought we should have it all spelt out somewhere. Haven't done tests or docs yet - just opening this to get initial feedback.

The actual change to code is very small, but a big improvement I think: you can now do
```
from spaceflights.__main__ import main
outputs = main(pipeline="ds")
print(outputs)
``` 
and it will Just Work, even in IPython/Juptyer. All the command line ways of invoking `main` work exactly as before, i.e. `python -m spaceflights --pipeline=ds` etc. We now have consistency between `main` and CLI ways of launching kedro.

## Description
A user can run their kedro project in several ways. Note that the `run` command executed can be defined on the framework side or overridden in turn by a plugin or a project cli.py (done by `_find_run_command`).

1. Kedro CLI: `kedro run`. This is the only route that doesn't go through the project `__main__.py`; instead it goes through `kedro.framework.main`, which builds the CLI tree and does something like `_find_run_command`
2. CLI but not kedro CLI: `python -m spaceflights`. This hits the project `__main__.py` and will call `main`
3. CLI but not kedro CLI: `python src/spaceflights`. This is just a more unusual way of doing 2 
4. Inside your own python script: `from spaceflights.__main__ import main; main()`, then run the script using `python`
5. Inside IPython/Jupyter with _no_ kedro ipython extension: same as 4 but you run it in the notebook
6. Inside IPython/Jupyter with kedro ipython extension: same as 5 but you can also do `session.run` (which is what we have advertised as the way to do a kedro run in the past)

All the above must be run from within the project root or kedro won't be able to find your conf. Options 2 onwards needs you to have `pip install`ed your project or to have `src` in your `PYTHONPATH`. Note that having the project `pip install`ed could mean first doing `kedro package` and then `pip install` the resulting .whl file or it could mean just `pip install ./src` from your project root; it doesn't make a difference.

## Current problems
1. When using 1, 2, 3 and 4 you specify arguments using the CLI syntax `--pipeline ds`. With `main()` you do `main(["--pipeline", "ds"])`, i.e. the CLI syntax shoehorned into a Python function call. When using `session.run` you do a pure Python function call as `session.run(pipeline_name="ds")` - but note the argument name is different!!
2. Methods 5 and 6 run ok but generate a horrible big mysterious ipython exception after completing
3. Method 4 isn't actually useful if you want to run a kedro project with anything else since (big problem) no code after `main()` will actually execute...
4. ... and (smaller problem) `main()` doesn't return anything like `session.run` does, so you couldn't use any kedro outputs downstream anyway
5. Method 6 using `main` doesn't work unless you call `session.close` first because you'll get some error about there already being an active session, same as https://github.com/kedro-org/kedro-viz/issues/811
 
This PR fixes 1, 2, 3, 4. We should have separate ticket(s) to fix 5 and also the following:
- [ ] move the horrible code out of the project `__main__.py` to somewhere framework side, because no one wants to see that in their project... Possible locations might be `kedro.framework.cli.utils` or `kedro.framework.project`
- [ ] figure out if we can get a user to do a nicer looking import than `from spaceflights.__main__ import main`, which doesn't really look like it should be done
- [ ] fix a bug where commands defined in the project cli.py aren't given their full path when you do `kedro` but instead `Project specific commands from cli`. I think this is a bug anyway and it didn't used to be like this...
- [ ] consider changing the behaviour when the project cli.py exists but is empty/all commented out. I found the current  behaviour a bit annoying when playing around with this
- [ ] consider whether we should recommend `main` over `session.run` in IPython or even stop exposing `session` altogether. Mooted briefly in https://github.com/kedro-org/kedro/issues/1335 but needs more discussion. `main` is a higher-level function than `session.run` and respects the hierarchy of framework < plugins < project cli.py. The arguments to `main` also match the usual `kedro run` arguments, which those in `session.run` do not

## Development notes
There's basically two things that have changed:
- add `return` to the kedro run command. `session.run`, and hence `main`, returns the free outputs of the pipeline after the kedro run. This fixes problem 4
- change how `main` calls the `run` command. This fixes problems 1, 2, 3

## Adventures with click
I opened [an issue on the click repo](https://github.com/pallets/click/issues/2249) (which didn't go down well... 😅) describing the original source of problems 1, 2, 3. In short, when you run a click command it _always_ exits afterwards with an Exception, even if execution was successful. This means it's impossible to run any code after that `main` in a Python script and also massively confuses ipython, which blows up.

For the record, some of the things that don't quite fix this are:
* `run(standalone_mode=True)` like suggested on the click repo. This solves problem 2 and 3 but not 1
* `run.callback`. This nearly gets you there but doesn't fill in the default arguments for you so you need to explicitly give all the arguments in the function call, which is horrible
* `run.main` is equivalent to what we were doing before (`run.__call__`) so doesn't help
* `run.invoke` is _really_ close to doing it, but unlike `run.forward` doesn't fills in default arguments and won't notice CLI arguments when called with `python -m spaceflights --pipeline=ds`

Overall, the code here is I think the unique thing that does exactly what we want both on the CLI and in scripts/ipython 🎉 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1423"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

