### PR TITLE
Experiment Tracking tutorial is broken due to `spaceflights` tutorial is now namespaced

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@
 * Fixed `CONFIG_LOADER_CLASS` validation so that `TemplatedConfigLoader` can be specified in settings.py. Any `CONFIG_LOADER_CLASS` must be a subclass of `AbstractConfigLoader`.
 * Added runner name to the `run_params` dictionary used in pipeline hooks.
 * Introduced `after_command_run` CLI hook.
+* Update sections on visualisation, namespacing, and experiment tracking in the spaceflight tutorial to correspond to the complete spaceflights starter.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/docs/source/deployment/kubeflow.md
+++ b/docs/source/deployment/kubeflow.md
@@ -185,7 +185,7 @@ $ kubectl create -f secret.yml
 $ kubectl get secrets aws-secrets -n kubeflow
 ```
 
-You can find more information about AWS configuration in [the Kubeflow Pipelines documentation](https://www.kubeflow.org/docs/distributions/aws/component-guides/pipeline/).
+You can find more information about AWS configuration in [the Kubeflow Pipelines documentation](https://awslabs.github.io/kubeflow-manifests/docs/component-guides/pipelines/).
 
 ### Upload workflow spec and execute runs
 

--- a/docs/source/tutorial/namespace_pipelines.md
+++ b/docs/source/tutorial/namespace_pipelines.md
@@ -179,7 +179,7 @@ In this section we want to add some namespaces in the modelling component of the
 
 ### Let's explain what's going on here
 
-Modular pipelines allow you instantiate multiple instances of pipelines with static structure, but dynamic inputs/outputs/parameters.
+Modular pipelines allow you to instantiate multiple instances of pipelines with static structure, but dynamic inputs/outputs/parameters.
 
 ```python
 pipeline_instance = pipeline(...)
@@ -210,8 +210,6 @@ The table below describes the purpose of each keyword arguments in detail:
 +--------------------+-------------------------------------------------------------------------------------------+------------------------------+
 | :code:`outputs`    | No outputs are at the boundary of this pipeline so nothing to list here                   | Same as `ds_pipeline_1`      |
 +--------------------+-------------------------------------------------------------------------------------------+------------------------------+
-| :code:`parameters` | Inherits defaults from template                                                           | Overrides provided           |
-+--------------------+-------------------------------------------------------------------------------------------+------------------------------+
 | :code:`namespace`  | A unique namespace                                                                        | A different unique namespace |
 +--------------------+-------------------------------------------------------------------------------------------+------------------------------+
 ```
@@ -220,7 +218,7 @@ The table below describes the purpose of each keyword arguments in detail:
 
 * Modular pipelines can be nested an arbitrary number of times
 * This can be an effective pattern for simplifying you mental model and to reduce visual noise
-* Namespaces will be chained using the `.` syntax just you `import` modules in Python
+* Namespaces will be chained using the `.` syntax just like you `import` modules in Python
 * You can quickly wrap your two modelling pipeline instances under one 'Data science' namespace by adding the following to your `pipelines/data_science/pipeline.py` return statement:
 
     ```python
@@ -232,7 +230,7 @@ The table below describes the purpose of each keyword arguments in detail:
     )
     ```
 
-  > If you do this, you will also need to add the `data_science` namespace to the `regressor` datasets in `catalogl.yml` as well as at the top level of your parameter file `data_science.yml` and indent the other entries. The complete `catalog.yml` and `data_science.yml` parameter file should look like the below.
+  * As we've created an outer namespace `data_science`, we'll be updating our catalog entries for the `regressor` datasets by adding the `data_science` prefix. Additionally, you need to add the `data_science` prefix at the top level of your parameter file `data_science.yml` and indent the other entries. The complete `catalog.yml` and `data_science.yml` parameter files should look like the below.
 
     <details>
     <summary><b>Click to expand</b></summary>
@@ -317,18 +315,3 @@ The table below describes the purpose of each keyword arguments in detail:
     This renders as follows:
 
     ![modular_ds](../meta/images/modular_ds.gif)
-
-    * As we've created an outer namespace `data_science`, we'll be updating our catalog entries as below by adding `data_science` prefix.
-    ```yaml
-    data_science.active_modelling_pipeline.regressor:
-        type: pickle.PickleDataSet
-        filepath: data/06_models/regressor_active.pickle
-        versioned: true
-        layer: models
-
-    data_science.candidate_modelling_pipeline.regressor:
-        type: pickle.PickleDataSet
-        filepath: data/06_models/regressor_candidate.pickle
-        versioned: true
-        layer: models
-    ```

--- a/docs/source/tutorial/namespace_pipelines.md
+++ b/docs/source/tutorial/namespace_pipelines.md
@@ -25,7 +25,7 @@ Adding namespaces to [modular pipelines](../nodes_and_pipelines/modular_pipeline
     from kedro.pipeline import Pipeline, node
     from kedro.pipeline.modular_pipeline import pipeline
 
-    from kedro_tutorial.pipelines.data_processing.nodes import (
+    from .nodes import (
         preprocess_companies,
         preprocess_shuttles,
         create_model_input_table,
@@ -76,18 +76,33 @@ Adding namespaces to [modular pipelines](../nodes_and_pipelines/modular_pipeline
 
 In this section we want to add some namespaces in the modelling component of the pipeline and also highlight the power of instantiating the same modular pipeline multiple times with different parameters.
 
-1. Add some more parameters to the bottom of `conf/base/parameters/data_science.yml` using this snippet:
+1. Update the parameters file `conf/base/parameters/data_science.yml` using this snippet:
 
     ```yaml
