### PR TITLE
Fix develop vs. main conflict

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@
 ## Bug fixes and other changes
 
 * Bumped `pyyaml` upper-bound to make Kedro compatible with the [pyodide](https://pyodide.org/en/stable/usage/loading-packages.html#micropip) stack.
-* Updated Starter template to use `myst_parser` instead of `recommonmark`
+* Updated project template's Sphinx configuration to use `myst_parser` instead of `recommonmark`.
 * Reduced number of log lines by changing the logging level from `INFO` to `DEBUG` for low priority messages.
 
 ## Upcoming deprecations for Kedro 0.19.0


### PR DESCRIPTION
## Description
We keep on getting conflicts on RELEASE.md. I think this should fix it... Don't know how this line got out of sync between `main` and `develop`.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
