### PR TITLE
Fix Jinja2 syntax loading with `TemplatedConfigloader`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@
 * Fixed `CONFIG_LOADER_CLASS` validation so that `TemplatedConfigLoader` can be specified in settings.py. Any `CONFIG_LOADER_CLASS` must be a subclass of `AbstractConfigLoader`.
 * Added runner name to the `run_params` dictionary used in pipeline hooks.
 * Introduced `after_command_run` CLI hook.
+* Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`. 
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@
 * Fixed `CONFIG_LOADER_CLASS` validation so that `TemplatedConfigLoader` can be specified in settings.py. Any `CONFIG_LOADER_CLASS` must be a subclass of `AbstractConfigLoader`.
 * Added runner name to the `run_params` dictionary used in pipeline hooks.
 * Introduced `after_command_run` CLI hook.
-* Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`. 
+* Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/kedro/config/templated_config.py
+++ b/kedro/config/templated_config.py
@@ -123,7 +123,7 @@ class TemplatedConfigLoader(AbstractConfigLoader):
         self._config_mapping = (
             _get_config_from_patterns(
                 conf_paths=self.conf_paths,
-                patterns=list(globals_pattern),
+                patterns=[globals_pattern],
                 ac_template=False,
             )
             if globals_pattern
@@ -159,7 +159,7 @@ class TemplatedConfigLoader(AbstractConfigLoader):
             ValueError: malformed config found.
         """
         config_raw = _get_config_from_patterns(
-            conf_paths=self.conf_paths, patterns=list(patterns), ac_template=True
+            conf_paths=self.conf_paths, patterns=patterns, ac_template=True
         )
         return _format_object(config_raw, self._config_mapping)
 

--- a/tests/config/test_templated_config.py
+++ b/tests/config/test_templated_config.py
@@ -367,6 +367,32 @@ class TestTemplatedConfigLoader:
         }
         assert catalog == expected_catalog
 
+    @pytest.mark.usefixtures("proj_catalog_globals", "catalog_with_jinja2_syntax")
+    def test_catalog_with_jinja2_syntax_and_globals_file(self, tmp_path, template_config):
+        """Test catalog with jinja2 syntax with globals yaml file"""
+        proj_catalog = tmp_path / _DEFAULT_RUN_ENV / "catalog.yml"
+        _write_yaml(proj_catalog, {})
+        config_loader = TemplatedConfigLoader(
+            str(tmp_path), globals_pattern="*globals.yml",
+        )
+        config_loader.default_run_env = ""
+        catalog = config_loader.get("catalog*.yml")
+        expected_catalog = {
+            "fast-trains": {"type": "MemoryDataSet"},
+            "fast-cars": {
+                "type": "pandas.CSVDataSet",
+                "filepath": "s3a://boat-and-car-bucket/fast-cars.csv",
+                "save_args": {"index": True},
+            },
+            "slow-trains": {"type": "MemoryDataSet"},
+            "slow-cars": {
+                "type": "pandas.CSVDataSet",
+                "filepath": "s3a://boat-and-car-bucket/slow-cars.csv",
+                "save_args": {"index": True},
+            },
+        }
+        assert catalog == expected_catalog
+
 
 class TestFormatObject:
     @pytest.mark.parametrize(

--- a/tests/config/test_templated_config.py
+++ b/tests/config/test_templated_config.py
@@ -368,12 +368,13 @@ class TestTemplatedConfigLoader:
         assert catalog == expected_catalog
 
     @pytest.mark.usefixtures("proj_catalog_globals", "catalog_with_jinja2_syntax")
-    def test_catalog_with_jinja2_syntax_and_globals_file(self, tmp_path, template_config):
+    def test_catalog_with_jinja2_syntax_and_globals_file(self, tmp_path):
         """Test catalog with jinja2 syntax with globals yaml file"""
         proj_catalog = tmp_path / _DEFAULT_RUN_ENV / "catalog.yml"
         _write_yaml(proj_catalog, {})
         config_loader = TemplatedConfigLoader(
-            str(tmp_path), globals_pattern="*globals.yml",
+            str(tmp_path),
+            globals_pattern="*globals.yml",
         )
         config_loader.default_run_env = ""
         catalog = config_loader.get("catalog*.yml")


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/issues/1437

## Development notes
1. Added a test that uses both `jinja2` and a `globals.yml` file. We had a test in place to check `jinja2` but it made use of the `globals_dict` to fill in the template. 
2. Fixed TemplatedConfigLoader to make above test work
3. Checked the new fixed TemplatedConfigLoader works on the kedro-viz demo-project

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [X] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1484"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