-
-    model_options_experimental:
-      test_size: 0.2
-      random_state: 8
-      features:
-        - engines
-        - passenger_capacity
-        - crew
-        - review_scores_rating
+   
+    active_modelling_pipeline:
+        model_options:
+          test_size: 0.2
+          random_state: 3
+          features:
+            - engines
+            - passenger_capacity
+            - crew
+            - d_check_complete
+            - moon_clearance_complete
+            - iata_approved
+            - company_rating
+            - review_scores_rating
+       
+    candidate_modelling_pipeline:
+        model_options:
+          test_size: 0.2
+          random_state: 8
+          features:
+            - engines
+            - passenger_capacity
+            - crew
+            - review_scores_rating
 
     ```
 
@@ -120,7 +135,7 @@ In this section we want to add some namespaces in the modelling component of the
 
     from .nodes import evaluate_model, split_data, train_model
 
-
+   
     def create_pipeline(**kwargs) -> Pipeline:
         pipeline_instance = pipeline(
             [
@@ -153,9 +168,8 @@ In this section we want to add some namespaces in the modelling component of the
             pipe=pipeline_instance,
             inputs="model_input_table",
             namespace="candidate_modelling_pipeline",
-            parameters={"params:model_options": "params:model_options_experimental"},
         )
-
+   
         return ds_pipeline_1 + ds_pipeline_2
     ```
 
@@ -178,7 +192,6 @@ ds_pipeline_2 = pipeline(
     pipe=pipeline_instance,
     inputs="model_input_table",
     namespace="candidate_modelling_pipeline",
-    parameters={"params:model_options": "params:model_options_experimental"},
 )
 ```
 
@@ -216,6 +229,40 @@ The table below describes the purpose of each keyword arguments in detail:
         namespace="data_science",
     )
     ```
+  
+  > If you do this, you will also need to add the `data_science` namespace at the top level of your parameter file `data_science.active_modelling_pipeline.model_options` and indent the other entries. The complete parameters file should look like the below.
+
+    <details>                                                                                                                                                                                                                                                                                                                                                             
+    <summary><b>Click to expand</b></summary>
+
+    ```yaml
+      data_science:
+          active_modelling_pipeline:
+            model_options:
+              test_size: 0.2
+              random_state: 3
+              features:
+                - engines
+                - passenger_capacity
+                - crew
+                - d_check_complete
+                - moon_clearance_complete
+                - iata_approved
+                - company_rating
+                - review_scores_rating
+  
+          candidate_modelling_pipeline:
+            model_options:
+              test_size: 0.2
+              random_state: 8
+              features:
+                - engines
+                - passenger_capacity
+                - crew
+                - review_scores_rating
+    ```
+
+    </details>
 
     This renders as follows:
 

--- a/docs/source/tutorial/namespace_pipelines.md
+++ b/docs/source/tutorial/namespace_pipelines.md
@@ -230,7 +230,7 @@ The table below describes the purpose of each keyword arguments in detail:
     )
     ```
   
-  > If you do this, you will also need to add the `data_science` namespace at the top level of your parameter file `data_science.active_modelling_pipeline.model_options` and indent the other entries. The complete parameters file should look like the below.
+  > If you do this, you will also need to add the `data_science` namespace at the top level of your parameter file `data_science.yml` and indent the other entries. The complete parameters file should look like the below.
 
     <details>                                                                                                                                                                                                                                                                                                                                                             
     <summary><b>Click to expand</b></summary>

--- a/docs/source/tutorial/set_up_experiment_tracking.md
+++ b/docs/source/tutorial/set_up_experiment_tracking.md
@@ -48,11 +48,11 @@ There are two types of tracking datasets: [`tracking.MetricsDataSet`](/kedro.ext
 Set up two datasets to log `r2 scores` and `parameters` for each run by adding the following in the `conf/base/catalog.yml` file:
 
 ```yaml
