### PR TITLE
Remove `kedro docs` command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 
 ## Breaking changes to the API
 
+### CLI
+* Removed deprecated`kedro docs` cli command.
+
 ## Migration guide from Kedro 0.18.* to 0.19.*
 
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -53,7 +53,6 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
 * Global Kedro commands
   * [`kedro --help`](#get-help-on-kedro-commands)
   * [`kedro --version`](#confirm-the-kedro-version)
-  * [`kedro docs`](#open-the-kedro-documentation-in-your-browser)
   * [`kedro info`](#confirm-kedro-information)
   * [`kedro new`](#create-a-new-kedro-project)
 
@@ -129,12 +128,6 @@ kedro_viz: 3.4.0 (hooks:global,line_magic)
 
 ```bash
 kedro new
-```
-
-### Open the Kedro documentation in your browser
-
-```bash
-kedro docs
 ```
 
 ## Customise or Override Project-specific Kedro commands

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -4,7 +4,6 @@ This module implements commands available from the kedro CLI.
 """
 import importlib
 import sys
-import webbrowser
 from collections import defaultdict
 from pathlib import Path
 from typing import Sequence
@@ -81,19 +80,6 @@ def info():
             )
     else:
         click.echo("No plugins installed")
-
-
-@cli.command(short_help="See the kedro API docs and introductory tutorial.")
-def docs():
-    """Display the online API docs and introductory tutorial in the browser. (DEPRECATED)"""
-    deprecation_message = (
-        "DeprecationWarning: Command `kedro docs` is deprecated and "
-        "will not be available from Kedro 0.19.0."
-    )
-    click.secho(deprecation_message, fg="red")
-    index_path = f"https://kedro.readthedocs.io/en/{version}"
-    click.echo(f"Opening {index_path}")
-    webbrowser.open(index_path)
 
 
 def _init_plugins():

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1,7 +1,6 @@
 from collections import namedtuple
 from itertools import cycle
 from pathlib import Path
-from unittest.mock import patch
 
 import anyconfig
 import click
@@ -121,18 +120,6 @@ class TestCliCommands:
         result = CliRunner().invoke(cli, ["-h"])
         assert result.exit_code == 0
         assert "-h, --help     Show this message and exit." in result.output
-
-    @patch("webbrowser.open")
-    def test_docs(self, patched_browser):
-        """Check that `kedro docs` opens a correct file in the browser."""
-        result = CliRunner().invoke(cli, ["docs"])
-
-        assert result.exit_code == 0
-        expected = f"https://kedro.readthedocs.io/en/{version}"
-
-        assert patched_browser.call_count == 1
-        args, _ = patched_browser.call_args
-        assert expected in args[0]
 
 
 class TestCommandCollection:


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->

Related to: https://github.com/kedro-org/kedro/pull/1500

Since `kedro docs` will be deprecated we will remove it in this PR for Kedro 0.19.0.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
