### PR TITLE
Make win_pip_compile-3.10 and win_unit_tests-3.10 not required

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -560,13 +560,22 @@ workflows:
       - docs_linkcheck
       - all_circleci_checks_succeeded:
           requires:
+            # win_pip_compile-3.10 and win_unit_tests-3.10 and not required currently 
+            # due to failing requirements installation. 
+            # See https://github.com/kedro-org/kedro/issues/1517
             - e2e_tests
             - win_e2e_tests
             - unit_tests
-            - win_unit_tests
+            # - win_unit_tests
+            - win_unit_tests-3.7
+            - win_unit_tests-3.8
+            - win_unit_tests-3.9
             - lint
             - pip_compile
-            - win_pip_compile
+            # - win_pip_compile
+            - win_pip_compile-3.7
+            - win_pip_compile-3.8
+            - win_pip_compile-3.9
             - build_docs
             - docs_linkcheck
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -560,8 +560,8 @@ workflows:
       - docs_linkcheck
       - all_circleci_checks_succeeded:
           requires:
-            # win_pip_compile-3.10 and win_unit_tests-3.10 and not required currently 
-            # due to failing requirements installation. 
+            # win_pip_compile-3.10 and win_unit_tests-3.10 and not required currently
+            # due to failing requirements installation.
             # See https://github.com/kedro-org/kedro/issues/1517
             - e2e_tests
             - win_e2e_tests


### PR DESCRIPTION
## Description
`win_pip_compile-3.10` and `win_unit_tests-3.10` have been failing for a while, meaning we need to force merge everything. I've made them not required for now and opened an issue to fix them: #1517.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1518"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

