### PR TITLE
Add `config_loader` as `KedroContext` property

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -22,6 +22,7 @@
 * Introduced `after_command_run` CLI hook.
 * Update sections on visualisation, namespacing, and experiment tracking in the spaceflight tutorial to correspond to the complete spaceflights starter.
 * Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`.
+* `config_loader` is available as public attribute of `KedroContext`.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/docs/source/tools_integration/pyspark.md
+++ b/docs/source/tools_integration/pyspark.md
@@ -51,7 +51,7 @@ class CustomContext(KedroContext):
         """Initialises a SparkSession using the config defined in project's conf folder."""
 
         # Load the spark configuration in spark.yaml using the config loader
-        parameters = self._config_loader.get("spark*", "spark*/**")
+        parameters = self.config_loader.get("spark*", "spark*/**")
         spark_conf = SparkConf().setAll(parameters.items())
 
         # Initialise the spark session

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -241,7 +241,7 @@ class KedroContext:
         """
         try:
             # '**/parameters*' reads modular pipeline configs
-            params = self._config_loader.get(
+            params = self.config_loader.get(
                 "parameters*", "parameters*/**", "**/parameters*"
             )
         except MissingConfigException as exc:
@@ -249,6 +249,17 @@ class KedroContext:
             params = {}
         _update_nested_dict(params, self._extra_params or {})
         return params
+
+    @property
+    def config_loader(self):
+        """Read-only property referring to Kedro's ``ConfigLoader`` for this
+        context.
+        Returns:
+            Instance of `ConfigLoader`.
+        Raises:
+            KedroContextError: Incorrect ``ConfigLoader`` registered for the project.
+        """
+        return self._config_loader
 
     def _get_catalog(
         self,
@@ -264,7 +275,7 @@ class KedroContext:
 
         """
         # '**/catalog*' reads modular pipeline configs
-        conf_catalog = self._config_loader.get("catalog*", "catalog*/**", "**/catalog*")
+        conf_catalog = self.config_loader.get("catalog*", "catalog*/**", "**/catalog*")
         # turn relative paths in conf_catalog into absolute paths
         # before initializing the catalog
         conf_catalog = _convert_paths_to_absolute_posix(
@@ -326,7 +337,7 @@ class KedroContext:
     def _get_config_credentials(self) -> Dict[str, Any]:
         """Getter for credentials specified in credentials directory."""
         try:
-            conf_creds = self._config_loader.get(
+            conf_creds = self.config_loader.get(
                 "credentials*", "credentials*/**", "**/credentials*"
             )
         except MissingConfigException as exc:

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -239,7 +239,7 @@ class TestKedroContext:
         assert dummy_context.project_path == tmp_path.resolve()
 
     def test_get_catalog_always_using_absolute_path(self, dummy_context):
-        config_loader = dummy_context._config_loader
+        config_loader = dummy_context.config_loader
         conf_catalog = config_loader.get("catalog*")
 
         # even though the raw configuration uses relative path


### PR DESCRIPTION
Signed-off-by: noklam <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Related to https://github.com/kedro-org/kedro/issues/1459.

This PR was originally part of this PR https://github.com/kedro-org/kedro/pull/1465/commits/52fdaf4180c33e8b2678e0d17a9a822911ba9122, but it is separated out as a standalone PR as this is more urgent.

Base on our previous discussion, `config_loader` should be a public property and this PR patch this property back.

## Development notes
<!-- What have you changed, and how has this been tested? -->
* Add `config_loader` as a property

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
