### PR TITLE
Use CircleCI context for AWS keys for ECR publish

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -591,6 +591,8 @@ workflows:
     when: <<pipeline.parameters.run_nightly>>
     jobs:
       - build_docker_image:
+          context:
+            - kedro-ecr-publish
           matrix:
             parameters:
               python_version: ["3.7", "3.8", "3.9", "3.10"]
@@ -612,6 +614,8 @@ workflows:
     when: << pipeline.parameters.run_nightly >>
     jobs:
       - build_docker_image:
+          context:
+            - kedro-ecr-publish
           matrix:
             parameters:
               python_version: []


### PR DESCRIPTION
## Description

Using CircleCI context for AWS credentials provides an easy way to use one set of credentials over multiple repositories. Since we have an enforced key rotation scheme for the ECR instance we are using, this will make key rotations a tad easier.
