### PR TITLE
Fix `CustomContext` example for PySpark in docs

### DIFF
--- a/docs/source/tools_integration/pyspark.md
+++ b/docs/source/tools_integration/pyspark.md
@@ -38,10 +38,13 @@ class CustomContext(KedroContext):
         package_name: str,
         project_path: Union[Path, str],
         config_loader: ConfigLoader,
+        hook_manager: PluginManager,
         env: str = None,
         extra_params: Dict[str, Any] = None,
     ):
-        super().__init__(package_name, project_path, config_loader, env, extra_params)
+        super().__init__(
+            package_name, project_path, config_loader, hook_manager, env, extra_params
+        )
         self.init_spark_session()
 
     def init_spark_session(self) -> None:
@@ -53,7 +56,7 @@ class CustomContext(KedroContext):
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(self.package_name)
+            SparkSession.builder.appName(self._package_name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->
Related issue: https://github.com/kedro-org/kedro/issues/1425
Related PR: https://github.com/kedro-org/kedro-starters/pull/83

This fixes the outdated `CustomContext` example code for `pyspark` in our documentation.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1452"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

