### PR TITLE
Add deprecation warning to `ColorHandler`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,12 +10,11 @@
 * `kedro docs` will be removed in 0.19.0.
 * `kedro.extras.ColorHandler` will be removed in 0.19.0.
 
-
 ## Migration guide from Kedro 0.18.* to 0.19.*
+
 # Upcoming Release 0.18.2
 
 ## Major features and improvements
-
 
 ## Bug fixes and other changes
 * Updated Starter template to use `myst_parser` instead of `recommonmark`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,7 +32,7 @@
 
 ## Upcoming deprecations for Kedro 0.19.0
 * `kedro docs` will be removed in 0.19.0.
-* `kedro.extras.ColorHandler` is being deprecated.
+* `kedro.extras.ColorHandler` will be removed in 0.19.0.
 
 # Release 0.18.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -32,6 +32,7 @@
 
 ## Upcoming deprecations for Kedro 0.19.0
 * `kedro docs` will be removed in 0.19.0.
+* `kedro.extras.ColorHandler` is being deprecated.
 
 # Release 0.18.0
 

--- a/kedro/extras/logging/__init__.py
+++ b/kedro/extras/logging/__init__.py
@@ -10,6 +10,6 @@ __all__ = ["ColorHandler"]
 warnings.simplefilter("default", DeprecationWarning)
 
 warnings.warn(
-    "Support for ColorHandler will be deprecated in Kedro 0.19.0.",
+    "Support for ColorHandler will be removed in Kedro 0.19.0.",
     DeprecationWarning,
 )

--- a/kedro/extras/logging/__init__.py
+++ b/kedro/extras/logging/__init__.py
@@ -1,7 +1,15 @@
 """
 This module contains a logging handler class which produces coloured logs.
 """
+import warnings
 
 from .color_logger import ColorHandler
 
 __all__ = ["ColorHandler"]
+
+warnings.simplefilter("default", DeprecationWarning)
+
+warnings.warn(
+    "Support for ColorHandler will be deprecated in Kedro 0.19.0.",
+    DeprecationWarning,
+)


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->
RichHandler will become the default logger, we need to remove the ColorHandler provided in `kedro.extras.logging` for Kedro 0.19.0. This PR will add deprecation warnings to warn users of this fact.

Related Issue: https://github.com/kedro-org/kedro/issues/1515

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1535"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

