### PR TITLE
Remove `kedro docs` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
 install: build-docs
-	rm -rf kedro/framework/html
-	cp -r docs/build/html kedro/framework
 	pip install .
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-install: build-docs
+install:
 	pip install .
 
 clean:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@
 * Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`.
 
 ## Upcoming deprecations for Kedro 0.19.0
-
+* `kedro docs` will be deprecated in 0.19.0.
 
 # Release 0.18.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -24,7 +24,7 @@
 * Fixed `Jinja2` syntax loading with `TemplatedConfigLoader` using `globals.yml`.
 
 ## Upcoming deprecations for Kedro 0.19.0
-* `kedro docs` will be deprecated in 0.19.0.
+* `kedro docs` will be removed in 0.19.0.
 
 # Release 0.18.0
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -53,7 +53,6 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
 * Global Kedro commands
   * [`kedro --help`](#get-help-on-kedro-commands)
   * [`kedro --version`](#confirm-the-kedro-version)
-  * [`kedro docs`](#open-the-kedro-documentation-in-your-browser)
   * [`kedro info`](#confirm-kedro-information)
   * [`kedro new`](#create-a-new-kedro-project)
 
@@ -129,12 +128,6 @@ kedro_viz: 3.4.0 (hooks:global,line_magic)
 
 ```bash
 kedro new
-```
-
-### Open the Kedro documentation in your browser
-
-```bash
-kedro docs
 ```
 
 ## Customise or Override Project-specific Kedro commands

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -4,7 +4,6 @@ This module implements commands available from the kedro CLI.
 """
 import importlib
 import sys
-import webbrowser
 from collections import defaultdict
 from pathlib import Path
 from typing import Sequence

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -85,10 +85,12 @@ def info():
 
 @cli.command(short_help="See the kedro API docs and introductory tutorial.")
 def docs():
-    """Display the API docs and introductory tutorial in the browser,
-    using the packaged HTML doc files."""
-    html_path = str((Path(__file__).parent.parent / "html" / "index.html").resolve())
-    index_path = f"file://{html_path}"
+    deprecation_message = (
+        "DeprecationWarning: Command `kedro docs` is deprecated in 0.18.1 and will not be available from 0.19.0."
+    )
+    click.secho(deprecation_message, fg="red")
+    """Display the online API docs and introductory tutorial in the browser."""
+    index_path = f"https://kedro.readthedocs.io/en/{version}"
     click.echo(f"Opening {index_path}")
     webbrowser.open(index_path)
 

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -83,19 +83,6 @@ def info():
         click.echo("No plugins installed")
 
 
-@cli.command(short_help="See the kedro API docs and introductory tutorial.")
-def docs():
-    """Display the online API docs and introductory tutorial in the browser. (DEPRECATED)"""
-    deprecation_message = (
-        "DeprecationWarning: Command `kedro docs` is deprecated and "
-        "will not be available from 0.19.0."
-    )
-    click.secho(deprecation_message, fg="red")
-    index_path = f"https://kedro.readthedocs.io/en/{version}"
-    click.echo(f"Opening {index_path}")
-    webbrowser.open(index_path)
-
-
 def _init_plugins():
     group = ENTRY_POINT_GROUPS["init"]
     for entry_point in pkg_resources.iter_entry_points(group=group):

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -85,11 +85,12 @@ def info():
 
 @cli.command(short_help="See the kedro API docs and introductory tutorial.")
 def docs():
+    """Display the online API docs and introductory tutorial in the browser."""
     deprecation_message = (
-        "DeprecationWarning: Command `kedro docs` is deprecated in 0.18.1 and will not be available from 0.19.0."
+        "DeprecationWarning: Command `kedro docs` is deprecated in 0.18.1 and "
+        "will not be available from 0.19.0."
     )
     click.secho(deprecation_message, fg="red")
-    """Display the online API docs and introductory tutorial in the browser."""
     index_path = f"https://kedro.readthedocs.io/en/{version}"
     click.echo(f"Opening {index_path}")
     webbrowser.open(index_path)

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -85,9 +85,9 @@ def info():
 
 @cli.command(short_help="See the kedro API docs and introductory tutorial.")
 def docs():
-    """Display the online API docs and introductory tutorial in the browser."""
+    """Display the online API docs and introductory tutorial in the browser. (DEPRECATED)"""
     deprecation_message = (
-        "DeprecationWarning: Command `kedro docs` is deprecated in 0.18.1 and "
+        "DeprecationWarning: Command `kedro docs` is deprecated and "
         "will not be available from 0.19.0."
     )
     click.secho(deprecation_message, fg="red")

--- a/setup.py
+++ b/setup.py
@@ -37,11 +37,6 @@ with open("test_requirements.txt", encoding="utf-8") as f:
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     readme = f.read()
 
-doc_html_files = [
-    name.replace("kedro/", "", 1)
-    for name in glob("kedro/framework/html/**/*", recursive=True)
-]
-
 template_files = []
 for pattern in ["**/*", "**/.*", "**/.*/**", "**/.*/.**"]:
     template_files.extend(
@@ -165,7 +160,7 @@ setup(
     author="Kedro",
     entry_points={"console_scripts": ["kedro = kedro.framework.cli:main"]},
     package_data={
-        name: ["py.typed", "test_requirements.txt"] + template_files + doc_html_files
+        name: ["py.typed", "test_requirements.txt"] + template_files
     },
     zip_safe=False,
     keywords="pipelines, machine learning, data pipelines, data science, data engineering",

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1,6 +1,5 @@
 from collections import namedtuple
 from itertools import cycle
-from os.path import join
 from pathlib import Path
 from unittest.mock import patch
 
@@ -124,7 +123,7 @@ class TestCliCommands:
         assert "-h, --help     Show this message and exit." in result.output
 
     @patch("webbrowser.open")
-    def test_docs(self, patched_browser):
+    def test_docs(self):
         """Check that `kedro docs` opens a correct file in the browser."""
         result = CliRunner().invoke(cli, ["docs"])
 

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from itertools import cycle
 from pathlib import Path
-from unittest.mock import patch
 
 import anyconfig
 import click

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -122,7 +122,6 @@ class TestCliCommands:
         assert result.exit_code == 0
         assert "-h, --help     Show this message and exit." in result.output
 
-    @patch("webbrowser.open")
     def test_docs(self):
         """Check that `kedro docs` opens a correct file in the browser."""
         result = CliRunner().invoke(cli, ["docs"])

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -129,13 +129,6 @@ class TestCliCommands:
         result = CliRunner().invoke(cli, ["docs"])
 
         assert result.exit_code == 0
-        for each in ("Opening file", join("html", "index.html")):
-            assert each in result.output
-
-        assert patched_browser.call_count == 1
-        args, _ = patched_browser.call_args
-        for each in ("file://", join("kedro", "framework", "html", "index.html")):
-            assert each in args[0]
 
 
 class TestCommandCollection:

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -121,12 +121,6 @@ class TestCliCommands:
         assert result.exit_code == 0
         assert "-h, --help     Show this message and exit." in result.output
 
-    def test_docs(self):
-        """Check that `kedro docs` opens a correct file in the browser."""
-        result = CliRunner().invoke(cli, ["docs"])
-
-        assert result.exit_code == 0
-
 
 class TestCommandCollection:
     def test_found(self):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Related to: https://github.com/kedro-org/kedro/pull/1500

Since `kedro docs` will be deprecated we will remove it in this PR for `Kedro 0.19.0`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1510"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

