### PR TITLE
Fix CircleCI triggers

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -505,13 +505,13 @@ workflows:
   version: 2.1
 
   build_docs_only:
-    when: <<pipeline.parameters.docs_change>>
-    unless:
-      or:
-        - <<pipeline.parameters.code_change>>
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_hourly>>
-        - <<pipeline.parameters.run_nightly>>
+    when:
+      and:
+        - <<pipeline.parameters.docs_change>>
+        - not: <<pipeline.parameters.code_change>>
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
+        - not: <<pipeline.parameters.run_nightly>>
     jobs:
       - build_docs
       - docs_linkcheck
@@ -521,12 +521,12 @@ workflows:
             - docs_linkcheck
 
   build_code_and_docs:
-    when: <<pipeline.parameters.code_change>>
-    unless:
-      or:
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_hourly>>
-        - <<pipeline.parameters.run_nightly>>
+    when:
+      and:
+        - <<pipeline.parameters.code_change>>
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
+        - not: <<pipeline.parameters.run_nightly>>
     jobs:
       - e2e_tests:
           matrix:
@@ -571,11 +571,11 @@ workflows:
             - docs_linkcheck
 
   main_updated:
-    unless:
-      or:
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_hourly>>
-        - <<pipeline.parameters.run_nightly>>
+    when:
+      and:
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
+        - not: <<pipeline.parameters.run_nightly>>
     jobs:
       - sync:
           filters:
@@ -587,11 +587,11 @@ workflows:
               only: main
 
   hourly_pr_merge:
-    when: <<pipeline.parameters.run_hourly>>
-    unless:
-      or:
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_nightly>>
+    when:
+      and:
+        - <<pipeline.parameters.run_hourly>>
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_nightly>>
     jobs:
       - merge_pr_to_develop:
         filters:
@@ -600,11 +600,11 @@ workflows:
 
   # Python versions that are supported on `main`.
   nightly_build_main:
-    when: <<pipeline.parameters.run_nightly>>
-    unless:
-      or:
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_hourly>>
+    when:
+      and:
+        - <<pipeline.parameters.run_nightly>>
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
     jobs:
       - build_docker_image:
           matrix:
@@ -625,11 +625,11 @@ workflows:
 
   # Python version that are *only* supported on `develop`.
   nightly_build_develop:
-    when: <<pipeline.parameters.run_nightly>>
-    unless:
-      or:
-        - <<pipeline.parameters.release_kedro>>
-        - <<pipeline.parameters.run_hourly>>
+    when:
+      and:
+        - <<pipeline.parameters.run_nightly>>
+        - not: <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
     jobs:
       - build_docker_image:
           matrix:
@@ -649,11 +649,11 @@ workflows:
               only: develop
 
   kedro_release:
-    when: <<pipeline.parameters.release_kedro>>
-    unless:
-      or:
-        - <<pipeline.parameters.run_hourly>>
-        - <<pipeline.parameters.run_nightly>>
+    when:
+      and:
+        - <<pipeline.parameters.release_kedro>>
+        - not: <<pipeline.parameters.run_hourly>>
+        - not: <<pipeline.parameters.run_nightly>>
     jobs:
       - build_kedro:
           matrix:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -505,11 +505,13 @@ workflows:
   version: 2.1
 
   build_docs_only:
-    when:
-      and:
-        - <<pipeline.parameters.docs_change>>
-        - not: <<pipeline.parameters.code_change>>
-        - not: <<pipeline.parameters.release_kedro>>
+    when: <<pipeline.parameters.docs_change>>
+    unless:
+      or:
+        - <<pipeline.parameters.code_change>>
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_hourly>>
+        - <<pipeline.parameters.run_nightly>>
     jobs:
       - build_docs
       - docs_linkcheck
@@ -519,10 +521,12 @@ workflows:
             - docs_linkcheck
 
   build_code_and_docs:
-    when:
-      and:
-        - <<pipeline.parameters.code_change>>
-        - not: <<pipeline.parameters.release_kedro>>
+    when: <<pipeline.parameters.code_change>>
+    unless:
+      or:
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_hourly>>
+        - <<pipeline.parameters.run_nightly>>
     jobs:
       - e2e_tests:
           matrix:
@@ -567,7 +571,11 @@ workflows:
             - docs_linkcheck
 
   main_updated:
-    unless: <<pipeline.parameters.release_kedro>>  # don't run if 'release_kedro' flag is set
+    unless:
+      or:
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_hourly>>
+        - <<pipeline.parameters.run_nightly>>
     jobs:
       - sync:
           filters:
@@ -580,6 +588,10 @@ workflows:
 
   hourly_pr_merge:
     when: <<pipeline.parameters.run_hourly>>
+    unless:
+      or:
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_nightly>>
     jobs:
       - merge_pr_to_develop:
         filters:
@@ -589,6 +601,10 @@ workflows:
   # Python versions that are supported on `main`.
   nightly_build_main:
     when: <<pipeline.parameters.run_nightly>>
+    unless:
+      or:
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_hourly>>
     jobs:
       - build_docker_image:
           matrix:
@@ -609,7 +625,11 @@ workflows:
 
   # Python version that are *only* supported on `develop`.
   nightly_build_develop:
-    when: << pipeline.parameters.run_nightly >>
+    when: <<pipeline.parameters.run_nightly>>
+    unless:
+      or:
+        - <<pipeline.parameters.release_kedro>>
+        - <<pipeline.parameters.run_hourly>>
     jobs:
       - build_docker_image:
           matrix:
@@ -629,7 +649,11 @@ workflows:
               only: develop
 
   kedro_release:
-    when: <<pipeline.parameters.release_kedro>>  # only run if 'release_kedro' flag is set
+    when: <<pipeline.parameters.release_kedro>>
+    unless:
+      or:
+        - <<pipeline.parameters.run_hourly>>
+        - <<pipeline.parameters.run_nightly>>
     jobs:
       - build_kedro:
           matrix:


### PR DESCRIPTION
## Description
Every hour there's a mysterious CircleCI job being launched on kedro-viz in my name...

After much detective work I think I've figured out the reason: when we changed from scheduled workflows to scheduled pipelines in https://github.com/kedro-org/kedro/pull/1365 I think we missed some conditions. Instead of just the `hourly_pr_merge`, it's actually running all the workflows on main, which include a `viz_build` job which triggers a build on kedro-viz CI.

Hopefully making these conditions stricter will mean that only `hourly_pr_merge` gets triggered hourly and then the extra jobs on kedro-viz (and on kedro) no longer get triggered.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1448"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

