### PR TITLE
Fix CI issues with python 3.10 builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 
-#  the default pipeline parameters, which will be updated according to
+# the default pipeline parameters, which will be updated according to
 # the results of the path-filtering orb
 parameters:
   code_change:

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 
-# the default pipeline parameters, which will be updated according to
+#  the default pipeline parameters, which will be updated according to
 # the results of the path-filtering orb
 parameters:
   code_change:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,14 +13,10 @@ dill~=0.3.1
 filelock>=3.4.0, <4.0
 gcsfs>=2021.4, <=2022.1
 geopandas>=0.6.0, <1.0
-h5py~=3.6
 hdfs>=2.5.8, <3.0
 holoviews~=1.13.0
-identify~=2.5
 import-linter[toml]==1.2.6
-importlib_metadata~=4.11
 ipython>=7.31.1, <8.0
-isort~=5.10
 Jinja2<3.1.0
 joblib>=0.14
 jupyterlab~=3.0
@@ -39,10 +35,10 @@ pandas-gbq>=0.12.0, <1.0
 pandas~=1.3  # 1.3 for read_xml/to_xml
 Pillow~=9.0
 plotly>=4.8.0, <6.0
-pre-commit~=2.19
+pre-commit~=1.17
 psutil==5.8.0
 pyarrow>=1.0, <7.0
-pylint==2.13.7
+pylint>=2.5.2, <3.0
 pyproj~=3.0
 pyspark>=2.2, <4.0
 pytest-cov~=3.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -31,7 +31,7 @@ matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
 moto==1.3.7; python_version < '3.10'
 moto==3.0.4; python_version == '3.10'
-nbconvert>=5.3.1, <6.0
+nbconvert~=6.0
 nbformat~=5.0
 networkx~=2.4
 openpyxl>=3.0.3, <4.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -13,10 +13,14 @@ dill~=0.3.1
 filelock>=3.4.0, <4.0
 gcsfs>=2021.4, <=2022.1
 geopandas>=0.6.0, <1.0
+h5py~=3.6
 hdfs>=2.5.8, <3.0
 holoviews~=1.13.0
+identify~=2.5
 import-linter[toml]==1.2.6
+importlib_metadata~=4.11
 ipython>=7.31.1, <8.0
+isort~=5.10
 Jinja2<3.1.0
 joblib>=0.14
 jupyterlab~=3.0
@@ -28,17 +32,17 @@ memory_profiler>=0.50.0, <1.0
 moto==1.3.7; python_version < '3.10'
 moto==3.0.4; python_version == '3.10'
 nbconvert>=5.3.1, <6.0
-nbformat~=4.4
+nbformat~=5.0
 networkx~=2.4
 openpyxl>=3.0.3, <4.0
 pandas-gbq>=0.12.0, <1.0
 pandas~=1.3  # 1.3 for read_xml/to_xml
 Pillow~=9.0
 plotly>=4.8.0, <6.0
-pre-commit~=1.17
+pre-commit~=2.19
 psutil==5.8.0
 pyarrow>=1.0, <7.0
-pylint>=2.5.2, <3.0
+pylint==2.13.7
 pyproj~=3.0
 pyspark>=2.2, <4.0
 pytest-cov~=3.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -27,8 +27,6 @@ matplotlib>=3.5, <3.6; python_version == '3.10'
 memory_profiler>=0.50.0, <1.0
 moto==1.3.7; python_version < '3.10'
 moto==3.0.4; python_version == '3.10'
-nbconvert~=6.0
-nbformat~=5.0
 networkx~=2.4
 openpyxl>=3.0.3, <4.0
 pandas-gbq>=0.12.0, <1.0


### PR DESCRIPTION
## Description
The python 3.10 builds all started failing because pip couldn't finish resolving dependencies.

## Development notes
I've tried pinning and updating several package versions. Eventually pinning `nbconvert~=6.0` and `nbformat~=5.0` seemed to do the trick.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1507"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

