### PR TITLE
feat: pass globals as context to jinja2 template

### DIFF
--- a/kedro/config/templated_config.py
+++ b/kedro/config/templated_config.py
@@ -159,7 +159,10 @@ class TemplatedConfigLoader(AbstractConfigLoader):
             ValueError: malformed config found.
         """
         config_raw = _get_config_from_patterns(
-            conf_paths=self.conf_paths, patterns=patterns, ac_template=True
+            conf_paths=self.conf_paths,
+            patterns=patterns,
+            ac_template=True,
+            ac_context=self._config_mapping,
         )
         return _format_object(config_raw, self._config_mapping)
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

When configuring with jinja2 templates, I don't want variables embedded in templates as a source of authority. 

Therefore, I have threaded through globals dict as context for configuration templates.

## Development notes
<!-- What have you changed, and how has this been tested? -->

I have changed `templated_config.py` and `common.py` to pass globals dictionary.

Unfortunately, I have not pushed a test (the code is working for me); nor have I added documentation. If you accept the concept, I can improve the PR.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1529"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

