### PR TITLE
Parametrized session_id

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
                 )
 
     - repo: https://github.com/asottile/blacken-docs
-      rev: v1.9.2
+      rev: v1.12.1
       hooks:
           - id: blacken-docs
             additional_dependencies: [black==21.5b1]

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -115,6 +115,7 @@ class KedroSession:
         save_on_close: bool = True,
         env: str = None,
         extra_params: Dict[str, Any] = None,
+        session_id: str = None,
     ) -> "KedroSession":
         """Create a new instance of ``KedroSession`` with the session data.
 
@@ -129,6 +130,7 @@ class KedroSession:
                 for underlying KedroContext. If specified, will update (and therefore
                 take precedence over) the parameters retrieved from the project
                 configuration.
+            session_id: The id of the session.
 
         Returns:
             A new ``KedroSession`` instance.
@@ -136,10 +138,13 @@ class KedroSession:
 
         validate_settings()
 
+        if session_id is None:
+            session_id = generate_timestamp()
+
         session = cls(
             package_name=package_name,
             project_path=project_path,
-            session_id=generate_timestamp(),
+            session_id=session_id,
             save_on_close=save_on_close,
         )
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -810,6 +810,16 @@ class TestKedroSession:
             catalog=mock_catalog,
         )
 
+    @pytest.mark.usefixtures("mock_settings_context_class")
+    def test_custom_name_for_session_id(
+        self, mock_package_name, fake_project, fake_session_id
+    ):
+
+        with KedroSession.create(
+            mock_package_name, fake_project, session_id=fake_session_id
+        ) as session:
+            assert session.session_id == fake_session_id
+
 
 @pytest.fixture
 def fake_project_with_logging_file_handler(fake_project):


### PR DESCRIPTION
## Description

### Use case

I have web application where I use kedro inside of endpoints. This web application has centralized logs, but I'm struggling with tracing which kedro session is executed for which endpoint since application is horizontally scaled.

### How I resolve this one

I add `session_id` argument to `KedroSession.create()` function and then i implemented kedro hooks for logging and linking with endpoints trace id

## Development notes

- [x] Updated `blacken-docs` revision in pre-commit (Resolves #1565)
- [x] Added `session_id` argument to `KedroSession.create()`
- [x] Added test case checking parametrized kedro session

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1571"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