-metrics:
+data_science.active_modelling_pipeline.metrics:
   type: tracking.MetricsDataSet
   filepath: data/09_tracking/metrics.json
 
-companies_columns:
+data_processing.companies_columns:
   type: tracking.JSONDataSet
   filepath: data/09_tracking/companies_columns.json
 ```
@@ -66,6 +66,9 @@ Set up the data to be logged for the metrics dataset - under `nodes.py` of your 
 The new `evaluate_model` function would look like this:
 
 ```python
+from sklearn.metrics import mean_absolute_error, max_error
+
+
 def evaluate_model(
     regressor: LinearRegression, X_test: pd.DataFrame, y_test: pd.Series
 ) -> Dict[str, float]:
@@ -101,6 +104,9 @@ node(
 You have to repeat the same steps for setting up the `companies_column` dataset. For this dataset you should log the column that contains the list of companies as outlined in `companies.csv` under `/data/01_raw`. Modify the `preprocess_companies` node under the `data_processing` pipeline (`src/kedro-experiment-tracking-tutorial/pipelines/data_processing/nodes.py`) to return the data under a key value pair, as shown below:
 
 ```python
+from typing import Tuple, Dict
+
+
 def preprocess_companies(companies: pd.DataFrame) -> Tuple[pd.DataFrame, Dict]:
     """Preprocesses the data for companies.
 

--- a/docs/source/tutorial/set_up_experiment_tracking.md
+++ b/docs/source/tutorial/set_up_experiment_tracking.md
@@ -9,11 +9,15 @@ Enabling experiment tracking features on Kedro-Viz relies on:
 * [experiment tracking datasets to let Kedro know what metrics should be tracked](#set-up-tracking-datasets)
 * [modifying your nodes and pipelines to output those metrics](#setting-up-your-nodes-and-pipelines-to-log-metrics).
 
-This tutorial will provide a step-by-step process to set up experiment tracking and access your logged metrics from each run on Kedro-Viz. It will use the spaceflights starter project that is outlined in [this tutorial](../tutorial/spaceflights_tutorial.md). You can also jump directly to [this section for direct reference in setting up experiment tracking](../logging/experiment_tracking.md) for your Kedro project.
+This tutorial will provide a step-by-step process to set up experiment tracking and access your logged metrics from each run on Kedro-Viz. It will use the spaceflights starter project that is outlined in [this tutorial](../tutorial/spaceflights_tutorial.md) and build on previously discussed topics such as [namespacing](../tutorial/namespace_pipelines.md). You can also jump directly to [this section for direct reference in setting up experiment tracking](../logging/experiment_tracking.md) for your Kedro project.
 
 You can also access a more detailed demo [here](https://kedro-viz-live-demo.hfa4c8ufrmn4u.eu-west-2.cs.amazonlightsail.com/).
 
 ## Set up a project
+
+```eval_rst
+  .. note:: You can skip this step if you have been following all previous parts of the tutorial.
+```
 
 We assume that you have already [installed Kedro](../get_started/install.md) and [Kedro-Viz](../tutorial/visualise_pipeline.md). Set up a new project using the spaceflights starter by running:
 
@@ -55,6 +59,10 @@ data_science.active_modelling_pipeline.metrics:
 data_processing.companies_columns:
   type: tracking.JSONDataSet
   filepath: data/09_tracking/companies_columns.json
+```
+
+```eval_rst
+  .. note:: Note that these two datasets include namespaces to correspond to the pipeline setup. If you have a project without namespaces you can still use experiment tracking.
 ```
 
 ## Set up your nodes and pipelines to log metrics

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -128,8 +128,12 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 import pandas as pd
 import numpy as np
 
+
 def compare_shuttle_speed():
-    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 2)), columns=['shuttle_name', 'shuttle_speed'])
+    df = pd.DataFrame(
+        np.random.randint(0, 100, size=(100, 2)),
+        columns=["shuttle_name", "shuttle_speed"],
+    )
     return df
 
 
