### PR TITLE
Align formatting of `register_pipelines` docstring

### DIFF
--- a/docs/source/tutorial/create_pipelines.md
+++ b/docs/source/tutorial/create_pipelines.md
@@ -169,8 +169,7 @@ def register_pipelines() -> Dict[str, Pipeline]:
     """Register the project's pipeline.
 
     Returns:
-    A mapping from a pipeline name to a ``Pipeline`` object.
-
+        A mapping from a pipeline name to a ``Pipeline`` object.
     """
     data_processing_pipeline = dp.create_pipeline()
 


### PR DESCRIPTION
Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
I noticed that the formatting of `register_pipelines` was not the same as output by the template when creating a new pipeline, and the indentation is generally not correct.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1582"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

