### PR TITLE
Reduce Kedro package size by removing docs from it

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -85,10 +85,12 @@ def info():
 
 @cli.command(short_help="See the kedro API docs and introductory tutorial.")
 def docs():
-    """Display the API docs and introductory tutorial in the browser,
-    using the packaged HTML doc files."""
-    html_path = str((Path(__file__).parent.parent / "html" / "index.html").resolve())
-    index_path = f"file://{html_path}"
+    deprecation_message = (
+        "DeprecationWarning: Command `kedro docs` is deprecated in 0.18.1 and will not be available from 0.19.0."
+    )
+    click.secho(deprecation_message, fg="red")
+    """Display the online API docs and introductory tutorial in the browser."""
+    index_path = f"https://kedro.readthedocs.io/en/{version}"
     click.echo(f"Opening {index_path}")
     webbrowser.open(index_path)
 

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,6 @@ with open("test_requirements.txt", encoding="utf-8") as f:
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
-doc_html_files = [
-    name.replace("kedro/", "", 1)
-    for name in glob("kedro/framework/html/**/*", recursive=True)
-]
-
 template_files = []
 for pattern in ["**/*", "**/.*", "**/.*/**", "**/.*/.**"]:
     template_files.extend(
@@ -165,7 +160,7 @@ setup(
     author="Kedro",
     entry_points={"console_scripts": ["kedro = kedro.framework.cli:main"]},
     package_data={
-        name: ["py.typed", "test_requirements.txt"] + template_files + doc_html_files
+        name: ["py.typed", "test_requirements.txt"] + template_files
     },
     zip_safe=False,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering",


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->
Kedro 0.18.0 is 112MB unpackaged, and 111MB of that is just from docs. For faster installations and reducing disk usage, this PR will remove docs from kedro package and alias `kedro docs` cli to point to the corresponding online version.

Related issue: https://github.com/kedro-org/kedro/issues/1410

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