@@ -174,9 +178,16 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 
 ```python
 import plotly.express as px
+import pandas as pd
+import numpy as np
 
-def compare_shuttle_speed(shuttle_data):
-    fig = px.bar(x=shuttle_data.name, y=shuttle_data.speed)
+
+def compare_shuttle_speed():
+    shuttle_data = pd.DataFrame(
+        np.random.randint(0, 100, size=(100, 2)),
+        columns=["shuttle_name", "shuttle_speed"],
+    )
+    fig = px.bar(x=shuttle_data.shuttle_name, y=shuttle_data.shuttle_speed)
     return fig
 
 
@@ -186,7 +197,7 @@ def create_pipeline(**kwargs) -> Pipeline:
         [
             node(
                 func=compare_shuttle_speed,
-                inputs="shuttle_speed_data",
+                inputs=None,
                 outputs="shuttle_speed_comparison_plot",
             ),
         ]

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -126,25 +126,20 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 
 ```python
 import pandas as pd
-import numpy as np
 
 
-def compare_shuttle_speed():
-    df = pd.DataFrame(
-        np.random.randint(0, 100, size=(100, 2)),
-        columns=["shuttle_name", "shuttle_speed"],
-    )
-    return df
+def compare_passenger_capacity(preprocessed_shuttles: pd.DataFrame):
+    return preprocessed_shuttles.groupby(['shuttle_type']).mean().reset_index()
 
 
 def create_pipeline(**kwargs) -> Pipeline:
     """This is a simple pipeline which generates a plot"""
     return pipeline(
         [
-            node(
-                func=compare_shuttle_speed,
-                inputs=None,
-                outputs="shuttle_speed_comparison_plot",
+             node(
+                func=compare_passenger_capacity,
+                inputs="preprocessed_shuttles",
+                outputs="shuttle_passenger_capacity_plot",
             ),
         ]
     )
@@ -153,19 +148,19 @@ def create_pipeline(**kwargs) -> Pipeline:
 You need to then configure the plot in `catalog.yml`
 
 ```yaml
-shuttle_speed_comparison_plot:
+shuttle_passenger_capacity_plot:
   type: plotly.PlotlyDataSet
-  filepath: data/08_reporting/shuttle_speed_comparison_plot.json
+  filepath: data/08_reporting/shuttle_passenger_capacity_plot.json
   plotly_args:
     type: bar
     fig:
-      x: shuttle_name
-      y: shuttle_speed
+      x: shuttle_type
+      y: passenger_capacity
       orientation: h
     layout:
       xaxis_title: Shuttles
-      yaxis_title: Shuttle Speed (km/hr)
-      title: Shuttle Speed Comaprison
+      yaxis_title: Average passenger capacity
+      title: Shuttle Passenger capacity
 ```
 
 
@@ -179,15 +174,13 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 ```python
 import plotly.express as px
 import pandas as pd
-import numpy as np
 
-
-def compare_shuttle_speed():
-    shuttle_data = pd.DataFrame(
-        np.random.randint(0, 100, size=(100, 2)),
-        columns=["shuttle_name", "shuttle_speed"],
+def compare_passenger_capacity(preprocessed_shuttles: pd.DataFrame):
+    fig = px.bar(
+        data_frame=preprocessed_shuttles.groupby(['shuttle_type']).mean().reset_index(),
+        x="shuttle_type",
+        y="passenger_capacity"
     )
-    fig = px.bar(x=shuttle_data.shuttle_name, y=shuttle_data.shuttle_speed)
     return fig
 
 
@@ -195,10 +188,10 @@ def create_pipeline(**kwargs) -> Pipeline:
     """This is a simple pipeline which generates a plot"""
     return pipeline(
         [
-            node(
-                func=compare_shuttle_speed,
-                inputs=None,
-                outputs="shuttle_speed_comparison_plot",
+             node(
+                func=compare_passenger_capacity,
+                inputs="preprocessed_shuttles",
+                outputs="shuttle_passenger_capacity_plot",
             ),
         ]
     )
@@ -207,9 +200,9 @@ def create_pipeline(**kwargs) -> Pipeline:
 For `plotly.JSONDataSet`, you will also need to specify the output type in `catalog.yml` like below.
 
 ```yaml
-shuttle_speed_comparison_plot:
+shuttle_passenger_capacity_plot:
   type: plotly.JSONDataSet
-  filepath: data/08_reporting/shuttle_speed_comparison_plot.json
+  filepath: data/08_reporting/shuttle_passenger_capacity_plot.json
 ```
 
 Once the above setup is completed, you can do a `kedro run` followed by `kedro viz` and your Kedro-Viz pipeline will show a new dataset type with icon ![](../meta/images/plotly-icon.png) . Once you click on the node, you can see a small preview of your Plotly chart in the metadata panel.

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -129,14 +129,14 @@ import pandas as pd
 
 
 def compare_passenger_capacity(preprocessed_shuttles: pd.DataFrame):
-    return preprocessed_shuttles.groupby(['shuttle_type']).mean().reset_index()
+    return preprocessed_shuttles.groupby(["shuttle_type"]).mean().reset_index()
 
 
 def create_pipeline(**kwargs) -> Pipeline:
     """This is a simple pipeline which generates a plot"""
     return pipeline(
         [
-             node(
+            node(
                 func=compare_passenger_capacity,
                 inputs="preprocessed_shuttles",
                 outputs="shuttle_passenger_capacity_plot",
@@ -175,11 +175,12 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 import plotly.express as px
 import pandas as pd
 
+
 def compare_passenger_capacity(preprocessed_shuttles: pd.DataFrame):
     fig = px.bar(
-        data_frame=preprocessed_shuttles.groupby(['shuttle_type']).mean().reset_index(),
+        data_frame=preprocessed_shuttles.groupby(["shuttle_type"]).mean().reset_index(),
         x="shuttle_type",
-        y="passenger_capacity"
+        y="passenger_capacity",
     )
     return fig
 
@@ -188,7 +189,7 @@ def create_pipeline(**kwargs) -> Pipeline:
     """This is a simple pipeline which generates a plot"""
     return pipeline(
         [
-             node(
+            node(
                 func=compare_passenger_capacity,
                 inputs="preprocessed_shuttles",
                 outputs="shuttle_passenger_capacity_plot",

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -110,7 +110,7 @@ We have also used the Plotly integration to allow users to [visualise metrics fr
   .. note:: Kedro's Plotly integration only supports `Plotly Express <https://plotly.com/python/plotly-express/>` charts.
 ```
 
-You need to update requirements.txt in your Kedro project and add the following datasets to enable plotly for your project.
+You need to update `requirements.txt` in your Kedro project and add the following datasets to enable plotly for your project.
 
 `kedro[plotly.PlotlyDataSet, plotly.JSONDataSet]==0.18.0`
 

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -125,8 +125,12 @@ Below is an example of how to visualise plots on Kedro-Viz using `plotly.PlotlyD
 The below functions can be added to the nodes.py and pipeline.py files respectively.
 
 ```python
+import pandas as pd
+import numpy as np
+
 def compare_shuttle_speed():
-    return pd.DataFrame([])
+    df = pd.DataFrame(np.random.randint(0, 100, size=(100, 2)), columns=['shuttle_name', 'shuttle_speed'])
+    return df
 
 
 def create_pipeline(**kwargs) -> Pipeline:
@@ -135,7 +139,7 @@ def create_pipeline(**kwargs) -> Pipeline:
         [
             node(
                 func=compare_shuttle_speed,
-                inputs="shuttle_speed_data",
+                inputs=None,
                 outputs="shuttle_speed_comparison_plot",
             ),
         ]
@@ -170,8 +174,6 @@ The below functions can be added to the nodes.py and pipeline.py files respectiv
 
 ```python
 import plotly.express as px
-from kedro.extras.datasets.plotly import JSONDataSet
-
 
 def compare_shuttle_speed(shuttle_data):
     fig = px.bar(x=shuttle_data.name, y=shuttle_data.speed)


### PR DESCRIPTION
Signed-off-by: noklam <nok.lam.chan@quantumblack.com>
Fix #1418 #1417

## Description
<!-- Why was this PR created? -->
The `spaceflight` tutorial has been updated with namespace pipeline. However, other tutorials like `kedro-viz` depends on it, and the documentation is outdated now.

While we can update the viz documentation to the namespace version, I dislike the configuration now looks a lot more complicated.

Experiment Tracking documentation:
https://kedro.readthedocs.io/en/0.18.0/tutorial/set_up_experiment_tracking.html


The config without namespaced in our doc:
![image](https://user-images.githubusercontent.com/18221871/162256079-84b72ee2-4d2d-486f-b8b1-d4b2b0e9b71b.png)


## Development notes
1. Updated the `namespaces` section so the final result corresponds to the `spaceflights` starter.
2. Updated the `visualise pipelines` section to include a functioning example.
3. Update the experiment tracking tutorial to build on the rest of the tutorial and the `spaceflights` starter. This means that namespaces are now carried on in this part. 

For review, I'd suggest to look at the resulting pages instead of the diff to check whether these sections now follow on each other properly.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1424"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

