### PR TITLE
Specify user agent to fix 403 errors in link check

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -561,4 +561,4 @@ except Exception as e:
         )
     )
 
-user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'
+user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99.0"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -561,4 +561,4 @@ except Exception as e:
         )
     )
 
-# user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'
+user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -560,3 +560,5 @@ except Exception as e:
             fg="red",
         )
     )
+
+user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -561,4 +561,4 @@ except Exception as e:
         )
     )
 
-user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'
+# user_agent = 'Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 Firefox/25.0'


### PR DESCRIPTION
Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
<!-- Why was this PR created? -->

`docs_linkcheck` build fails. 😭 

Most likely, some link doesn't like the Sphinx user agent, so we change it.

## Development notes
<!-- What have you changed, and how has this been tested? -->

`docs_linkcheck` build passes! 🥳 

Issue and resolution: https://github.com/sphinx-doc/sphinx/issues/7369#issuecomment-605009428
Firefox user agent string reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/User-Agent/Firefox#linux

Currently using latest version of Firefox, but possible to use ESR if necessary (I don't think it is).

You can verify that build/link check fails without this change, referencing commit [c95ddef](https://github.com/kedro-org/kedro/pull/1443/commits/c95ddefc66d2c5b05c0f1ce3ebbd2b23a3420c6e).

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1443"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

