### PR TITLE
Add deprecations for 0.19.0 section back to every 0.18.x section

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,10 +6,6 @@
 
 ## Breaking changes to the API
 
-## Upcoming deprecations for Kedro 0.19.0
-* `kedro docs` will be removed in 0.19.0.
-* `kedro.extras.ColorHandler` will be removed in 0.19.0.
-
 ## Migration guide from Kedro 0.18.* to 0.19.*
 
 # Upcoming Release 0.18.2
@@ -18,6 +14,9 @@
 
 ## Bug fixes and other changes
 * Updated Starter template to use `myst_parser` instead of `recommonmark`
+
+## Upcoming deprecations for Kedro 0.19.0
+* `kedro.extras.ColorHandler` will be removed in 0.19.0.
 
 # Release 0.18.1
 
@@ -39,6 +38,9 @@
 * `config_loader` is available as a public read-only attribute of `KedroContext`.
 * Made `hook_manager` argument optional for `runner.run`.
 * `kedro docs` now opens an online version of the Kedro documentation instead of a locally built version.
+
+## Upcoming deprecations for Kedro 0.19.0
+* `kedro docs` will be removed in 0.19.0.
 
 # Release 0.18.0
 


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Every time we add a change that is related to a deprecation for `0.19.0` the "Upcoming deprecations for Kedro 0.19.0" section should be added to the release notes for that upcoming release. So `0.18.1` should have the section, and so should `0.18.2`, and so on.. The section should _not_ be at the top level for "Upcoming release 0.19.0". You can see how it worked for 0.18.0 in all the 0.17.X versions: https://github.com/kedro-org/kedro/blob/main/RELEASE.md

## Development notes

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1548"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

