### PR TITLE
Bumbed outdated schema references

### DIFF
--- a/docs/source/development/set_up_pycharm.md
+++ b/docs/source/development/set_up_pycharm.md
@@ -163,7 +163,7 @@ You can enable the Kedro catalog validation schema in your PyCharm IDE to enable
 
 ![](../meta/images/pycharm_edit_schema_mapping.png)
 
-Add a new mapping using the "+" button in the top left of the window and select the name you want for it. Enter this URL `https://raw.githubusercontent.com/kedro-org/kedro/develop/static/jsonschema/kedro-catalog-0.17.json` in the "Schema URL" field and select "JSON Schema Version 7" in the "Schema version" field.
+Add a new mapping using the "+" button in the top left of the window and select the name you want for it. Enter this URL `https://raw.githubusercontent.com/kedro-org/kedro/develop/static/jsonschema/kedro-catalog-0.18.json` in the "Schema URL" field and select "JSON Schema Version 7" in the "Schema version" field.
 
 Add the following file path pattern to the mapping: `conf/**/*catalog*`.
 

--- a/docs/source/development/set_up_vscode.md
+++ b/docs/source/development/set_up_vscode.md
@@ -255,7 +255,7 @@ Enter the following in your `settings.json` file:
 ```json
 {
   "yaml.schemas": {
-    "https://raw.githubusercontent.com/kedro-org/kedro/develop/static/jsonschema/kedro-catalog-0.17.json": "conf/**/*catalog*"
+    "https://raw.githubusercontent.com/kedro-org/kedro/develop/static/jsonschema/kedro-catalog-0.18.json": "conf/**/*catalog*"
   }
 }
 ```


### PR DESCRIPTION
## Description
Noticed our IDE guides pointed to the 0.17.x jsonschema files

## Development notes
URLs work correctly

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1463"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

