### PR TITLE
Replace backticks with single quotes

### DIFF
--- a/features/ipython.feature
+++ b/features/ipython.feature
@@ -6,5 +6,5 @@ Feature: IPython target in new project
     When I execute the kedro command "ipython"
     Then I should get a message including "An enhanced Interactive Python"
     And I should get a message including "Kedro project project-dummy"
-    And I should get a message including "Defined global variable `context`,"
-    And I should get a message including "`session`, `catalog` and `pipelines`"
+    And I should get a message including "Defined global variable 'context',"
+    And I should get a message including "'session', 'catalog' and 'pipelines'"

--- a/kedro/config/common.py
+++ b/kedro/config/common.py
@@ -57,7 +57,7 @@ def _get_config_from_patterns(
 
     if not patterns:
         raise ValueError(
-            "`patterns` must contain at least one glob "
+            "'patterns' must contain at least one glob "
             "pattern to match config filenames against."
         )
 

--- a/kedro/config/common.py
+++ b/kedro/config/common.py
@@ -82,7 +82,7 @@ def _get_config_from_patterns(
         if common_keys:
             sorted_keys = ", ".join(sorted(common_keys))
             msg = (
-                "Config from path `%s` will override the following "
+                "Config from path '%s' will override the following "
                 "existing top-level config keys: %s"
             )
             _config_logger.info(msg, conf_path, sorted_keys)

--- a/kedro/extras/datasets/holoviews/holoviews_writer.py
+++ b/kedro/extras/datasets/holoviews/holoviews_writer.py
@@ -107,7 +107,7 @@ class HoloviewsWriter(AbstractVersionedDataSet):
         )
 
     def _load(self) -> str:
-        raise DataSetError(f"Loading not supported for `{self.__class__.__name__}`")
+        raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(self, data: HoloViews) -> None:
         bytes_buffer = io.BytesIO()

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -154,7 +154,7 @@ class MatplotlibWriter(AbstractVersionedDataSet):
         )
 
     def _load(self) -> None:
-        raise DataSetError(f"Loading not supported for `{self.__class__.__name__}`")
+        raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(
         self, data: Union[plt.figure, List[plt.figure], Dict[str, plt.figure]]

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -138,9 +138,9 @@ class MatplotlibWriter(AbstractVersionedDataSet):
 
         if overwrite and version is not None:
             warn(
-                "Setting `overwrite=True` is ineffective if versioning "
+                "Setting 'overwrite=True' is ineffective if versioning "
                 "is enabled, since the versioned path must not already "
-                "exist; overriding flag with `overwrite=False` instead."
+                "exist; overriding flag with 'overwrite=False' instead."
             )
             overwrite = False
         self._overwrite = overwrite

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -134,8 +134,8 @@ class CSVDataSet(AbstractVersionedDataSet):
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -143,13 +143,13 @@ class ExcelDataSet(AbstractVersionedDataSet):
 
         if version and self._writer_args.get("mode") == "a":  # type: ignore
             raise DataSetError(
-                "`ExcelDataSet` doesn't support versioning in append mode."
+                "'ExcelDataSet' doesn't support versioning in append mode."
             )
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -113,8 +113,8 @@ class FeatherDataSet(AbstractVersionedDataSet):
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -164,7 +164,7 @@ class GBQTableDataSet(AbstractDataSet):
 
         if save_location != load_location:
             raise DataSetError(
-                """ "load_args['location']" is different from "save_args['location']". """
+                """"load_args['location']" is different from "save_args['location']". """
                 "The 'location' defines where BigQuery data is stored, therefore has "
                 "to be the same for save and load args. "
                 "Details: https://cloud.google.com/bigquery/docs/locations"

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -164,8 +164,8 @@ class GBQTableDataSet(AbstractDataSet):
 
         if save_location != load_location:
             raise DataSetError(
-                "`load_args['location']` is different from `save_args['location']`. "
-                "The `location` defines where BigQuery data is stored, therefore has "
+                """ "load_args['location']" is different from "save_args['location']". """
+                "The 'location' defines where BigQuery data is stored, therefore has "
                 "to be the same for save and load args. "
                 "Details: https://cloud.google.com/bigquery/docs/locations"
             )
@@ -242,13 +242,13 @@ class GBQQueryDataSet(AbstractDataSet):
         """
         if sql and filepath:
             raise DataSetError(
-                "`sql` and `filepath` arguments cannot both be provided."
+                "'sql' and 'filepath' arguments cannot both be provided."
                 "Please only provide one."
             )
 
         if not (sql or filepath):
             raise DataSetError(
-                "`sql` and `filepath` arguments cannot both be empty."
+                "'sql' and 'filepath' arguments cannot both be empty."
                 "Please provide a sql query or path to a sql query file."
             )
 
@@ -307,4 +307,4 @@ class GBQQueryDataSet(AbstractDataSet):
         )
 
     def _save(self, data: pd.DataFrame) -> None:
-        raise DataSetError("`save` is not supported on GBQQueryDataSet")
+        raise DataSetError("'save' is not supported on GBQQueryDataSet")

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -176,7 +176,7 @@ class GenericDataSet(AbstractVersionedDataSet):
         # Fail fast if provided a known non-filesystem target
         if self._file_format in NON_FILE_SYSTEM_TARGETS:
             raise DataSetError(
-                f"Cannot create a dataset of file_format `{self._file_format}` as it "
+                f"Cannot create a dataset of file_format '{self._file_format}' as it "
                 f"does not support a filepath target/source."
             )
 
@@ -190,7 +190,7 @@ class GenericDataSet(AbstractVersionedDataSet):
             with self._fs.open(load_path, **self._fs_open_args_load) as fs_file:
                 return load_method(fs_file, **self._load_args)
         raise DataSetError(
-            f"Unable to retrieve `pandas.read_{self._file_format}` method, please ensure that your "
+            f"Unable to retrieve 'pandas.read_{self._file_format}' method, please ensure that your "
             "'file_format' parameter has been defined correctly as per the Pandas API "
             "https://pandas.pydata.org/docs/reference/io.html"
         )
@@ -208,7 +208,7 @@ class GenericDataSet(AbstractVersionedDataSet):
                 self._invalidate_cache()
         else:
             raise DataSetError(
-                f"Unable to retrieve `pandas.DataFrame.to_{self._file_format}` method, please "
+                f"Unable to retrieve 'pandas.DataFrame.to_{self._file_format}' method, please "
                 "ensure that your 'file_format' parameter has been defined correctly as "
                 "per the Pandas API "
                 "https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html"

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -125,8 +125,8 @@ class JSONDataSet(AbstractVersionedDataSet):
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -141,8 +141,8 @@ class ParquetDataSet(AbstractVersionedDataSet):
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)
@@ -198,7 +198,7 @@ class ParquetDataSet(AbstractVersionedDataSet):
         if "partition_cols" in self._save_args:
             raise DataSetError(
                 f"{self.__class__.__name__} does not support save argument "
-                f"`partition_cols`. Please use `kedro.io.PartitionedDataSet` instead."
+                f"'partition_cols'. Please use 'kedro.io.PartitionedDataSet' instead."
             )
 
         bytes_buffer = BytesIO()

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -191,11 +191,11 @@ class SQLTableDataSet(AbstractDataSet):
         """
 
         if not table_name:
-            raise DataSetError("`table_name` argument cannot be empty.")
+            raise DataSetError("'table_name' argument cannot be empty.")
 
         if not (credentials and "con" in credentials and credentials["con"]):
             raise DataSetError(
-                "`con` argument cannot be empty. Please "
+                "'con' argument cannot be empty. Please "
                 "provide a SQLAlchemy connection string."
             )
 
@@ -352,19 +352,19 @@ class SQLQueryDataSet(AbstractDataSet):
         """
         if sql and filepath:
             raise DataSetError(
-                "`sql` and `filepath` arguments cannot both be provided."
+                "'sql' and 'filepath' arguments cannot both be provided."
                 "Please only provide one."
             )
 
         if not (sql or filepath):
             raise DataSetError(
-                "`sql` and `filepath` arguments cannot both be empty."
+                "'sql' and 'filepath' arguments cannot both be empty."
                 "Please provide a sql query or path to a sql query file."
             )
 
         if not (credentials and "con" in credentials and credentials["con"]):
             raise DataSetError(
-                "`con` argument cannot be empty. Please "
+                "'con' argument cannot be empty. Please "
                 "provide a SQLAlchemy connection string."
             )
 
@@ -430,4 +430,4 @@ class SQLQueryDataSet(AbstractDataSet):
         return pd.read_sql_query(con=engine, **load_args)
 
     def _save(self, data: pd.DataFrame) -> None:
-        raise DataSetError("`save` is not supported on SQLQueryDataSet")
+        raise DataSetError("'save' is not supported on SQLQueryDataSet")

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -109,8 +109,8 @@ class XMLDataSet(AbstractVersionedDataSet):
 
         if "storage_options" in self._save_args or "storage_options" in self._load_args:
             logger.warning(
-                "Dropping `storage_options` for %s, "
-                "please specify them under `fs_args` or `credentials`.",
+                "Dropping 'storage_options' for %s, "
+                "please specify them under 'fs_args' or 'credentials'.",
                 self._filepath,
             )
             self._save_args.pop("storage_options", None)

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -158,7 +158,7 @@ class PickleDataSet(AbstractVersionedDataSet):
         ):
             raise ValueError(
                 f"Selected backend '{backend}' should satisfy the pickle interface. "
-                "Missing one of `load` and `dump` on the backend."
+                "Missing one of 'load' and 'dump' on the backend."
             )
 
         _fs_args = deepcopy(fs_args) or {}

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -125,7 +125,7 @@ class PickleDataSet(AbstractDataSet):
         ):
             raise ValueError(
                 f"Selected backend '{backend}' should satisfy the pickle interface. "
-                "Missing one of `loads` and `dumps` on the backend."
+                "Missing one of 'loads' and 'dumps' on the backend."
             )
 
         self._backend = backend

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -288,7 +288,7 @@ class SparkDataSet(AbstractVersionedDataSet):
         elif fs_prefix == "hdfs://" and version:
             warn(
                 f"HDFS filesystem support for versioned {self.__class__.__name__} is "
-                f"in beta and uses `hdfs.client.InsecureClient`, please use with "
+                f"in beta and uses 'hdfs.client.InsecureClient', please use with "
                 f"caution"
             )
 

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -276,8 +276,8 @@ class SparkDataSet(AbstractVersionedDataSet):
         if fs_prefix in ("s3a://", "s3n://"):
             if fs_prefix == "s3n://":
                 warn(
-                    "`s3n` filesystem has now been deprecated by Spark, "
-                    "please consider switching to `s3a`",
+                    "'s3n' filesystem has now been deprecated by Spark, "
+                    "please consider switching to 's3a'",
                     DeprecationWarning,
                 )
             _s3 = S3FileSystem(**credentials)
@@ -341,8 +341,8 @@ class SparkDataSet(AbstractVersionedDataSet):
         filepath = schema.get("filepath")
         if not filepath:
             raise DataSetError(
-                "Schema load argument does not specify a `filepath` attribute. Please"
-                "include a path to a JSON serialized `pyspark.sql.types.StructType`."
+                "Schema load argument does not specify a 'filepath' attribute. Please"
+                "include a path to a JSON serialized 'pyspark.sql.types.StructType'."
             )
 
         credentials = deepcopy(schema.get("credentials")) or {}
@@ -358,8 +358,8 @@ class SparkDataSet(AbstractVersionedDataSet):
                 return StructType.fromJson(json.loads(fs_file.read()))
             except Exception as exc:
                 raise DataSetError(
-                    f"Contents of `schema.filepath` ({schema_path}) are invalid. Please"
-                    f"provide a valid JSON serialized `pyspark.sql.types.StructType`."
+                    f"Contents of 'schema.filepath' ({schema_path}) are invalid. Please"
+                    f"provide a valid JSON serialized 'pyspark.sql.types.StructType'."
                 ) from exc
 
     def _describe(self) -> Dict[str, Any]:
@@ -412,7 +412,7 @@ class SparkDataSet(AbstractVersionedDataSet):
             and write_mode not in supported_modes
         ):
             raise DataSetError(
-                f"It is not possible to perform `save()` for file format `delta` "
-                f"with mode `{write_mode}` on `SparkDataSet`. "
-                f"Please use `spark.DeltaTableDataSet` instead."
+                f"It is not possible to perform 'save()' for file format 'delta' "
+                f"with mode '{write_mode}' on 'SparkDataSet'. "
+                f"Please use 'spark.DeltaTableDataSet' instead."
             )

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -100,11 +100,11 @@ class SparkHiveDataSet(AbstractDataSet):
         if write_mode not in _write_modes:
             valid_modes = ", ".join(_write_modes)
             raise DataSetError(
-                f"Invalid `write_mode` provided: {write_mode}. "
-                f"`write_mode` must be one of: {valid_modes}"
+                f"Invalid 'write_mode' provided: {write_mode}. "
+                f"'write_mode' must be one of: {valid_modes}"
             )
         if write_mode == "upsert" and not table_pk:
-            raise DataSetError("`table_pk` must be set to utilise `upsert` read mode")
+            raise DataSetError("'table_pk' must be set to utilise 'upsert' read mode")
 
         self._write_mode = write_mode
         self._table_pk = table_pk or []

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -101,14 +101,14 @@ class SparkJDBCDataSet(AbstractDataSet):
 
         if not url:
             raise DataSetError(
-                "`url` argument cannot be empty. Please "
+                "'url' argument cannot be empty. Please "
                 "provide a JDBC URL of the form "
-                "``jdbc:subprotocol:subname``."
+                "'jdbc:subprotocol:subname'."
             )
 
         if not table:
             raise DataSetError(
-                "`table` argument cannot be empty. Please "
+                "'table' argument cannot be empty. Please "
                 "provide the name of the table to load or save "
                 "data to."
             )
@@ -131,7 +131,7 @@ class SparkJDBCDataSet(AbstractDataSet):
             for cred_key, cred_value in credentials.items():
                 if cred_value is None:
                     raise DataSetError(
-                        f"Credential property `{cred_key}` cannot be None. "
+                        f"Credential property '{cred_key}' cannot be None. "
                         f"Please provide a value."
                     )
 

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -32,4 +32,4 @@ class JSONDataSet(JDS):
     versioned = True
 
     def _load(self) -> Dict:
-        raise DataSetError(f"Loading not supported for `{self.__class__.__name__}`")
+        raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -34,7 +34,7 @@ class MetricsDataSet(JSONDataSet):
     versioned = True
 
     def _load(self) -> Dict:
-        raise DataSetError(f"Loading not supported for `{self.__class__.__name__}`")
+        raise DataSetError(f"Loading not supported for '{self.__class__.__name__}'")
 
     def _save(self, data: Dict[str, float]) -> None:
         """Converts all values in the data from a ``MetricsDataSet`` to float to make sure

--- a/kedro/extras/extensions/ipython.py
+++ b/kedro/extras/extensions/ipython.py
@@ -83,7 +83,7 @@ def reload_kedro(
 
     for line_magic in load_entry_points("line_magic"):
         register_line_magic(needs_local_scope(line_magic))
-        logger.info("Registered line magic `%s`", line_magic.__name__)  # type: ignore
+        logger.info("Registered line magic '%s'", line_magic.__name__)  # type: ignore
 
 
 def load_ipython_extension(ipython):
@@ -102,5 +102,5 @@ def load_ipython_extension(ipython):
     except Exception:  # pylint: disable=broad-except
         logger.warning(
             "Kedro extension was registered but couldn't find a Kedro project. "
-            "Make sure you run `%reload_kedro <path_to_kedro_project>`."
+            "Make sure you run '%reload_kedro <path_to_kedro_project>'."
         )

--- a/kedro/extras/extensions/ipython.py
+++ b/kedro/extras/extensions/ipython.py
@@ -78,7 +78,7 @@ def reload_kedro(
 
     logger.info("Kedro project %s", str(metadata.project_name))
     logger.info(
-        "Defined global variable `context`, `session`, `catalog` and `pipelines`"
+        "Defined global variable 'context', 'session', 'catalog' and 'pipelines'"
     )
 
     for line_magic in load_entry_points("line_magic"):

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -66,7 +66,7 @@ def list_datasets(metadata: ProjectMetadata, pipeline, env):
         else:
             existing_pls = ", ".join(sorted(pipelines.keys()))
             raise KedroCliError(
-                f"`{pipe}` pipeline not found! Existing pipelines: {existing_pls}"
+                f"'{pipe}' pipeline not found! Existing pipelines: {existing_pls}"
             )
 
         unused_ds = catalog_ds - pipeline_ds
@@ -129,7 +129,7 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
     if not pipeline:
         existing_pipelines = ", ".join(sorted(pipelines.keys()))
         raise KedroCliError(
-            f"`{pipeline_name}` pipeline not found! Existing pipelines: {existing_pipelines}"
+            f"'{pipeline_name}' pipeline not found! Existing pipelines: {existing_pipelines}"
         )
 
     pipe_datasets = {

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -89,7 +89,7 @@ def info():
 def docs():
     """Display the online API docs and introductory tutorial in the browser. (DEPRECATED)"""
     deprecation_message = (
-        "DeprecationWarning: Command `kedro docs` is deprecated and "
+        "DeprecationWarning: Command 'kedro docs' is deprecated and "
         "will not be available from Kedro 0.19.0."
     )
     click.secho(deprecation_message, fg="red")

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -272,7 +272,7 @@ def package_micropkg(
         module_path, metadata, alias=alias, destination=destination, env=env
     )
 
-    as_alias = f" as `{alias}`" if alias else ""
+    as_alias = f" as '{alias}'" if alias else ""
     message = (
         f"'{metadata.package_name}.{module_path}' packaged{as_alias}! "
         f"Location: {result_path}"

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -274,7 +274,7 @@ def package_micropkg(
 
     as_alias = f" as `{alias}`" if alias else ""
     message = (
-        f"`{metadata.package_name}.{module_path}` packaged{as_alias}! "
+        f"'{metadata.package_name}.{module_path}' packaged{as_alias}! "
         f"Location: {result_path}"
     )
     click.secho(message, fg="green")

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -109,7 +109,7 @@ def pull_package(  # pylint:disable=unused-argument, too-many-arguments
     if not package_path and not all_flag:
         click.secho(
             "Please specify a package path or add '--all' to pull all micro-packages in the "
-            "`pyproject.toml` package manifest section."
+            "'pyproject.toml' package manifest section."
         )
         sys.exit(1)
 
@@ -125,7 +125,7 @@ def pull_package(  # pylint:disable=unused-argument, too-many-arguments
         destination=destination,
         fs_args=fs_args,
     )
-    as_alias = f" as `{alias}`" if alias else ""
+    as_alias = f" as '{alias}'" if alias else ""
     message = f"Micro-package {package_path} pulled and unpacked{as_alias}!"
     click.secho(message, fg="green")
 
@@ -189,7 +189,7 @@ def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:
 
     if not build_specs:
         click.secho(
-            "Nothing to pull. Please update the `pyproject.toml` package manifest section.",
+            "Nothing to pull. Please update the 'pyproject.toml' package manifest section.",
             fg="yellow",
         )
         return
@@ -198,7 +198,7 @@ def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:
         if "alias" in specs:
             _assert_pkg_name_ok(specs["alias"].split(".")[-1])
         _pull_package(package_path, metadata, **specs)
-        click.secho(f"Pulled and unpacked `{package_path}`!")
+        click.secho(f"Pulled and unpacked '{package_path}'!")
 
     click.secho("Micro-packages pulled and unpacked!", fg="green")
 
@@ -213,7 +213,7 @@ def _package_micropkgs_from_manifest(metadata: ProjectMetadata) -> None:
 
     if not build_specs:
         click.secho(
-            "Nothing to package. Please update the `pyproject.toml` package manifest section.",
+            "Nothing to package. Please update the 'pyproject.toml' package manifest section.",
             fg="yellow",
         )
         return
@@ -222,7 +222,7 @@ def _package_micropkgs_from_manifest(metadata: ProjectMetadata) -> None:
         if "alias" in specs:
             _assert_pkg_name_ok(specs["alias"])
         _package_micropkg(package_name, metadata, **specs)
-        click.secho(f"Packaged `{package_name}` micro-package!")
+        click.secho(f"Packaged '{package_name}' micro-package!")
 
     click.secho("Micro-packages packaged!", fg="green")
 
@@ -260,7 +260,7 @@ def package_micropkg(
     if not module_path and not all_flag:
         click.secho(
             "Please specify a micro-package name or add '--all' to package all micro-packages in "
-            "the `pyproject.toml` package manifest section."
+            "the 'pyproject.toml' package manifest section."
         )
         sys.exit(1)
 
@@ -819,7 +819,7 @@ def _append_package_reqs(
             )
             file.write(sep.join(sorted_reqs))
         click.secho(
-            f"Added the following requirements from micro-package `{package_name}` to "
+            f"Added the following requirements from micro-package '{package_name}' to "
             f"requirements.txt:\n{sep.join(sorted_reqs)}"
         )
     else:
@@ -832,7 +832,7 @@ def _append_package_reqs(
             file.write(sep.join(sorted_reqs))
 
     click.secho(
-        "Use `kedro build-reqs` to compile and `pip install -r src/requirements.lock` to install "
+        "Use 'kedro build-reqs' to compile and 'pip install -r src/requirements.lock' to install "
         "the updated list of requirements."
     )
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -174,7 +174,7 @@ def delete_pipeline(
     click.secho(f"\nPipeline '{name}' was successfully deleted.", fg="green")
     click.secho(
         f"\nIf you added the pipeline '{name}' to 'register_pipelines()' in"
-        f""" "{package_dir / 'pipeline_registry.py'}", you will need to remove it.""",
+        f""" '{package_dir / "pipeline_registry.py"}', you will need to remove it.""",
         fg="yellow",
     )
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -50,7 +50,7 @@ def _assert_pkg_name_ok(pkg_name: str):
         KedroCliError: If package name violates the requirements.
     """
 
-    base_message = f"`{pkg_name}` is not a valid Python package name."
+    base_message = f"'{pkg_name}' is not a valid Python package name."
     if not re.match(r"^[a-zA-Z_]", pkg_name):
         message = base_message + " It must start with a letter or underscore."
         raise KedroCliError(message)
@@ -101,18 +101,18 @@ def create_pipeline(
     env = env or "base"
     if not skip_config and not (project_conf_path / env).exists():
         raise KedroCliError(
-            f"Unable to locate environment `{env}`. "
+            f"Unable to locate environment '{env}'. "
             f"Make sure it exists in the project configuration."
         )
 
     result_path = _create_pipeline(name, package_dir / "pipelines")
     _copy_pipeline_tests(name, result_path, package_dir)
     _copy_pipeline_configs(result_path, project_conf_path, skip_config, env=env)
-    click.secho(f"\nPipeline `{name}` was successfully created.\n", fg="green")
+    click.secho(f"\nPipeline '{name}' was successfully created.\n", fg="green")
 
     click.secho(
-        f"To be able to run the pipeline `{name}`, you will need to add it "
-        f"to `register_pipelines()` in `{package_dir / 'pipeline_registry.py'}`.",
+        f"To be able to run the pipeline '{name}', you will need to add it "
+        f"""to 'register_pipelines()' in "{package_dir / 'pipeline_registry.py'}".""",
         fg="yellow",
     )
 
@@ -120,7 +120,7 @@ def create_pipeline(
 @command_with_verbosity(pipeline, "delete")
 @click.argument("name", nargs=1, callback=_check_pipeline_name)
 @env_option(
-    help="Environment to delete pipeline configuration from. Defaults to `base`."
+    help="Environment to delete pipeline configuration from. Defaults to 'base'."
 )
 @click.option(
     "-y", "--yes", is_flag=True, help="Confirm deletion of pipeline non-interactively."
@@ -137,7 +137,7 @@ def delete_pipeline(
     env = env or "base"
     if not (project_conf_path / env).exists():
         raise KedroCliError(
-            f"Unable to locate environment `{env}`. "
+            f"Unable to locate environment '{env}'. "
             f"Make sure it exists in the project configuration."
         )
 
@@ -155,7 +155,7 @@ def delete_pipeline(
     ]
 
     if not files_to_delete and not dirs_to_delete:
-        raise KedroCliError(f"Pipeline `{name}` not found.")
+        raise KedroCliError(f"Pipeline '{name}' not found.")
 
     if not yes:
         _echo_deletion_warning(
@@ -164,17 +164,17 @@ def delete_pipeline(
             files=files_to_delete,
         )
         click.echo()
-        yes = click.confirm(f"Are you sure you want to delete pipeline `{name}`?")
+        yes = click.confirm(f"Are you sure you want to delete pipeline '{name}'?")
         click.echo()
 
     if not yes:
         raise KedroCliError("Deletion aborted!")
 
     _delete_artifacts(*files_to_delete, *dirs_to_delete)
-    click.secho(f"\nPipeline `{name}` was successfully deleted.", fg="green")
+    click.secho(f"\nPipeline '{name}' was successfully deleted.", fg="green")
     click.secho(
-        f"\nIf you added the pipeline `{name}` to `register_pipelines()` in "
-        f"`{package_dir / 'pipeline_registry.py'}`, you will need to remove it.",
+        f"\nIf you added the pipeline '{name}' to 'register_pipelines()' in"
+        f""" "{package_dir / 'pipeline_registry.py'}", you will need to remove it.""",
         fg="yellow",
     )
 
@@ -199,7 +199,7 @@ def _create_pipeline(name: str, output_dir: Path) -> Path:
     template_path = Path(kedro.__file__).parent / "templates" / "pipeline"
     cookie_context = {"pipeline_name": name, "kedro_version": kedro.__version__}
 
-    click.echo(f"Creating the pipeline `{name}`: ", nl=False)
+    click.echo(f"Creating the pipeline '{name}': ", nl=False)
 
     try:
         result_path = cookiecutter(
@@ -215,7 +215,7 @@ def _create_pipeline(name: str, output_dir: Path) -> Path:
 
     click.secho("OK", fg="green")
     result_path = Path(result_path)
-    message = indent(f"Location: `{result_path.resolve()}`", " " * 2)
+    message = indent(f"Location: '{result_path.resolve()}'", " " * 2)
     click.secho(message, bold=True)
 
     _clean_pycache(result_path)
@@ -254,7 +254,7 @@ def _sync_dirs(source: Path, target: Path, prefix: str = "", overwrite: bool = F
     for source_path in content:
         source_name = source_path.name
         target_path = target / source_name
-        click.echo(indent(f"Creating `{target_path}`: ", prefix), nl=False)
+        click.echo(indent(f"Creating '{target_path}': ", prefix), nl=False)
 
         if (  # rule #1
             not overwrite
@@ -323,7 +323,7 @@ def _copy_pipeline_configs(
 
 def _delete_artifacts(*artifacts: Path):
     for artifact in artifacts:
-        click.echo(f"Deleting `{artifact}`: ", nl=False)
+        click.echo(f"Deleting '{artifact}': ", nl=False)
         try:
             if artifact.is_dir():
                 shutil.rmtree(artifact)

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -112,7 +112,7 @@ def create_pipeline(
 
     click.secho(
         f"To be able to run the pipeline '{name}', you will need to add it "
-        f"""to 'register_pipelines()' in "{package_dir / 'pipeline_registry.py'}".""",
+        f"""to 'register_pipelines()' in '{package_dir / "pipeline_registry.py"}'.""",
         fg="yellow",
     )
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -29,7 +29,7 @@ from kedro.framework.startup import ProjectMetadata
 from kedro.utils import load_obj
 
 NO_DEPENDENCY_MESSAGE = """{module} is not installed. Please make sure {module} is in
-{src}/requirements.txt and run `pip install -r src/requirements.txt`."""
+{src}/requirements.txt and run 'pip install -r src/requirements.txt'."""
 LINT_CHECK_ONLY_HELP = """Check the files for style guide violations, unsorted /
 unformatted imports, and unblackened Python code without modifying the files."""
 OPEN_ARG_HELP = """Open the documentation in your default browser after building."""
@@ -41,7 +41,7 @@ FROM_NODES_HELP = """A list of node names which should be used as a starting poi
 TO_NODES_HELP = """A list of node names which should be used as an end point."""
 NODE_ARG_HELP = """Run only nodes with specified names."""
 RUNNER_ARG_HELP = """Specify a runner that you want to run the pipeline with.
-Available runners: `SequentialRunner`, `ParallelRunner` and `ThreadRunner`."""
+Available runners: 'SequentialRunner', 'ParallelRunner' and 'ThreadRun'."""
 ASYNC_ARG_HELP = """Load and save node inputs and outputs asynchronously
 with threads. If not specified, load and save datasets synchronously."""
 TAG_ARG_HELP = """Construct the pipeline using only nodes which have this tag
@@ -235,7 +235,7 @@ def build_reqs(
 
     else:
         raise FileNotFoundError(
-            f"File `{input_file}` not found in the project. "
+            f"File '{input_file}' not found in the project. "
             "Please specify another input or create the file and try again."
         )
 
@@ -276,7 +276,7 @@ def activate_nbstripout(
             stderr=subprocess.PIPE,
         )
         if res.returncode:
-            raise KedroCliError("Not a git repository. Run `git init` first.")
+            raise KedroCliError("Not a git repository. Run'git init' first.")
     except FileNotFoundError as exc:
         raise KedroCliError("Git executable not found. Install Git first.") from exc
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -276,7 +276,7 @@ def activate_nbstripout(
             stderr=subprocess.PIPE,
         )
         if res.returncode:
-            raise KedroCliError("Not a git repository. Run'git init' first.")
+            raise KedroCliError("Not a git repository. Run 'git init' first.")
     except FileNotFoundError as exc:
         raise KedroCliError("Git executable not found. Install Git first.") from exc
 

--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -38,7 +38,7 @@ def describe_registered_pipeline(
         all_pipeline_names = pipelines.keys()
         existing_pipelines = ", ".join(sorted(all_pipeline_names))
         raise KedroCliError(
-            f"`{name}` pipeline not found. Existing pipelines: [{existing_pipelines}]"
+            f"'{name}' pipeline not found. Existing pipelines: [{existing_pipelines}]"
         )
 
     nodes = []

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -254,7 +254,7 @@ def _create_project(template_path: str, cookiecutter_args: Dict[str, str]):
     )
     click.secho(
         "\nA best-practice setup includes initialising git and creating "
-        "a virtual environment before running ``pip install -r src/requirements.txt`` to install "
+        "a virtual environment before running 'pip install -r src/requirements.txt' to install "
         "project-specific dependencies. Refer to the Kedro documentation: "
         "https://kedro.readthedocs.io/"
     )
@@ -383,7 +383,7 @@ class _Prompt:
     def validate(self, user_input: str) -> None:
         """Validate a given prompt value against the regex validator"""
         if self.regexp and not re.match(self.regexp, user_input):
-            click.secho(f"`{user_input}` is an invalid value.", fg="red", err=True)
+            click.secho(f"'{user_input}' is an invalid value.", fg="red", err=True)
             click.secho(self.error_message, fg="red", err=True)
             raise ValueError(user_input)
 
@@ -428,6 +428,6 @@ def _validate_config_file(config: Dict[str, str], prompts: Dict[str, Any]):
 
     if "output_dir" in config and not Path(config["output_dir"]).exists():
         raise KedroCliError(
-            f"`{config['output_dir']}` is not a valid output directory. "
+            f"'{config['output_dir']}' is not a valid output directory. "
             "It must be a relative or absolute path to an existing directory."
         )

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -213,7 +213,7 @@ def get_pkg_version(reqs_path: (Union[str, Path]), package_name: str) -> str:
     """
     reqs_path = Path(reqs_path).absolute()
     if not reqs_path.is_file():
-        raise KedroCliError(f"Given path `{reqs_path}` is not a regular file.")
+        raise KedroCliError(f"Given path '{reqs_path}' is not a regular file.")
 
     pattern = re.compile(package_name + r"([^\w]|$)")
     with reqs_path.open("r", encoding="utf-8") as reqs_file:
@@ -222,7 +222,7 @@ def get_pkg_version(reqs_path: (Union[str, Path]), package_name: str) -> str:
             if pattern.search(req_line):
                 return req_line
 
-    raise KedroCliError(f"Cannot find `{package_name}` package in `{reqs_path}`.")
+    raise KedroCliError(f"Cannot find '{package_name}' package in '{reqs_path}'.")
 
 
 def _update_verbose_flag(ctx, param, value):  # pylint: disable=unused-argument
@@ -313,8 +313,8 @@ def _check_module_importable(module_name: str) -> None:
         import_module(module_name)
     except ImportError as exc:
         raise KedroCliError(
-            f"Module `{module_name}` not found. Make sure to install required project "
-            f"dependencies by running the `pip install -r src/requirements.txt` command first."
+            f"Module '{module_name}' not found. Make sure to install required project "
+            f"dependencies by running the 'pip install -r src/requirements.txt' command first."
         ) from exc
 
 
@@ -378,8 +378,8 @@ def _reformat_load_versions(  # pylint: disable=unused-argument
         load_version_list = load_version.split(":", 1)
         if len(load_version_list) != 2:
             raise KedroCliError(
-                f"Expected the form of `load_version` to be "
-                f"`dataset_name:YYYY-MM-DDThh.mm.ss.sssZ`,"
+                f"Expected the form of 'load_version' to be "
+                f"'dataset_name:YYYY-MM-DDThh.mm.ss.sssZ',"
                 f"found {load_version} instead"
             )
         load_versions_dict[load_version_list[0]] = load_version_list[1]

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -33,9 +33,9 @@ class _IsSubclassValidator(Validator):
             setting_value = getattr(settings, name)
             if not issubclass(setting_value, default_class):
                 raise ValidationError(
-                    f"Invalid value `{setting_value.__module__}.{setting_value.__qualname__}` "
-                    f"received for setting `{name}`. It must be a subclass of "
-                    f"`{default_class.__module__}.{default_class.__qualname__}`."
+                    f"Invalid value'{setting_value.__module__}.{setting_value.__qualname__}' "
+                    f"received for setting '{name}'. It must be a subclass of "
+                    f"'{default_class.__module__}.{default_class.__qualname__}'."
                 )
 
 
@@ -62,9 +62,9 @@ class _HasSharedParentClassValidator(Validator):
             default_class_parent = default_class.mro()[1]
             if default_class_parent not in setting_value.mro():
                 raise ValidationError(
-                    f"Invalid value `{setting_value.__module__}.{setting_value.__qualname__}` "
-                    f"received for setting `{name}`. It must be a subclass of "
-                    f"`{default_class_parent.__module__}.{default_class_parent.__qualname__}`."
+                    f"Invalid value '{setting_value.__module__}.{setting_value.__qualname__}' "
+                    f"received for setting '{name}'. It must be a subclass of "
+                    f"'{default_class_parent.__module__}.{default_class_parent.__qualname__}'."
                 )
 
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -33,7 +33,7 @@ class _IsSubclassValidator(Validator):
             setting_value = getattr(settings, name)
             if not issubclass(setting_value, default_class):
                 raise ValidationError(
-                    f"Invalid value'{setting_value.__module__}.{setting_value.__qualname__}' "
+                    f"Invalid value '{setting_value.__module__}.{setting_value.__qualname__}' "
                     f"received for setting '{name}'. It must be a subclass of "
                     f"'{default_class.__module__}.{default_class.__qualname__}'."
                 )

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -206,11 +206,11 @@ class KedroSession:
         except TypeError as err:
             raise ValueError(
                 f"\n{err}.\nStore config must only contain arguments valid "
-                f"for the constructor of `{classpath}`."
+                f"for the constructor of '{classpath}'."
             ) from err
         except Exception as err:
             raise ValueError(
-                f"\n{err}.\nFailed to instantiate session store of type `{classpath}`."
+                f"\n{err}.\nFailed to instantiate session store of type '{classpath}'."
             ) from err
 
     def _log_exception(self, exc_type, exc_value, exc_tb):

--- a/kedro/framework/session/store.py
+++ b/kedro/framework/session/store.py
@@ -30,7 +30,7 @@ class BaseSessionStore(UserDict):
             A mapping containing the session store data.
         """
         self._logger.debug(
-            "`read()` not implemented for `%s`. Assuming empty store.",
+            "'read()' not implemented for '%s'. Assuming empty store.",
             self.__class__.__name__,
         )
         return {}
@@ -38,7 +38,7 @@ class BaseSessionStore(UserDict):
     def save(self):
         """Persist the session store"""
         self._logger.debug(
-            "`save()` not implemented for `%s`. Skipping the step.",
+            "'save()' not implemented for '%s'. Skipping the step.",
             self.__class__.__name__,
         )
 

--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -56,7 +56,7 @@ class CachedDataSet(AbstractDataSet):
             self._dataset = dataset
         else:
             raise ValueError(
-                "The argument type of `dataset` should be either a dict/YAML "
+                "The argument type of 'dataset' should be either a dict/YAML "
                 "representation of the dataset, or the actual dataset object."
             )
         self._cache = MemoryDataSet(copy_mode=copy_mode)
@@ -70,7 +70,7 @@ class CachedDataSet(AbstractDataSet):
         if VERSIONED_FLAG_KEY in config:
             raise ValueError(
                 "Cached datasets should specify that they are versioned in the "
-                "`CachedDataSet`, not in the wrapped dataset."
+                "'CachedDataSet', not in the wrapped dataset."
             )
         if version:
             config[VERSIONED_FLAG_KEY] = True

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -603,7 +603,7 @@ class AbstractVersionedDataSet(AbstractDataSet, abc.ABC):
             # FileNotFoundError raised in Win, NotADirectoryError raised in Unix
             _default_version = "YYYY-MM-DDThh.mm.ss.sssZ"
             raise DataSetError(
-                f"Cannot save versioned dataset `{self._filepath.name}` to "
+                f"Cannot save versioned dataset '{self._filepath.name}' to "
                 f"'{self._filepath.parent.as_posix()}' because a file with the same "
                 f"name already exists in the directory. This is likely because "
                 f"versioning was enabled on a dataset already saved previously. Either "

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -144,7 +144,7 @@ class AbstractDataSet(abc.ABC):
         except Exception as exc:
             raise DataSetError(
                 f"An exception occurred when parsing config "
-                f"for DataSet `{name}`:\n{str(exc)}"
+                f"for DataSet '{name}':\n{str(exc)}"
             ) from exc
 
         try:
@@ -152,12 +152,12 @@ class AbstractDataSet(abc.ABC):
         except TypeError as err:
             raise DataSetError(
                 f"\n{err}.\nDataSet '{name}' must only contain arguments valid for the "
-                f"constructor of `{class_obj.__module__}.{class_obj.__qualname__}`."
+                f"constructor of '{class_obj.__module__}.{class_obj.__qualname__}'."
             ) from err
         except Exception as err:
             raise DataSetError(
                 f"\n{err}.\nFailed to instantiate DataSet '{name}' "
-                f"of type `{class_obj.__module__}.{class_obj.__qualname__}`."
+                f"of type '{class_obj.__module__}.{class_obj.__qualname__}'."
             ) from err
         return data_set
 
@@ -203,7 +203,7 @@ class AbstractDataSet(abc.ABC):
         """
 
         if data is None:
-            raise DataSetError("Saving `None` to a `DataSet` is not allowed")
+            raise DataSetError("Saving 'None' to a 'DataSet' is not allowed")
 
         try:
             self._logger.debug("Saving %s", str(self))
@@ -246,22 +246,22 @@ class AbstractDataSet(abc.ABC):
     @abc.abstractmethod
     def _load(self) -> Any:
         raise NotImplementedError(
-            f"`{self.__class__.__name__}` is a subclass of AbstractDataSet and "
-            f"it must implement the `_load` method"
+            f"'{self.__class__.__name__}' is a subclass of AbstractDataSet and "
+            f"it must implement the '_load' method"
         )
 
     @abc.abstractmethod
     def _save(self, data: Any) -> None:
         raise NotImplementedError(
-            f"`{self.__class__.__name__}` is a subclass of AbstractDataSet and "
-            f"it must implement the `_save` method"
+            f"'{self.__class__.__name__}' is a subclass of AbstractDataSet and "
+            f"it must implement the '_save' method"
         )
 
     @abc.abstractmethod
     def _describe(self) -> Dict[str, Any]:
         raise NotImplementedError(
-            f"`{self.__class__.__name__}` is a subclass of AbstractDataSet and "
-            f"it must implement the `_describe` method"
+            f"'{self.__class__.__name__}' is a subclass of AbstractDataSet and "
+            f"it must implement the '_describe' method"
         )
 
     def exists(self) -> bool:
@@ -286,7 +286,7 @@ class AbstractDataSet(abc.ABC):
 
     def _exists(self) -> bool:
         self._logger.warning(
-            "`exists()` not implemented for `%s`. Assuming output does not exist.",
+            "'exists()' not implemented for '%s'. Assuming output does not exist.",
             self.__class__.__name__,
         )
         return False
@@ -337,9 +337,9 @@ class Version(namedtuple("Version", ["load", "save"])):
 
 
 _CONSISTENCY_WARNING = (
-    "Save version `{}` did not match load version `{}` for {}. This is strongly "
-    "discouraged due to inconsistencies it may cause between `save` and "
-    "`load` operations. Please refrain from setting exact load version for "
+    "Save version '{}' did not match load version '{}' for {}. This is strongly "
+    "discouraged due to inconsistencies it may cause between 'save' and "
+    "'load' operations. Please refrain from setting exact load version for "
     "intermediate data sets where possible to avoid this warning."
 )
 
@@ -371,13 +371,13 @@ def parse_dataset_definition(
     config = copy.deepcopy(config)
 
     if "type" not in config:
-        raise DataSetError("`type` is missing from DataSet catalog configuration")
+        raise DataSetError("'type' is missing from DataSet catalog configuration")
 
     class_obj = config.pop("type")
     if isinstance(class_obj, str):
         if len(class_obj.strip(".")) != len(class_obj):
             raise DataSetError(
-                "`type` class path does not support relative "
+                "'type' class path does not support relative "
                 "paths or paths ending with a dot."
             )
         class_paths = (prefix + class_obj for prefix in _DEFAULT_PACKAGES)
@@ -387,21 +387,21 @@ def parse_dataset_definition(
             class_obj = next(obj for obj in trials if obj is not None)
         except StopIteration as exc:
             raise DataSetError(
-                f"Class `{class_obj}` not found or one of its dependencies "
+                f"Class '{class_obj}' not found or one of its dependencies "
                 f"has not been installed."
             ) from exc
 
     if not issubclass(class_obj, AbstractDataSet):
         raise DataSetError(
-            f"DataSet type `{class_obj.__module__}.{class_obj.__qualname__}` "
-            f"is invalid: all data set types must extend `AbstractDataSet`."
+            f"DataSet type '{class_obj.__module__}.{class_obj.__qualname__}' "
+            f"is invalid: all data set types must extend 'AbstractDataSet'."
         )
 
     if VERSION_KEY in config:
         # remove "version" key so that it's not passed
         # to the "unversioned" data set constructor
         message = (
-            "`%s` attribute removed from data set configuration since it is a "
+            "'%s' attribute removed from data set configuration since it is a "
             "reserved word and cannot be directly specified"
         )
         logging.getLogger(__name__).warning(message, VERSION_KEY)
@@ -581,7 +581,7 @@ class AbstractVersionedDataSet(AbstractDataSet, abc.ABC):
 
         if self._exists_function(str(versioned_path)):
             raise DataSetError(
-                f"Save path `{versioned_path}` for {str(self)} must not exist if "
+                f"Save path '{versioned_path}' for {str(self)} must not exist if "
                 f"versioning is enabled."
             )
 
@@ -604,14 +604,14 @@ class AbstractVersionedDataSet(AbstractDataSet, abc.ABC):
             _default_version = "YYYY-MM-DDThh.mm.ss.sssZ"
             raise DataSetError(
                 f"Cannot save versioned dataset `{self._filepath.name}` to "
-                f"`{self._filepath.parent.as_posix()}` because a file with the same "
+                f"'{self._filepath.parent.as_posix()}' because a file with the same "
                 f"name already exists in the directory. This is likely because "
                 f"versioning was enabled on a dataset already saved previously. Either "
-                f"remove `{self._filepath.name}` from the directory or manually "
+                f"remove '{self._filepath.name}' from the directory or manually "
                 f"convert it into a versioned dataset by placing it in a versioned "
                 f"directory (e.g. with default versioning format "
-                f"`{self._filepath.as_posix()}/{_default_version}/{self._filepath.name}"
-                f"`)."
+                f"'{self._filepath.as_posix()}/{_default_version}/{self._filepath.name}"
+                f"')."
             ) from err
 
         load_version = self.resolve_load_version()
@@ -735,5 +735,5 @@ def validate_on_forbidden_chars(**kwargs):
     for key, value in kwargs.items():
         if " " in value or ";" in value:
             raise DataSetError(
-                f"Neither white-space nor semicolon are allowed in `{key}`."
+                f"Neither white-space nor semicolon are allowed in '{key}'."
             )

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -263,7 +263,7 @@ class DataCatalog:
         missing_keys = load_versions.keys() - catalog.keys()
         if missing_keys:
             raise DataSetNotFoundError(
-                f"`load_versions` keys [{', '.join(sorted(missing_keys))}] "
+                f"'load_versions' keys [{', '.join(sorted(missing_keys))}] "
                 f"are not found in the catalog."
             )
 
@@ -341,7 +341,7 @@ class DataCatalog:
         dataset = self._get_dataset(name, version=load_version)
 
         self._logger.info(
-            "Loading data from `%s` (%s)...", name, type(dataset).__name__
+            "Loading data from '%s' (%s)...", name, type(dataset).__name__
         )
 
         result = dataset.load()
@@ -379,7 +379,7 @@ class DataCatalog:
         """
         dataset = self._get_dataset(name)
 
-        self._logger.info("Saving data to `%s` (%s)...", name, type(dataset).__name__)
+        self._logger.info("Saving data to '%s' (%s)...", name, type(dataset).__name__)
 
         dataset.save(data)
 
@@ -561,7 +561,7 @@ class DataCatalog:
 
         except re.error as exc:
             raise SyntaxError(
-                f"Invalid regular expression provided: `{regex_search}`"
+                f"Invalid regular expression provided: '{regex_search}'"
             ) from exc
         return [dset_name for dset_name in self._data_sets if pattern.search(dset_name)]
 

--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -50,7 +50,7 @@ class LambdaDataSet(AbstractDataSet):
     def _save(self, data: Any) -> None:
         if not self.__save:
             raise DataSetError(
-                "Cannot save to data set. No `save` function "
+                "Cannot save to data set. No 'save' function "
                 "provided when LambdaDataSet was created."
             )
         self.__save(data)
@@ -58,7 +58,7 @@ class LambdaDataSet(AbstractDataSet):
     def _load(self) -> Any:
         if not self.__load:
             raise DataSetError(
-                "Cannot load data set. No `load` function "
+                "Cannot load data set. No 'load' function "
                 "provided when LambdaDataSet was created."
             )
         return self.__load()
@@ -103,8 +103,8 @@ class LambdaDataSet(AbstractDataSet):
         ]:
             if value is not None and not callable(value):
                 raise DataSetError(
-                    f"`{name}` function for LambdaDataSet must be a Callable. "
-                    f"Object of type `{value.__class__.__name__}` provided instead."
+                    f"'{name}' function for LambdaDataSet must be a Callable. "
+                    f"Object of type '{value.__class__.__name__}' provided instead."
                 )
 
         self.__load = load

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -161,8 +161,8 @@ class PartitionedDataSet(AbstractDataSet):
         self._dataset_type, self._dataset_config = parse_dataset_definition(dataset)
         if VERSION_KEY in self._dataset_config:
             raise DataSetError(
-                f"`{self.__class__.__name__}` does not support versioning of the "
-                f"underlying dataset. Please remove `{VERSIONED_FLAG_KEY}` flag from "
+                f"'{self.__class__.__name__}' does not support versioning of the "
+                f"underlying dataset. Please remove '{VERSIONED_FLAG_KEY}' flag from "
                 f"the dataset definition."
             )
 
@@ -253,7 +253,7 @@ class PartitionedDataSet(AbstractDataSet):
             partitions[partition_id] = dataset.load
 
         if not partitions:
-            raise DataSetError(f"No partitions found in `{self._path}`")
+            raise DataSetError(f"No partitions found in '{self._path}'")
 
         return partitions
 
@@ -425,8 +425,8 @@ class IncrementalDataSet(PartitionedDataSet):
 
         for key in {VERSION_KEY, VERSIONED_FLAG_KEY} & checkpoint_config.keys():
             raise DataSetError(
-                f"`{self.__class__.__name__}` does not support versioning of the "
-                f"checkpoint. Please remove `{key}` key from the checkpoint definition."
+                f"'{self.__class__.__name__}' does not support versioning of the "
+                f"checkpoint. Please remove '{key}' key from the checkpoint definition."
             )
 
         default_checkpoint_path = self._sep.join(

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -190,7 +190,7 @@ class PartitionedDataSet(AbstractDataSet):
         self._filepath_arg = filepath_arg
         if self._filepath_arg in self._dataset_config:
             warn(
-                f"`{self._filepath_arg}` key must not be specified in the dataset "
+                f"'{self._filepath_arg}' key must not be specified in the dataset "
                 f"definition as it will be overwritten by partition path"
             )
 

--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -44,7 +44,7 @@ def _validate_inputs_outputs(
 
     if any(_is_parameter(i) for i in inputs):
         raise ModularPipelineError(
-            "Parameters should be specified in the `parameters` argument"
+            "Parameters should be specified in the 'parameters' argument"
         )
 
     free_inputs = {_strip_transcoding(i) for i in pipe.inputs()}

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -67,29 +67,29 @@ class Node:
         if not callable(func):
             raise ValueError(
                 _node_error_message(
-                    f"first argument must be a function, not `{type(func).__name__}`."
+                    f"first argument must be a function, not '{type(func).__name__}'."
                 )
             )
 
         if inputs and not isinstance(inputs, (list, dict, str)):
             raise ValueError(
                 _node_error_message(
-                    f"`inputs` type must be one of [String, List, Dict, None], "
-                    f"not `{type(inputs).__name__}`."
+                    f"'inputs' type must be one of [String, List, Dict, None], "
+                    f"not '{type(inputs).__name__}'."
                 )
             )
 
         if outputs and not isinstance(outputs, (list, dict, str)):
             raise ValueError(
                 _node_error_message(
-                    f"`outputs` type must be one of [String, List, Dict, None], "
-                    f"not `{type(outputs).__name__}`."
+                    f"'outputs' type must be one of [String, List, Dict, None], "
+                    f"not '{type(outputs).__name__}'."
                 )
             )
 
         if not inputs and not outputs:
             raise ValueError(
-                _node_error_message("it must have some `inputs` or `outputs`.")
+                _node_error_message("it must have some 'inputs' or 'outputs'.")
             )
 
         self._validate_inputs(func, inputs)
@@ -349,7 +349,7 @@ class Node:
 
         # purposely catch all exceptions
         except Exception as exc:
-            self._logger.error("Node `%s` failed with error: \n%s", str(self), str(exc))
+            self._logger.error("Node '%s' failed with error: \n%s", str(self), str(exc))
             raise exc
 
     def _run_with_no_inputs(self, inputs: Dict[str, Any]):
@@ -411,7 +411,7 @@ class Node:
                     f"Failed to save outputs of node {str(self)}.\n"
                     f"The node definition contains a list of "
                     f"outputs {self._outputs}, whereas the node function "
-                    f"returned a `{type(outputs).__name__}`."
+                    f"returned a '{type(outputs).__name__}'."
                 )
             if len(outputs) != len(self._outputs):
                 raise ValueError(

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -181,9 +181,9 @@ class Node:
         name = _get_readable_func_name(self._func)
         if name == "<partial>":
             warn(
-                f"The node producing outputs `{self.outputs}` is made from a `partial` function. "
-                f"Partial functions do not have a `__name__` attribute: consider using "
-                f"`functools.update_wrapper` for better log messages."
+                f"The node producing outputs '{self.outputs}' is made from a 'partial' function. "
+                f"Partial functions do not have a '__name__' attribute: consider using "
+                f"'functools.update_wrapper' for better log messages."
             )
         return name
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -129,7 +129,7 @@ class Pipeline:  # pylint: disable=too-many-public-methods
         """
         if nodes is None:
             raise ValueError(
-                "`nodes` argument of `Pipeline` is None. It must be an "
+                "'nodes' argument of 'Pipeline' is None. It must be an "
                 "iterable of nodes and/or pipelines instead."
             )
         nodes = list(nodes)  # in case it's a generator
@@ -407,7 +407,7 @@ class Pipeline:  # pylint: disable=too-many-public-methods
         ]
         if not nodes:
             raise ValueError(
-                f"Pipeline does not contain nodes with namespace `{node_namespace}`"
+                f"Pipeline does not contain nodes with namespace '{node_namespace}'"
             )
         return Pipeline(nodes)
 
@@ -818,7 +818,7 @@ def _validate_duplicate_nodes(nodes_or_pipes: Iterable[Union[Node, Pipeline]]):
         raise ValueError(
             f"Pipeline nodes must have unique names. The following node names "
             f"appear more than once:\n\n{duplicates_info}\nYou can name your "
-            f"nodes using the last argument of `node()`."
+            f"nodes using the last argument of 'node()'."
         )
 
 

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -241,8 +241,8 @@ def _collect_inputs_from_hook(
             if response is not None and not isinstance(response, dict):
                 response_type = type(response).__name__
                 raise TypeError(
-                    f"`before_node_run` must return either None or a dictionary mapping "
-                    f"dataset names to updated values, got `{response_type}` instead."
+                    f"'before_node_run' must return either None or a dictionary mapping "
+                    f"dataset names to updated values, got '{response_type}' instead."
                 )
             response = response or {}
             additional_inputs.update(response)

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -39,9 +39,9 @@ class ThreadRunner(AbstractRunner):
         """
         if is_async:
             warnings.warn(
-                "`ThreadRunner` doesn't support loading and saving the "
+                "'ThreadRunner' doesn't support loading and saving the "
                 "node inputs and outputs asynchronously with threads. "
-                "Setting `is_async` to False."
+                "Setting 'is_async' to False."
             )
         super().__init__(is_async=False)
 

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -24,5 +24,5 @@ def load_obj(obj_path: str, default_obj_path: str = "") -> Any:
     obj_name = obj_path_list[0]
     module_obj = importlib.import_module(obj_path)
     if not hasattr(module_obj, obj_name):
-        raise AttributeError(f"Object `{obj_name}` cannot be loaded from `{obj_path}`.")
+        raise AttributeError(f"Object '{obj_name}' cannot be loaded from '{obj_path}'.")
     return getattr(module_obj, obj_name)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -220,7 +220,7 @@ class TestConfigLoader:
     def test_empty_patterns(self, tmp_path):
         """Check the error if no config patterns were specified"""
         pattern = (
-            r"`patterns` must contain at least one glob pattern "
+            r"'patterns' must contain at least one glob pattern "
             r"to match config filenames against"
         )
         with pytest.raises(ValueError, match=pattern):

--- a/tests/extras/datasets/email/test_message_dataset.py
+++ b/tests/extras/datasets/email/test_message_dataset.py
@@ -172,7 +172,7 @@ class TestEmailMessageDataSetVersioned:
         corresponding text file for a given save version already exists."""
         versioned_message_data_set.save(dummy_msg)
         pattern = (
-            r"Save path \`.+\` for EmailMessageDataSet\(.+\) must "
+            r"Save path \'.+\' for EmailMessageDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -190,8 +190,8 @@ class TestEmailMessageDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            f"Save version `{save_version}` did not match "
-            f"load version `{load_version}` for "
+            f"Save version '{save_version}' did not match "
+            f"load version '{load_version}' for "
             r"EmailMessageDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):

--- a/tests/extras/datasets/geojson/test_geojson_dataset.py
+++ b/tests/extras/datasets/geojson/test_geojson_dataset.py
@@ -179,7 +179,7 @@ class TestGeoJSONDataSetVersioned:
         version."""
         versioned_geojson_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for GeoJSONDataSet\(.+\) must not "
+            r"Save path \'.+\' for GeoJSONDataSet\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -197,8 +197,8 @@ class TestGeoJSONDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for GeoJSONDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for GeoJSONDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_geojson_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/holoviews/test_holoviews_writer.py
+++ b/tests/extras/datasets/holoviews/test_holoviews_writer.py
@@ -142,7 +142,7 @@ class TestHoloviewsWriterVersioned:
         corresponding file for a given save version already exists."""
         versioned_hv_writer.save(dummy_hv_object)
         pattern = (
-            r"Save path \`.+\` for HoloviewsWriter\(.+\) must "
+            r"Save path \'.+\' for HoloviewsWriter\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -160,8 +160,8 @@ class TestHoloviewsWriterVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for HoloviewsWriter\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for HoloviewsWriter\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_hv_writer.save(dummy_hv_object)

--- a/tests/extras/datasets/holoviews/test_holoviews_writer.py
+++ b/tests/extras/datasets/holoviews/test_holoviews_writer.py
@@ -68,7 +68,7 @@ class TestHoloviewsWriter:
         assert writer._fs_open_args_save == fs_args["open_args_save"]
 
     def test_load_fail(self, hv_writer):
-        pattern = r"Loading not supported for `HoloviewsWriter`"
+        pattern = r"Loading not supported for 'HoloviewsWriter'"
         with pytest.raises(DataSetError, match=pattern):
             hv_writer.load()
 

--- a/tests/extras/datasets/json/test_json_dataset.py
+++ b/tests/extras/datasets/json/test_json_dataset.py
@@ -146,7 +146,7 @@ class TestJSONDataSetVersioned:
         corresponding json file for a given save version already exists."""
         versioned_json_data_set.save(dummy_data)
         pattern = (
-            r"Save path \`.+\` for JSONDataSet\(.+\) must "
+            r"Save path \'.+\' for JSONDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -164,8 +164,8 @@ class TestJSONDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            f"Save version `{save_version}` did not match "
-            f"load version `{load_version}` for "
+            f"Save version '{save_version}' did not match "
+            f"load version '{load_version}' for "
             r"JSONDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):

--- a/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
+++ b/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
@@ -234,7 +234,7 @@ class TestMatplotlibWriter:
         assert plot_writer._fs_open_args_save == fs_args["open_args_save"]
 
     def test_load_fail(self, plot_writer):
-        pattern = r"Loading not supported for `MatplotlibWriter`"
+        pattern = r"Loading not supported for 'MatplotlibWriter'"
         with pytest.raises(DataSetError, match=pattern):
             plot_writer.load()
 

--- a/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
+++ b/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
@@ -278,7 +278,7 @@ class TestMatplotlibWriterVersioned:
         corresponding matplotlib file for a given save version already exists."""
         versioned_plot_writer.save(mock_single_plot)
         pattern = (
-            r"Save path \`.+\` for MatplotlibWriter\(.+\) must "
+            r"Save path \'.+\' for MatplotlibWriter\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -286,9 +286,9 @@ class TestMatplotlibWriterVersioned:
 
     def test_ineffective_overwrite(self, load_version, save_version):
         pattern = (
-            "Setting `overwrite=True` is ineffective if versioning "
+            "Setting 'overwrite=True' is ineffective if versioning "
             "is enabled, since the versioned path must not already "
-            "exist; overriding flag with `overwrite=False` instead."
+            "exist; overriding flag with 'overwrite=False' instead."
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_plot_writer = MatplotlibWriter(
@@ -310,8 +310,8 @@ class TestMatplotlibWriterVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for MatplotlibWriter\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for MatplotlibWriter\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_plot_writer.save(mock_single_plot)

--- a/tests/extras/datasets/networkx/test_gml_dataset.py
+++ b/tests/extras/datasets/networkx/test_gml_dataset.py
@@ -124,7 +124,7 @@ class TestGMLDataSetVersioned:
         version."""
         versioned_gml_data_set.save(dummy_graph_data)
         pattern = (
-            r"Save path \`.+\` for GMLDataSet\(.+\) must not "
+            r"Save path \'.+\' for GMLDataSet\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -142,8 +142,8 @@ class TestGMLDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match "
-            rf"load version `{load_version}` for GMLDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match "
+            rf"load version '{load_version}' for GMLDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_gml_data_set.save(dummy_graph_data)

--- a/tests/extras/datasets/networkx/test_graphml_dataset.py
+++ b/tests/extras/datasets/networkx/test_graphml_dataset.py
@@ -124,7 +124,7 @@ class TestGraphMLDataSetVersioned:
         version."""
         versioned_graphml_data_set.save(dummy_graph_data)
         pattern = (
-            r"Save path \`.+\` for GraphMLDataSet\(.+\) must not "
+            r"Save path \'.+\' for GraphMLDataSet\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -142,8 +142,8 @@ class TestGraphMLDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match "
-            rf"load version `{load_version}` for GraphMLDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match "
+            rf"load version '{load_version}' for GraphMLDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_graphml_data_set.save(dummy_graph_data)

--- a/tests/extras/datasets/networkx/test_json_dataset.py
+++ b/tests/extras/datasets/networkx/test_json_dataset.py
@@ -162,7 +162,7 @@ class TestJSONDataSetVersioned:
         version."""
         versioned_json_data_set.save(dummy_graph_data)
         pattern = (
-            r"Save path \`.+\` for JSONDataSet\(.+\) must not "
+            r"Save path \'.+\' for JSONDataSet\(.+\) must not "
             r"exist if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -180,8 +180,8 @@ class TestJSONDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for JSONDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for JSONDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_data_set.save(dummy_graph_data)

--- a/tests/extras/datasets/pandas/test_csv_dataset.py
+++ b/tests/extras/datasets/pandas/test_csv_dataset.py
@@ -84,8 +84,8 @@ class TestCSVDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -247,7 +247,7 @@ class TestCSVDataSetVersioned:
         corresponding CSV file for a given save version already exists."""
         versioned_csv_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for CSVDataSet\(.+\) must "
+            r"Save path \'.+\' for CSVDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -265,8 +265,8 @@ class TestCSVDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for CSVDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for CSVDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_excel_dataset.py
+++ b/tests/extras/datasets/pandas/test_excel_dataset.py
@@ -209,7 +209,7 @@ class TestExcelDataSetVersioned:
         filepath = str(tmp_path / "test.xlsx")
         save_args = {"writer": {"mode": "a"}}
 
-        pattern = "`ExcelDataSet` doesn't support versioning in append mode."
+        pattern = "'ExcelDataSet' doesn't support versioning in append mode."
         with pytest.raises(DataSetError, match=pattern):
             ExcelDataSet(
                 filepath=filepath,

--- a/tests/extras/datasets/pandas/test_excel_dataset.py
+++ b/tests/extras/datasets/pandas/test_excel_dataset.py
@@ -114,8 +114,8 @@ class TestExcelDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -228,7 +228,7 @@ class TestExcelDataSetVersioned:
         corresponding Excel file for a given save version already exists."""
         versioned_excel_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for ExcelDataSet\(.+\) must "
+            r"Save path \'.+\' for ExcelDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -246,8 +246,8 @@ class TestExcelDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for ExcelDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for ExcelDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_excel_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_feather_dataset.py
+++ b/tests/extras/datasets/pandas/test_feather_dataset.py
@@ -74,8 +74,8 @@ class TestFeatherDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -167,7 +167,7 @@ class TestFeatherDataSetVersioned:
         corresponding feather file for a given save version already exists."""
         versioned_feather_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for FeatherDataSet\(.+\) must "
+            r"Save path \'.+\' for FeatherDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -185,8 +185,8 @@ class TestFeatherDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for FeatherDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for FeatherDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_feather_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_gbq_dataset.py
+++ b/tests/extras/datasets/pandas/test_gbq_dataset.py
@@ -110,8 +110,8 @@ class TestGBQDataSet:
     @pytest.mark.parametrize("save_args", [{"location": "l2"}], indirect=True)
     def test_invalid_location(self, save_args, load_args):
         """Check the error when initializing instance if save_args and load_args
-        '`location' are different."""
-        pattern = r""" "load_args\['location'\]" is different from "save_args\['location'\]"."""
+        'location' are different."""
+        pattern = r""""load_args\['location'\]" is different from "save_args\['location'\]"."""
         with pytest.raises(DataSetError, match=pattern):
             GBQTableDataSet(
                 dataset=DATASET,

--- a/tests/extras/datasets/pandas/test_gbq_dataset.py
+++ b/tests/extras/datasets/pandas/test_gbq_dataset.py
@@ -110,9 +110,9 @@ class TestGBQDataSet:
     @pytest.mark.parametrize("save_args", [{"location": "l2"}], indirect=True)
     def test_invalid_location(self, save_args, load_args):
         """Check the error when initializing instance if save_args and load_args
-        `location` are different."""
+    '`location' are different."""
         pattern = (
-            r"`load_args\['location'\]` is different from `save_args\['location'\]`."
+            r""" "load_args\['location'\]" is different from "save_args\['location'\]"."""
         )
         with pytest.raises(DataSetError, match=pattern):
             GBQTableDataSet(

--- a/tests/extras/datasets/pandas/test_gbq_dataset.py
+++ b/tests/extras/datasets/pandas/test_gbq_dataset.py
@@ -110,10 +110,8 @@ class TestGBQDataSet:
     @pytest.mark.parametrize("save_args", [{"location": "l2"}], indirect=True)
     def test_invalid_location(self, save_args, load_args):
         """Check the error when initializing instance if save_args and load_args
-    '`location' are different."""
-        pattern = (
-            r""" "load_args\['location'\]" is different from "save_args\['location'\]"."""
-        )
+        '`location' are different."""
+        pattern = r""" "load_args\['location'\]" is different from "save_args\['location'\]"."""
         with pytest.raises(DataSetError, match=pattern):
             GBQTableDataSet(
                 dataset=DATASET,

--- a/tests/extras/datasets/pandas/test_gbq_dataset.py
+++ b/tests/extras/datasets/pandas/test_gbq_dataset.py
@@ -216,7 +216,7 @@ class TestGBQQueryDataSet:
     def test_empty_query_error(self):
         """Check the error when instantiating with empty query or file"""
         pattern = (
-            r"`sql` and `filepath` arguments cannot both be empty\."
+            r"'sql' and 'filepath' arguments cannot both be empty\."
             r"Please provide a sql query or path to a sql query file\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -285,7 +285,7 @@ class TestGBQQueryDataSet:
 
     def test_save_error(self, gbq_sql_dataset, dummy_dataframe):
         """Check the error when trying to save to the data set"""
-        pattern = r"`save` is not supported on GBQQueryDataSet"
+        pattern = r"'save' is not supported on GBQQueryDataSet"
         with pytest.raises(DataSetError, match=pattern):
             gbq_sql_dataset.save(dummy_dataframe)
 
@@ -310,7 +310,7 @@ class TestGBQQueryDataSet:
     def test_sql_and_filepath_args(self, sql_file):
         """Test that an error is raised when both `sql` and `filepath` args are given."""
         pattern = (
-            r"`sql` and `filepath` arguments cannot both be provided."
+            r"'sql' and 'filepath' arguments cannot both be provided."
             r"Please only provide one."
         )
         with pytest.raises(DataSetError, match=pattern):

--- a/tests/extras/datasets/pandas/test_generic_dataset.py
+++ b/tests/extras/datasets/pandas/test_generic_dataset.py
@@ -284,7 +284,7 @@ class TestGenericCSVDataSetVersioned:
         corresponding Generic (csv) file for a given save version already exists."""
         versioned_csv_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for GenericDataSet\(.+\) must "
+            r"Save path \'.+\' for GenericDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -302,8 +302,8 @@ class TestGenericCSVDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for GenericDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for GenericDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_csv_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_generic_dataset.py
+++ b/tests/extras/datasets/pandas/test_generic_dataset.py
@@ -98,7 +98,7 @@ class TestGenericSasDataSet:
 
     def test_save_fail(self, sas_data_set, dummy_dataframe):
         pattern = (
-            "Unable to retrieve `pandas.DataFrame.to_sas` method, please ensure that your "
+            "Unable to retrieve 'pandas.DataFrame.to_sas' method, please ensure that your "
             "'file_format' parameter has been defined correctly as per the Pandas API "
             "https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html"
         )
@@ -341,7 +341,7 @@ class TestBadGenericDataSet:
         ds = GenericDataSet(filepath="test.kedro", file_format="kedro")
 
         pattern = (
-            "Unable to retrieve `pandas.read_kedro` method, please ensure that your 'file_format' "
+            "Unable to retrieve 'pandas.read_kedro' method, please ensure that your 'file_format' "
             "parameter has been defined correctly as per the Pandas API "
             "https://pandas.pydata.org/docs/reference/io.html"
         )
@@ -350,7 +350,7 @@ class TestBadGenericDataSet:
             _ = ds.load()
 
         pattern2 = (
-            "Unable to retrieve `pandas.DataFrame.to_kedro` method, please ensure that your 'file_format' "
+            "Unable to retrieve 'pandas.DataFrame.to_kedro' method, please ensure that your 'file_format' "
             "parameter has been defined correctly as per the Pandas API "
             "https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.html"
         )
@@ -370,7 +370,7 @@ class TestBadGenericDataSet:
     def test_generic_no_filepaths(self, file_format):
         error = (
             "Cannot create a dataset of file_format "
-            f"`{file_format}` as it does not support a filepath target/source"
+            f"'{file_format}' as it does not support a filepath target/source"
         )
 
         with pytest.raises(DataSetError, match=error):

--- a/tests/extras/datasets/pandas/test_hdf_dataset.py
+++ b/tests/extras/datasets/pandas/test_hdf_dataset.py
@@ -187,7 +187,7 @@ class TestHDFDataSetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_hdf_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for HDFDataSet\(.+\) must "
+            r"Save path \'.+\' for HDFDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -205,8 +205,8 @@ class TestHDFDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for HDFDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for HDFDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_hdf_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_json_dataset.py
+++ b/tests/extras/datasets/pandas/test_json_dataset.py
@@ -86,8 +86,8 @@ class TestJSONDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -188,7 +188,7 @@ class TestJSONDataSetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_json_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for JSONDataSet\(.+\) must "
+            r"Save path \'.+\' for JSONDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -206,8 +206,8 @@ class TestJSONDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for JSONDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for JSONDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_json_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_parquet_dataset.py
+++ b/tests/extras/datasets/pandas/test_parquet_dataset.py
@@ -112,8 +112,8 @@ class TestParquetDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -282,7 +282,7 @@ class TestParquetDataSetVersioned:
         )
         versioned_parquet_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for ParquetDataSet\(.+\) must "
+            r"Save path \'.+\' for ParquetDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -305,8 +305,8 @@ class TestParquetDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for ParquetDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for ParquetDataSet\(.+\)"
         )
         mocker.patch(
             "pyarrow.fs._ensure_filesystem",

--- a/tests/extras/datasets/pandas/test_parquet_dataset.py
+++ b/tests/extras/datasets/pandas/test_parquet_dataset.py
@@ -219,7 +219,7 @@ class TestParquetDataSet:
             filepath=(tmp_path / FILENAME).as_posix(),
             save_args={"partition_cols": ["col2"]},
         )
-        pattern = "does not support save argument `partition_cols`"
+        pattern = "does not support save argument 'partition_cols'"
 
         with pytest.raises(DataSetError, match=pattern):
             data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pandas/test_sql_dataset.py
+++ b/tests/extras/datasets/pandas/test_sql_dataset.py
@@ -70,7 +70,7 @@ class TestSQLTableDataSet:
 
     def test_empty_table_name(self):
         """Check the error when instantiating with an empty table"""
-        pattern = r"`table\_name` argument cannot be empty\."
+        pattern = r"'table\_name' argument cannot be empty\."
         with pytest.raises(DataSetError, match=pattern):
             SQLTableDataSet(table_name="", credentials=dict(con=CONNECTION))
 
@@ -78,7 +78,7 @@ class TestSQLTableDataSet:
         """Check the error when instantiating with an empty
         connection string"""
         pattern = (
-            r"`con` argument cannot be empty\. "
+            r"'con' argument cannot be empty\. "
             r"Please provide a SQLAlchemy connection string\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -252,7 +252,7 @@ class TestSQLQueryDataSet:
     def test_empty_query_error(self):
         """Check the error when instantiating with empty query or file"""
         pattern = (
-            r"`sql` and `filepath` arguments cannot both be empty\."
+            r"'sql' and 'filepath' arguments cannot both be empty\."
             r"Please provide a sql query or path to a sql query file\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -261,7 +261,7 @@ class TestSQLQueryDataSet:
     def test_empty_con_error(self):
         """Check the error when instantiating with empty connection string"""
         pattern = (
-            r"`con` argument cannot be empty\. Please provide "
+            r"'con' argument cannot be empty\. Please provide "
             r"a SQLAlchemy connection string"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -324,7 +324,7 @@ class TestSQLQueryDataSet:
 
     def test_save_error(self, query_data_set, dummy_dataframe):
         """Check the error when trying to save to the data set"""
-        pattern = r"`save` is not supported on SQLQueryDataSet"
+        pattern = r"'save' is not supported on SQLQueryDataSet"
         with pytest.raises(DataSetError, match=pattern):
             query_data_set.save(dummy_dataframe)
 
@@ -351,7 +351,7 @@ class TestSQLQueryDataSet:
     def test_sql_and_filepath_args(self, sql_file):
         """Test that an error is raised when both `sql` and `filepath` args are given."""
         pattern = (
-            r"`sql` and `filepath` arguments cannot both be provided."
+            r"'sql' and 'filepath' arguments cannot both be provided."
             r"Please only provide one."
         )
         with pytest.raises(DataSetError, match=pattern):

--- a/tests/extras/datasets/pandas/test_xml_dataset.py
+++ b/tests/extras/datasets/pandas/test_xml_dataset.py
@@ -86,8 +86,8 @@ class TestXMLDataSet:
 
         records = [r for r in caplog.records if r.levelname == "WARNING"]
         expected_log_message = (
-            f"Dropping `storage_options` for {filepath}, "
-            f"please specify them under `fs_args` or `credentials`."
+            f"Dropping 'storage_options' for {filepath}, "
+            f"please specify them under 'fs_args' or 'credentials'."
         )
         assert records[0].getMessage() == expected_log_message
         assert "storage_options" not in ds._save_args
@@ -188,7 +188,7 @@ class TestXMLDataSetVersioned:
         corresponding hdf file for a given save version already exists."""
         versioned_xml_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for XMLDataSet\(.+\) must "
+            r"Save path \'.+\' for XMLDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -206,8 +206,8 @@ class TestXMLDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match "
-            rf"load version `{load_version}` for XMLDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match "
+            rf"load version '{load_version}' for XMLDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_xml_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pickle/test_pickle_dataset.py
+++ b/tests/extras/datasets/pickle/test_pickle_dataset.py
@@ -211,7 +211,7 @@ class TestPickleDataSetVersioned:
         corresponding Pickle file for a given save version already exists."""
         versioned_pickle_data_set.save(dummy_dataframe)
         pattern = (
-            r"Save path \`.+\` for PickleDataSet\(.+\) must "
+            r"Save path \'.+\' for PickleDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -229,8 +229,8 @@ class TestPickleDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for PickleDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for PickleDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_pickle_data_set.save(dummy_dataframe)

--- a/tests/extras/datasets/pickle/test_pickle_dataset.py
+++ b/tests/extras/datasets/pickle/test_pickle_dataset.py
@@ -138,7 +138,7 @@ class TestPickleDataSet:
     def test_invalid_backend(self, mocker):
         pattern = (
             r"Selected backend 'invalid' should satisfy the pickle interface. "
-            r"Missing one of `load` and `dump` on the backend."
+            r"Missing one of 'load' and 'dump' on the backend."
         )
         mocker.patch(
             "kedro.extras.datasets.pickle.pickle_dataset.importlib.import_module",

--- a/tests/extras/datasets/pillow/test_image_dataset.py
+++ b/tests/extras/datasets/pillow/test_image_dataset.py
@@ -178,7 +178,7 @@ class TestImageDataSetVersioned:
         corresponding image file for a given save version already exists."""
         versioned_image_dataset.save(image_object)
         pattern = (
-            r"Save path \`.+\` for ImageDataSet\(.+\) must "
+            r"Save path \'.+\' for ImageDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -196,8 +196,8 @@ class TestImageDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for ImageDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for ImageDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_image_dataset.save(image_object)

--- a/tests/extras/datasets/redis/test_redis_dataset.py
+++ b/tests/extras/datasets/redis/test_redis_dataset.py
@@ -143,7 +143,7 @@ class TestPickleDataSet:
     def test_invalid_backend(self, mocker):
         pattern = (
             r"Selected backend 'invalid' should satisfy the pickle interface. "
-            r"Missing one of `loads` and `dumps` on the backend."
+            r"Missing one of 'loads' and 'dumps' on the backend."
         )
         mocker.patch(
             "kedro.extras.datasets.pickle.pickle_dataset.importlib.import_module",

--- a/tests/extras/datasets/spark/test_spark_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_dataset.py
@@ -281,8 +281,8 @@ class TestSparkDataSet:
         Path(schemapath).write_text("dummy", encoding="utf-8")
 
         pattern = (
-            f"Contents of `schema.filepath` ({schemapath}) are invalid. Please"
-            f"provide a valid JSON serialized `pyspark.sql.types.StructType`."
+            f"Contents of 'schema.filepath' ({schemapath}) are invalid. Please"
+            f"provide a valid JSON serialized 'pyspark.sql.types.StructType'."
         )
 
         with pytest.raises(DataSetError, match=re.escape(pattern)):
@@ -296,8 +296,8 @@ class TestSparkDataSet:
         filepath = (tmp_path / "data").as_posix()
 
         pattern = (
-            "Schema load argument does not specify a `filepath` attribute. Please"
-            "include a path to a JSON serialized `pyspark.sql.types.StructType`."
+            "Schema load argument does not specify a 'filepath' attribute. Please"
+            "include a path to a JSON serialized 'pyspark.sql.types.StructType'."
         )
 
         with pytest.raises(DataSetError, match=pattern):
@@ -363,9 +363,9 @@ class TestSparkDataSet:
     def test_file_format_delta_and_unsupported_mode(self, tmp_path, mode):
         filepath = (tmp_path / "test_data").as_posix()
         pattern = (
-            f"It is not possible to perform `save()` for file format `delta` "
-            f"with mode `{mode}` on `SparkDataSet`. "
-            f"Please use `spark.DeltaTableDataSet` instead."
+            f"It is not possible to perform 'save()' for file format 'delta' "
+            f"with mode '{mode}' on 'SparkDataSet'. "
+            f"Please use 'spark.DeltaTableDataSet' instead."
         )
 
         with pytest.raises(DataSetError, match=re.escape(pattern)):
@@ -502,7 +502,7 @@ class TestSparkDataSetVersionedLocal:
         versioned_local.save(sample_spark_df)
 
         pattern = (
-            r"Save path `.+` for SparkDataSet\(.+\) must not exist "
+            r"Save path '.+' for SparkDataSet\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -766,7 +766,7 @@ class TestSparkDataSetVersionedS3:
         mocker.patch.object(versioned_dataset_s3, "_exists_function", return_value=True)
 
         pattern = (
-            r"Save path `.+` for SparkDataSet\(.+\) must not exist "
+            r"Save path '.+' for SparkDataSet\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -776,8 +776,8 @@ class TestSparkDataSetVersionedS3:
 
     def test_s3n_warning(self, version):
         pattern = (
-            "`s3n` filesystem has now been deprecated by Spark, "
-            "please consider switching to `s3a`"
+            "'s3n' filesystem has now been deprecated by Spark, "
+            "please consider switching to 's3a'"
         )
         with pytest.warns(DeprecationWarning, match=pattern):
             SparkDataSet(filepath=f"s3n://{BUCKET_NAME}/{FILENAME}", version=version)
@@ -906,7 +906,7 @@ class TestSparkDataSetVersionedHdfs:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save path `.+` for SparkDataSet\(.+\) must not exist "
+            r"Save path '.+' for SparkDataSet\(.+\) must not exist "
             r"if versioning is enabled"
         )
         with pytest.raises(DataSetError, match=pattern):

--- a/tests/extras/datasets/spark/test_spark_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_dataset.py
@@ -486,8 +486,8 @@ class TestSparkDataSetVersionedLocal:
         )
 
         pattern = (
-            r"Save version `{ev.save}` did not match load version "
-            r"`{ev.load}` for SparkDataSet\(.+\)".format(ev=exact_version)
+            r"Save version '{ev.save}' did not match load version "
+            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_local.save(sample_spark_df)
@@ -749,8 +749,8 @@ class TestSparkDataSetVersionedS3:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save version `{ev.save}` did not match load version "
-            r"`{ev.load}` for SparkDataSet\(.+\)".format(ev=exact_version)
+            r"Save version '{ev.save}' did not match load version "
+            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_s3.save(mocked_spark_df)
@@ -882,8 +882,8 @@ class TestSparkDataSetVersionedHdfs:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save version `{ev.save}` did not match load version "
-            r"`{ev.load}` for SparkDataSet\(.+\)".format(ev=exact_version)
+            r"Save version '{ev.save}' did not match load version "
+            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
         )
 
         with pytest.warns(UserWarning, match=pattern):
@@ -921,7 +921,7 @@ class TestSparkDataSetVersionedHdfs:
     def test_hdfs_warning(self, version):
         pattern = (
             "HDFS filesystem support for versioned SparkDataSet is in beta "
-            "and uses `hdfs.client.InsecureClient`, please use with caution"
+            "and uses 'hdfs.client.InsecureClient', please use with caution"
         )
         with pytest.warns(UserWarning, match=pattern):
             SparkDataSet(filepath=f"hdfs://{HDFS_PREFIX}", version=version)

--- a/tests/extras/datasets/spark/test_spark_hive_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_hive_dataset.py
@@ -192,7 +192,7 @@ class TestSparkHiveDataSet:
     def test_upsert_config_err(self):
         # no pk provided should prompt config error
         with pytest.raises(
-            DataSetError, match="`table_pk` must be set to utilise `upsert` read mode"
+            DataSetError, match="'table_pk' must be set to utilise 'upsert' read mode"
         ):
             SparkHiveDataSet(database="default_1", table="table_1", write_mode="upsert")
 
@@ -248,8 +248,8 @@ class TestSparkHiveDataSet:
 
     def test_invalid_write_mode_provided(self):
         pattern = (
-            "Invalid `write_mode` provided: not_a_write_mode. "
-            "`write_mode` must be one of: "
+            "Invalid 'write_mode' provided: not_a_write_mode. "
+            "'write_mode' must be one of: "
             "append, error, errorifexists, upsert, overwrite"
         )
         with pytest.raises(DataSetError, match=re.escape(pattern)):

--- a/tests/extras/datasets/spark/test_spark_jdbc_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_jdbc_dataset.py
@@ -37,8 +37,8 @@ def spark_jdbc_args_save_load(spark_jdbc_args):
 
 def test_missing_url():
     error_message = (
-        "`url` argument cannot be empty. Please provide a JDBC"
-        " URL of the form ``jdbc:subprotocol:subname``."
+        "'url' argument cannot be empty. Please provide a JDBC"
+        " URL of the form 'jdbc:subprotocol:subname'."
     )
     with pytest.raises(DataSetError, match=error_message):
         SparkJDBCDataSet(url=None, table="dummy_table")
@@ -46,7 +46,7 @@ def test_missing_url():
 
 def test_missing_table():
     error_message = (
-        "`table` argument cannot be empty. Please provide"
+        "'table' argument cannot be empty. Please provide"
         " the name of the table to load or save data to."
     )
     with pytest.raises(DataSetError, match=error_message):
@@ -82,7 +82,7 @@ def test_save_args(spark_jdbc_args_save_load):
 
 
 def test_except_bad_credentials(spark_jdbc_args_credentials_with_none_password):
-    pattern = r"Credential property `password` cannot be None(.+)"
+    pattern = r"Credential property 'password' cannot be None(.+)"
     with pytest.raises(DataSetError, match=pattern):
         mock_save(spark_jdbc_args_credentials_with_none_password)
 

--- a/tests/extras/datasets/tensorflow/test_tensorflow_model_dataset.py
+++ b/tests/extras/datasets/tensorflow/test_tensorflow_model_dataset.py
@@ -192,7 +192,7 @@ class TestTensorFlowModelDataset:
             r"Sequential model. It does not work for subclassed models, because such models are "
             r"defined via the body of a Python method, which isn\'t safely serializable. Consider "
             r"saving to the Tensorflow SavedModel format \(by setting save_format=\"tf\"\) "
-            r"or using 'save_weights'."
+            r"or using `save_weights`."
         )
         with pytest.raises(DataSetError, match=pattern):
             hdf5_data_set.save(dummy_tf_subclassed_model)
@@ -310,7 +310,7 @@ class TestTensorFlowModelDatasetVersioned:
         corresponding file for a given save version already exists."""
         versioned_tf_model_dataset.save(dummy_tf_base_model)
         pattern = (
-            r"Save path \`.+\` for TensorFlowModelDataset\(.+\) must "
+            r"Save path \'.+\' for TensorFlowModelDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -331,7 +331,7 @@ class TestTensorFlowModelDatasetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version `{load_version}` "
+            rf"Save version '{save_version}' did not match load version '{load_version}' "
             rf"for TensorFlowModelDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):

--- a/tests/extras/datasets/tensorflow/test_tensorflow_model_dataset.py
+++ b/tests/extras/datasets/tensorflow/test_tensorflow_model_dataset.py
@@ -192,7 +192,7 @@ class TestTensorFlowModelDataset:
             r"Sequential model. It does not work for subclassed models, because such models are "
             r"defined via the body of a Python method, which isn\'t safely serializable. Consider "
             r"saving to the Tensorflow SavedModel format \(by setting save_format=\"tf\"\) "
-            r"or using `save_weights`."
+            r"or using 'save_weights'."
         )
         with pytest.raises(DataSetError, match=pattern):
             hdf5_data_set.save(dummy_tf_subclassed_model)

--- a/tests/extras/datasets/text/test_text_dataset.py
+++ b/tests/extras/datasets/text/test_text_dataset.py
@@ -132,7 +132,7 @@ class TestTextDataSetVersioned:
         corresponding text file for a given save version already exists."""
         versioned_txt_data_set.save(STRING)
         pattern = (
-            r"Save path \`.+\` for TextDataSet\(.+\) must "
+            r"Save path \'.+\' for TextDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -150,8 +150,8 @@ class TestTextDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for TextDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for TextDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_txt_data_set.save(STRING)

--- a/tests/extras/datasets/tracking/test_json_dataset.py
+++ b/tests/extras/datasets/tracking/test_json_dataset.py
@@ -62,7 +62,7 @@ class TestJSONDataSet:
 
     def test_load_fail(self, json_dataset, dummy_data):
         json_dataset.save(dummy_data)
-        pattern = r"Loading not supported for `JSONDataSet`"
+        pattern = r"Loading not supported for 'JSONDataSet'"
         with pytest.raises(DataSetError, match=pattern):
             json_dataset.load()
 

--- a/tests/extras/datasets/tracking/test_json_dataset.py
+++ b/tests/extras/datasets/tracking/test_json_dataset.py
@@ -147,7 +147,7 @@ class TestJSONDataSet:
         corresponding json file for a given save version already exists."""
         explicit_versioned_json_dataset.save(dummy_data)
         pattern = (
-            r"Save path \`.+\` for JSONDataSet\(.+\) must "
+            r"Save path \'.+\' for JSONDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -169,8 +169,8 @@ class TestJSONDataSet:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            f"Save version `{save_version}` did not match "
-            f"load version `{load_version}` for "
+            f"Save version '{save_version}' did not match "
+            f"load version '{load_version}' for "
             r"JSONDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):

--- a/tests/extras/datasets/tracking/test_metrics_dataset.py
+++ b/tests/extras/datasets/tracking/test_metrics_dataset.py
@@ -68,7 +68,7 @@ class TestMetricsDataSet:
 
     def test_load_fail(self, metrics_dataset, dummy_data):
         metrics_dataset.save(dummy_data)
-        pattern = r"Loading not supported for `MetricsDataSet`"
+        pattern = r"Loading not supported for 'MetricsDataSet'"
         with pytest.raises(DataSetError, match=pattern):
             metrics_dataset.load()
 

--- a/tests/extras/datasets/tracking/test_metrics_dataset.py
+++ b/tests/extras/datasets/tracking/test_metrics_dataset.py
@@ -160,7 +160,7 @@ class TestMetricsDataSet:
         corresponding json file for a given save version already exists."""
         explicit_versioned_metrics_dataset.save(dummy_data)
         pattern = (
-            r"Save path \`.+\` for MetricsDataSet\(.+\) must "
+            r"Save path \'.+\' for MetricsDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -178,8 +178,8 @@ class TestMetricsDataSet:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            f"Save version `{save_version}` did not match "
-            f"load version `{load_version}` for "
+            f"Save version '{save_version}' did not match "
+            f"load version '{load_version}' for "
             r"MetricsDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):

--- a/tests/extras/datasets/yaml/test_yaml_dataset.py
+++ b/tests/extras/datasets/yaml/test_yaml_dataset.py
@@ -157,7 +157,7 @@ class TestYAMLDataSetVersioned:
         corresponding yaml file for a given save version already exists."""
         versioned_yaml_data_set.save(dummy_data)
         pattern = (
-            r"Save path \`.+\` for YAMLDataSet\(.+\) must "
+            r"Save path \'.+\' for YAMLDataSet\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DataSetError, match=pattern):
@@ -175,8 +175,8 @@ class TestYAMLDataSetVersioned:
         """Check the warning when saving to the path that differs from
         the subsequent load path."""
         pattern = (
-            rf"Save version `{save_version}` did not match load version "
-            rf"`{load_version}` for YAMLDataSet\(.+\)"
+            rf"Save version '{save_version}' did not match load version "
+            rf"'{load_version}' for YAMLDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             versioned_yaml_data_set.save(dummy_data)

--- a/tests/extras/extensions/test_ipython.py
+++ b/tests/extras/extensions/test_ipython.py
@@ -206,7 +206,7 @@ class TestLoadIPythonExtension:
             (
                 RuntimeError,
                 "Kedro extension was registered but couldn't find a Kedro project. "
-                "Make sure you run `%reload_kedro <path_to_kedro_project>`.",
+                "Make sure you run '%reload_kedro <path_to_kedro_project>'.",
                 "WARNING",
             ),
         ],

--- a/tests/framework/cli/micropkg/test_micropkg_package.py
+++ b/tests/framework/cli/micropkg/test_micropkg_package.py
@@ -42,11 +42,11 @@ class TestMicropkgPackageCommand:
     @pytest.mark.parametrize(
         "options,package_name,success_message",
         [
-            ([], PIPELINE_NAME, f"`dummy_package.pipelines.{PIPELINE_NAME}` packaged!"),
+            ([], PIPELINE_NAME, f"'dummy_package.pipelines.{PIPELINE_NAME}' packaged!"),
             (
                 ["--alias", "alternative"],
                 "alternative",
-                f"`dummy_package.pipelines.{PIPELINE_NAME}` packaged as `alternative`!",
+                f"'dummy_package.pipelines.{PIPELINE_NAME}' packaged as 'alternative'!",
             ),
         ],
     )
@@ -157,7 +157,7 @@ class TestMicropkgPackageCommand:
 
         assert result.exit_code == 0
         success_message = (
-            f"`dummy_package.pipelines.{PIPELINE_NAME}` packaged! "
+            f"'dummy_package.pipelines.{PIPELINE_NAME}' packaged! "
             f"Location: {destination}"
         )
         assert success_message in result.output
@@ -191,7 +191,7 @@ class TestMicropkgPackageCommand:
 
         warning_message = f"Package file {sdist_file} will be overwritten!"
         success_message = (
-            f"`dummy_package.pipelines.{PIPELINE_NAME}` packaged! "
+            f"'dummy_package.pipelines.{PIPELINE_NAME}' packaged! "
             f"Location: {destination}"
         )
         assert warning_message in result.output
@@ -246,7 +246,7 @@ class TestMicropkgPackageCommand:
         )
 
         assert result.exit_code == 0
-        assert f"`dummy_package.pipelines.{PIPELINE_NAME}` packaged!" in result.output
+        assert f"'dummy_package.pipelines.{PIPELINE_NAME}' packaged!" in result.output
 
         sdist_location = fake_repo_path / "dist"
         assert f"Location: {sdist_location}" in result.output
@@ -551,7 +551,7 @@ class TestMicropkgPackageFromManifest:
 
         assert result.exit_code == 0
         expected_message = (
-            "Nothing to package. Please update the `pyproject.toml` "
+            "Nothing to package. Please update the 'pyproject.toml' "
             "package manifest section."
         )
         assert expected_message in result.output
@@ -576,6 +576,6 @@ class TestMicropkgPackageFromManifest:
         assert result.exit_code
         expected_message = (
             "Please specify a micro-package name or add '--all' to package all micro-packages in "
-            "the `pyproject.toml` package manifest section."
+            "the 'pyproject.toml' package manifest section."
         )
         assert expected_message in result.output

--- a/tests/framework/cli/micropkg/test_micropkg_package.py
+++ b/tests/framework/cli/micropkg/test_micropkg_package.py
@@ -339,7 +339,7 @@ class TestMicropkgPackageCommand:
         )
 
         assert result.exit_code == 0
-        assert "`dummy_package.pipelines.retail` packaged!" in result.output
+        assert "'dummy_package.pipelines.retail' packaged!" in result.output
 
         sdist_location = fake_repo_path / "dist"
         assert f"Location: {sdist_location}" in result.output
@@ -404,7 +404,7 @@ class TestMicropkgPackageCommand:
         )
 
         assert result.exit_code == 0
-        assert "`dummy_package.pipelines.retail` packaged!" in result.output
+        assert "'dummy_package.pipelines.retail' packaged!" in result.output
 
         sdist_location = fake_repo_path / "dist"
         assert f"Location: {sdist_location}" in result.output

--- a/tests/framework/cli/micropkg/test_micropkg_pull.py
+++ b/tests/framework/cli/micropkg/test_micropkg_pull.py
@@ -813,7 +813,7 @@ class TestMicropkgPullFromManifest:
 
         assert result.exit_code == 0
         expected_message = (
-            "Nothing to pull. Please update the `pyproject.toml` package "
+            "Nothing to pull. Please update the 'pyproject.toml' package "
             "manifest section."
         )
         assert expected_message in result.output
@@ -838,6 +838,6 @@ class TestMicropkgPullFromManifest:
         assert result.exit_code
         expected_message = (
             "Please specify a package path or add '--all' to pull all micro-packages in the"
-            " `pyproject.toml` package manifest section."
+            " 'pyproject.toml' package manifest section."
         )
         assert expected_message in result.output

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -292,7 +292,7 @@ class TestPipelineDeleteCommand:
         assert f"Pipeline '{PIPELINE_NAME}' was successfully deleted." in result.output
         assert (
             f"If you added the pipeline '{PIPELINE_NAME}' to 'register_pipelines()' in "
-            f""""{fake_package_path / 'pipeline_registry.py'}", you will need to remove it."""
+            f"""'{fake_package_path / "pipeline_registry.py"}', you will need to remove it."""
         ) in result.output
 
         assert not source_path.exists()
@@ -328,7 +328,7 @@ class TestPipelineDeleteCommand:
         assert f"Pipeline '{PIPELINE_NAME}' was successfully deleted." in result.output
         assert (
             f"If you added the pipeline '{PIPELINE_NAME}' to 'register_pipelines()' in "
-            f""""{fake_package_path / 'pipeline_registry.py'}", you will need to remove it."""
+            f"""'{fake_package_path / "pipeline_registry.py"}', you will need to remove it."""
         ) in result.output
 
         assert not source_path.exists()

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -59,14 +59,14 @@ class TestPipelineCreateCommand:
 
         assert result.exit_code == 0
         assert (
-            f"To be able to run the pipeline `{PIPELINE_NAME}`, you will need "
-            f"to add it to `register_pipelines()`" in result.output
+            f"To be able to run the pipeline '{PIPELINE_NAME}', you will need "
+            f"to add it to 'register_pipelines()'" in result.output
         )
 
         # pipeline
-        assert f"Creating the pipeline `{PIPELINE_NAME}`: OK" in result.output
-        assert f"Location: `{pipelines_dir / PIPELINE_NAME}`" in result.output
-        assert f"Pipeline `{PIPELINE_NAME}` was successfully created." in result.output
+        assert f"Creating the pipeline '{PIPELINE_NAME}': OK" in result.output
+        assert f"Location: '{pipelines_dir / PIPELINE_NAME}'" in result.output
+        assert f"Pipeline '{PIPELINE_NAME}' was successfully created." in result.output
 
         # config
         conf_env = env or "base"
@@ -93,11 +93,11 @@ class TestPipelineCreateCommand:
         result = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
         assert result.exit_code == 0
         assert (
-            f"To be able to run the pipeline `{PIPELINE_NAME}`, you will need "
-            f"to add it to `register_pipelines()`" in result.output
+            f"To be able to run the pipeline '{PIPELINE_NAME}', you will need "
+            f"to add it to 'register_pipelines()'" in result.output
         )
-        assert f"Creating the pipeline `{PIPELINE_NAME}`: OK" in result.output
-        assert f"Pipeline `{PIPELINE_NAME}` was successfully created." in result.output
+        assert f"Creating the pipeline '{PIPELINE_NAME}': OK" in result.output
+        assert f"Pipeline '{PIPELINE_NAME}' was successfully created." in result.output
 
         conf_dirs = list((fake_repo_path / settings.CONF_SOURCE).rglob(PIPELINE_NAME))
         assert conf_dirs == []  # no configs created for the pipeline
@@ -173,8 +173,8 @@ class TestPipelineCreateCommand:
         result = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
 
         assert result.exit_code == 0
-        assert "__init__.py`: SKIPPED" in result.output
-        assert f"parameters{os.sep}{PIPELINE_NAME}.yml`: SKIPPED" in result.output
+        assert "__init__.py': SKIPPED" in result.output
+        assert f"parameters{os.sep}{PIPELINE_NAME}.yml': SKIPPED" in result.output
         assert result.output.count("SKIPPED") == 2  # only 2 files skipped
 
     def test_failed_copy(
@@ -240,7 +240,7 @@ class TestPipelineCreateCommand:
 
         second = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
         assert second.exit_code
-        assert f"Creating the pipeline `{PIPELINE_NAME}`: FAILED" in second.output
+        assert f"Creating the pipeline '{PIPELINE_NAME}': FAILED" in second.output
         assert "directory already exists" in second.output
 
     def test_bad_env(self, fake_project_cli, fake_metadata):
@@ -249,7 +249,7 @@ class TestPipelineCreateCommand:
         cmd = ["pipeline", "create", "-e", env, PIPELINE_NAME]
         result = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
         assert result.exit_code
-        assert f"Unable to locate environment `{env}`" in result.output
+        assert f"Unable to locate environment '{env}'" in result.output
 
 
 @pytest.mark.usefixtures("chdir_to_dummy_project", "make_pipelines")
@@ -285,14 +285,14 @@ class TestPipelineDeleteCommand:
             / f"{PIPELINE_NAME}.yml"
         )
 
-        assert f"Deleting `{source_path}`: OK" in result.output
-        assert f"Deleting `{tests_path}`: OK" in result.output
-        assert f"Deleting `{params_path}`: OK" in result.output
+        assert f"Deleting '{source_path}': OK" in result.output
+        assert f"Deleting '{tests_path}': OK" in result.output
+        assert f"Deleting '{params_path}': OK" in result.output
 
-        assert f"Pipeline `{PIPELINE_NAME}` was successfully deleted." in result.output
+        assert f"Pipeline '{PIPELINE_NAME}' was successfully deleted." in result.output
         assert (
-            f"If you added the pipeline `{PIPELINE_NAME}` to `register_pipelines()` in "
-            f"`{fake_package_path / 'pipeline_registry.py'}`, you will need to remove it."
+            f"If you added the pipeline '{PIPELINE_NAME}' to 'register_pipelines()' in "
+            f""""{fake_package_path / 'pipeline_registry.py'}", you will need to remove it."""
         ) in result.output
 
         assert not source_path.exists()
@@ -321,14 +321,14 @@ class TestPipelineDeleteCommand:
             / f"{PIPELINE_NAME}.yml"
         )
 
-        assert f"Deleting `{source_path}`" not in result.output
-        assert f"Deleting `{tests_path}`: OK" in result.output
-        assert f"Deleting `{params_path}`: OK" in result.output
+        assert f"Deleting '{source_path}'" not in result.output
+        assert f"Deleting '{tests_path}': OK" in result.output
+        assert f"Deleting '{params_path}': OK" in result.output
 
-        assert f"Pipeline `{PIPELINE_NAME}` was successfully deleted." in result.output
+        assert f"Pipeline '{PIPELINE_NAME}' was successfully deleted." in result.output
         assert (
-            f"If you added the pipeline `{PIPELINE_NAME}` to `register_pipelines()` in "
-            f"`{fake_package_path / 'pipeline_registry.py'}`, you will need to remove it."
+            f"If you added the pipeline '{PIPELINE_NAME}' to 'register_pipelines()' in "
+            f""""{fake_package_path / 'pipeline_registry.py'}", you will need to remove it."""
         ) in result.output
 
         assert not source_path.exists()
@@ -351,7 +351,7 @@ class TestPipelineDeleteCommand:
         )
 
         assert result.exit_code, result.output
-        assert f"Deleting `{source_path}`: FAILED" in result.output
+        assert f"Deleting '{source_path}': FAILED" in result.output
 
     @pytest.mark.parametrize(
         "bad_name,error_message",
@@ -379,7 +379,7 @@ class TestPipelineDeleteCommand:
             obj=fake_metadata,
         )
         assert result.exit_code
-        assert "Pipeline `non_existent` not found." in result.output
+        assert "Pipeline 'non_existent' not found." in result.output
 
     def test_bad_env(self, fake_project_cli, fake_metadata):
         """Test error when provided conf environment does not exist."""
@@ -389,7 +389,7 @@ class TestPipelineDeleteCommand:
             obj=fake_metadata,
         )
         assert result.exit_code
-        assert "Unable to locate environment `invalid_env`" in result.output
+        assert "Unable to locate environment 'invalid_env'" in result.output
 
     @pytest.mark.parametrize("input_", ["n", "N", "random"])
     def test_pipeline_delete_confirmation(
@@ -419,7 +419,7 @@ class TestPipelineDeleteCommand:
         assert str(params_path) in result.output
 
         assert (
-            f"Are you sure you want to delete pipeline `{PIPELINE_NAME}`"
+            f"Are you sure you want to delete pipeline '{PIPELINE_NAME}'"
             in result.output
         )
         assert "Deletion aborted!" in result.output
@@ -460,7 +460,7 @@ class TestPipelineDeleteCommand:
         assert str(params_path) in result.output
 
         assert (
-            f"Are you sure you want to delete pipeline `{PIPELINE_NAME}`"
+            f"Are you sure you want to delete pipeline '{PIPELINE_NAME}'"
             in result.output
         )
         assert "Deletion aborted!" in result.output

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -66,7 +66,7 @@ class TestCatalogListCommand:
 
         assert result.exit_code
         expected_output = (
-            "Error: `fake` pipeline not found! Existing pipelines: pipeline, second"
+            "Error: 'fake' pipeline not found! Existing pipelines: pipeline, second"
         )
         assert expected_output in result.output
 
@@ -182,7 +182,7 @@ class TestCatalogCreateCommand:
 
         existing_pipelines = ", ".join(sorted(mock_pipelines.keys()))
         expected_output = (
-            f"Error: `fake` pipeline not found! Existing "
+            f"Error: 'fake' pipeline not found! Existing "
             f"pipelines: {existing_pipelines}\n"
         )
         assert expected_output in result.output

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -734,8 +734,8 @@ class TestRunCommand:
         assert result.exit_code, result.output
 
         expected_output = (
-            f"Error: Expected the form of `load_version` to be "
-            f"`dataset_name:YYYY-MM-DDThh.mm.ss.sssZ`,"
+            f"Error: Expected the form of 'load_version' to be "
+            f"'dataset_name:YYYY-MM-DDThh.mm.ss.sssZ',"
             f"found {load_version} instead\n"
         )
         assert expected_output in result.output

--- a/tests/framework/cli/test_jupyter.py
+++ b/tests/framework/cli/test_jupyter.py
@@ -69,8 +69,8 @@ class TestJupyterNotebookCommand:
 
         assert result.exit_code
         error = (
-            "Module `notebook` not found. Make sure to install required project "
-            "dependencies by running the `pip install -r src/requirements.txt` command first."
+            "Module 'notebook' not found. Make sure to install required project "
+            "dependencies by running the 'pip install -r src/requirements.txt' command first."
         )
         assert error in result.output
 
@@ -119,8 +119,8 @@ class TestJupyterLabCommand:
 
         assert result.exit_code
         error = (
-            "Module `jupyterlab` not found. Make sure to install required project "
-            "dependencies by running the `pip install -r src/requirements.txt` command first."
+            "Module 'jupyterlab' not found. Make sure to install required project "
+            "dependencies by running the 'pip install -r src/requirements.txt' command first."
         )
         assert error in result.output
 

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -278,8 +278,8 @@ class TestIpythonCommand:
 
         assert result.exit_code
         error = (
-            "Module `IPython` not found. Make sure to install required project "
-            "dependencies by running the `pip install -r src/requirements.txt` command first."
+            "Module 'IPython' not found. Make sure to install required project "
+            "dependencies by running the 'pip install -r src/requirements.txt' command first."
         )
         assert error in result.output
 
@@ -476,4 +476,4 @@ class TestBuildReqsCommand:
         result = CliRunner().invoke(fake_project_cli, ["build-reqs"], obj=fake_metadata)
         assert result.exit_code  # Error expected
         assert isinstance(result.exception, FileNotFoundError)
-        assert f"File `{requirements_txt}` not found" in str(result.exception)
+        assert f"File '{requirements_txt}' not found" in str(result.exception)

--- a/tests/framework/cli/test_registry.py
+++ b/tests/framework/cli/test_registry.py
@@ -62,7 +62,7 @@ class TestRegistryDescribeCommand:
 
         assert result.exit_code
         expected_output = (
-            "Error: `missing` pipeline not found. Existing pipelines: "
+            "Error: 'missing' pipeline not found. Existing pipelines: "
             "[__default__, de, dp, ds]\n"
         )
         assert expected_output in result.output

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -242,9 +242,9 @@ class TestKedroContext:
 
     def test_wrong_catalog_type(self, mock_settings_file_bad_data_catalog_class):
         pattern = (
-            "Invalid value `tests.framework.context.test_context.BadCatalog` received "
-            "for setting `DATA_CATALOG_CLASS`. "
-            "It must be a subclass of `kedro.io.data_catalog.DataCatalog`."
+            "Invalid value 'tests.framework.context.test_context.BadCatalog' received "
+            "for setting 'DATA_CATALOG_CLASS'. "
+            "It must be a subclass of 'kedro.io.data_catalog.DataCatalog'."
         )
         mock_settings = _ProjectSettings(
             settings_file=str(mock_settings_file_bad_data_catalog_class)

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -335,9 +335,9 @@ class TestKedroSession:
 
     def test_broken_config_loader(self, mock_settings_file_bad_config_loader_class):
         pattern = (
-            "Invalid value `tests.framework.session.test_session.BadConfigLoader` received "
-            "for setting `CONFIG_LOADER_CLASS`. "
-            "It must be a subclass of `kedro.config.abstract_config.AbstractConfigLoader`."
+            "Invalid value 'tests.framework.session.test_session.BadConfigLoader' received "
+            "for setting 'CONFIG_LOADER_CLASS'. "
+            "It must be a subclass of 'kedro.config.abstract_config.AbstractConfigLoader'."
         )
         mock_settings = _ProjectSettings(
             settings_file=str(mock_settings_file_bad_config_loader_class)
@@ -376,8 +376,8 @@ class TestKedroSession:
         assert session._store._session_id == fake_session_id
         session.close()
         expected_log_messages = [
-            "`read()` not implemented for `BaseSessionStore`. Assuming empty store.",
-            "`save()` not implemented for `BaseSessionStore`. Skipping the step.",
+            "'read()' not implemented for 'BaseSessionStore'. Assuming empty store.",
+            "'save()' not implemented for 'BaseSessionStore'. Skipping the step.",
         ]
         actual_log_messages = [
             rec.getMessage()
@@ -410,9 +410,9 @@ class TestKedroSession:
 
     def test_wrong_store_type(self, mock_settings_file_bad_session_store_class):
         pattern = (
-            "Invalid value `tests.framework.session.test_session.BadStore` received "
-            "for setting `SESSION_STORE_CLASS`. "
-            "It must be a subclass of `kedro.framework.session.store.BaseSessionStore`."
+            "Invalid value 'tests.framework.session.test_session.BadStore' received "
+            "for setting 'SESSION_STORE_CLASS'. "
+            "It must be a subclass of 'kedro.framework.session.store.BaseSessionStore'."
         )
         mock_settings = _ProjectSettings(
             settings_file=str(mock_settings_file_bad_session_store_class)
@@ -426,7 +426,7 @@ class TestKedroSession:
         classpath = f"{BaseSessionStore.__module__}.{BaseSessionStore.__qualname__}"
         pattern = (
             f"Store config must only contain arguments valid for "
-            f"the constructor of `{classpath}`."
+            f"the constructor of '{classpath}'."
         )
         with pytest.raises(ValueError, match=re.escape(pattern)):
             KedroSession.create(mock_package_name, fake_project)
@@ -439,7 +439,7 @@ class TestKedroSession:
         mock_package_name,
     ):
         classpath = f"{BaseSessionStore.__module__}.{BaseSessionStore.__qualname__}"
-        pattern = f"Failed to instantiate session store of type `{classpath}`."
+        pattern = f"Failed to instantiate session store of type '{classpath}'."
         with pytest.raises(ValueError, match=re.escape(pattern)):
             KedroSession.create(mock_package_name, fake_project)
 

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -494,8 +494,8 @@ class TestBeforeNodeRunHookWithInputUpdates:
         catalog.save("boats", dummy_dataframe)
 
         pattern = (
-            "`before_node_run` must return either None or a dictionary "
-            "mapping dataset names to updated values, got `MockDatasetReplacement`"
+            "'before_node_run' must return either None or a dictionary "
+            "mapping dataset names to updated values, got 'MockDatasetReplacement'"
         )
         with pytest.raises(TypeError, match=re.escape(pattern)):
             mock_session_with_broken_before_node_run_hooks.run()
@@ -510,8 +510,8 @@ class TestBeforeNodeRunHookWithInputUpdates:
         catalog.save("boats", dummy_dataframe)
 
         pattern = (
-            "`before_node_run` must return either None or a dictionary "
-            "mapping dataset names to updated values, got `MockDatasetReplacement`"
+            "'before_node_run' must return either None or a dictionary "
+            "mapping dataset names to updated values, got 'MockDatasetReplacement'"
         )
         with pytest.raises(TypeError, match=re.escape(pattern)):
             mock_session_with_broken_before_node_run_hooks.run(runner=ParallelRunner())

--- a/tests/framework/session/test_store.py
+++ b/tests/framework/session/test_store.py
@@ -20,7 +20,7 @@ class TestBaseStore:
         assert store._session_id == FAKE_SESSION_ID
 
         expected_debug_messages = [
-            "`read()` not implemented for `BaseSessionStore`. Assuming empty store."
+            "'read()' not implemented for 'BaseSessionStore'. Assuming empty store."
         ]
         actual_debug_messages = [
             rec.getMessage()
@@ -38,8 +38,8 @@ class TestBaseStore:
         assert store == {}
 
         expected_debug_messages = [
-            "`read()` not implemented for `BaseSessionStore`. Assuming empty store.",
-            "`save()` not implemented for `BaseSessionStore`. Skipping the step.",
+            "'read()' not implemented for 'BaseSessionStore'. Assuming empty store.",
+            "'save()' not implemented for 'BaseSessionStore'. Skipping the step.",
         ]
         actual_debug_messages = [
             rec.getMessage()

--- a/tests/io/test_cached_dataset.py
+++ b/tests/io/test_cached_dataset.py
@@ -92,7 +92,7 @@ class TestCachedDataset:
     def test_bad_argument(self):
         with pytest.raises(
             ValueError,
-            match=r"The argument type of `dataset` "
+            match=r"The argument type of 'dataset' "
             r"should be either a dict/YAML representation "
             r"of the dataset, or the actual dataset object",
         ):
@@ -108,7 +108,7 @@ class TestCachedDataset:
         with pytest.raises(
             DataSetError,
             match=r"Cached datasets should specify that they are "
-            r"versioned in the `CachedDataSet`, not in the "
+            r"versioned in the 'CachedDataSet', not in the "
             r"wrapped dataset",
         ):
             _ = DataCatalog.from_config(config, load_versions={"test_ds": "42"})

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -215,7 +215,7 @@ class TestDataCatalog:
         log_record = caplog.records[0]
         assert log_record.levelname == "WARNING"
         assert (
-            "`exists()` not implemented for `LambdaDataSet`. "
+            "'exists()' not implemented for 'LambdaDataSet'. "
             "Assuming output does not exist." in log_record.message
         )
         assert result is False
@@ -263,7 +263,7 @@ class TestDataCatalog:
     def test_multi_catalog_list_bad_regex(self, multi_catalog):
         """Test that bad regex is caught accordingly"""
         escaped_regex = r"\(\("
-        pattern = f"Invalid regular expression provided: `{escaped_regex}`"
+        pattern = f"Invalid regular expression provided: '{escaped_regex}'"
         with pytest.raises(SyntaxError, match=pattern):
             multi_catalog.list("((")
 
@@ -349,8 +349,8 @@ class TestDataCatalogFromConfig:
         in the config"""
         del sane_config["catalog"]["boats"]["type"]
         pattern = (
-            "An exception occurred when parsing config for DataSet `boats`:\n"
-            "`type` is missing from DataSet catalog configuration"
+            "An exception occurred when parsing config for DataSet 'boats':\n"
+            "'type' is missing from DataSet catalog configuration"
         )
         with pytest.raises(DataSetError, match=re.escape(pattern)):
             DataCatalog.from_config(**sane_config)
@@ -361,7 +361,7 @@ class TestDataCatalogFromConfig:
             "type"
         ] = "kedro.invalid_module_name.io.CSVDataSet"
 
-        error_msg = "Class `kedro.invalid_module_name.io.CSVDataSet` not found"
+        error_msg = "Class 'kedro.invalid_module_name.io.CSVDataSet' not found"
         with pytest.raises(DataSetError, match=re.escape(error_msg)):
             DataCatalog.from_config(**sane_config)
 
@@ -369,7 +369,7 @@ class TestDataCatalogFromConfig:
         """Check the error if the type points to a relative import"""
         sane_config["catalog"]["boats"]["type"] = ".CSVDataSetInvalid"
 
-        pattern = "`type` class path does not support relative paths"
+        pattern = "'type' class path does not support relative paths"
         with pytest.raises(DataSetError, match=re.escape(pattern)):
             DataCatalog.from_config(**sane_config)
 
@@ -383,8 +383,8 @@ class TestDataCatalogFromConfig:
         sane_config["catalog"]["boats"]["type"] = "kedro.io.CSVDataSetInvalid"
 
         pattern = (
-            "An exception occurred when parsing config for DataSet `boats`:\n"
-            "Class `kedro.io.CSVDataSetInvalid` not found"
+            "An exception occurred when parsing config for DataSet 'boats':\n"
+            "Class 'kedro.io.CSVDataSetInvalid' not found"
         )
         with pytest.raises(DataSetError, match=re.escape(pattern)):
             DataCatalog.from_config(**sane_config)
@@ -393,9 +393,9 @@ class TestDataCatalogFromConfig:
         """Check the error if the type points to invalid class"""
         sane_config["catalog"]["boats"]["type"] = "DataCatalog"
         pattern = (
-            "An exception occurred when parsing config for DataSet `boats`:\n"
-            "DataSet type `kedro.io.data_catalog.DataCatalog` is invalid: "
-            "all data set types must extend `AbstractDataSet`"
+            "An exception occurred when parsing config for DataSet 'boats':\n"
+            "DataSet type 'kedro.io.data_catalog.DataCatalog' is invalid: "
+            "all data set types must extend 'AbstractDataSet'"
         )
         with pytest.raises(DataSetError, match=re.escape(pattern)):
             DataCatalog.from_config(**sane_config)
@@ -405,7 +405,7 @@ class TestDataCatalogFromConfig:
         sane_config["catalog"]["boats"]["save_and_load_args"] = False
         pattern = (
             r"DataSet 'boats' must only contain arguments valid for "
-            r"the constructor of `.*CSVDataSet`"
+            r"the constructor of '.*CSVDataSet'"
         )
         with pytest.raises(DataSetError, match=pattern):
             DataCatalog.from_config(**sane_config)
@@ -479,7 +479,7 @@ class TestDataCatalogFromConfig:
 
     def test_error_dataset_init(self, bad_config):
         """Check the error when trying to instantiate erroneous data set"""
-        pattern = r"Failed to instantiate DataSet \'bad\' of type `.*BadDataSet`"
+        pattern = r"Failed to instantiate DataSet \'bad\' of type '.*BadDataSet'"
         with pytest.raises(DataSetError, match=pattern):
             DataCatalog.from_config(bad_config, None)
 
@@ -568,7 +568,7 @@ class TestDataCatalogVersioned:
         DataCatalog.from_config(**sane_config)
         log_record = caplog.records[0]
         expected_log_message = (
-            "`version` attribute removed from data set configuration since it "
+            "'version' attribute removed from data set configuration since it "
             "is a reserved word and cannot be directly specified"
         )
         assert log_record.levelname == "WARNING"

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -578,7 +578,7 @@ class TestDataCatalogVersioned:
         sane_config["catalog"]["boats"]["versioned"] = True
         version = generate_timestamp()
         load_version = {"non-boart": version}
-        pattern = r"\`load_versions\` keys \[non-boart\] are not found in the catalog\."
+        pattern = r"\'load_versions\' keys \[non-boart\] are not found in the catalog\."
         with pytest.raises(DataSetNotFoundError, match=pattern):
             DataCatalog.from_config(**sane_config, load_versions=load_version)
 

--- a/tests/io/test_incremental_dataset.py
+++ b/tests/io/test_incremental_dataset.py
@@ -241,14 +241,14 @@ class TestIncrementalDataSetLocal:
         [
             (
                 {"versioned": True},
-                "`IncrementalDataSet` does not support versioning "
-                "of the checkpoint. Please remove `versioned` key from the "
+                "'IncrementalDataSet' does not support versioning "
+                "of the checkpoint. Please remove 'versioned' key from the "
                 "checkpoint definition.",
             ),
             (
                 {"version": None},
-                "`IncrementalDataSet` does not support versioning "
-                "of the checkpoint. Please remove `version` key from the "
+                "'IncrementalDataSet' does not support versioning "
+                "of the checkpoint. Please remove 'version' key from the "
                 "checkpoint definition.",
             ),
         ],

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -80,8 +80,8 @@ class TestLambdaDataSetLoad:
 
     def test_load_not_callable(self):
         pattern = (
-            r"`load` function for LambdaDataSet must be a Callable\. "
-            r"Object of type `str` provided instead\."
+            r"'load' function for LambdaDataSet must be a Callable\. "
+            r"Object of type 'str' provided instead\."
         )
         with pytest.raises(DataSetError, match=pattern):
             LambdaDataSet("load", None)
@@ -113,15 +113,15 @@ class TestLambdaDataSetSave:
 
     def test_save_none(self, mocked_save, mocked_data_set):
         """Check the error when passing None to `save` call"""
-        pattern = "Saving `None` to a `DataSet` is not allowed"
+        pattern = "Saving 'None' to a 'DataSet' is not allowed"
         with pytest.raises(DataSetError, match=pattern):
             mocked_data_set.save(None)
         assert mocked_save.called == 0
 
     def test_save_not_callable(self):
         pattern = (
-            r"`save` function for LambdaDataSet must be a Callable\. "
-            r"Object of type `str` provided instead\."
+            r"'save' function for LambdaDataSet must be a Callable\. "
+            r"Object of type 'str' provided instead\."
         )
         with pytest.raises(DataSetError, match=pattern):
             LambdaDataSet(None, "save")
@@ -154,8 +154,8 @@ class TestLambdaDataSetExists:
 
     def test_exists_not_callable(self):
         pattern = (
-            r"`exists` function for LambdaDataSet must be a Callable\. "
-            r"Object of type `str` provided instead\."
+            r"'exists' function for LambdaDataSet must be a Callable\. "
+            r"Object of type 'str' provided instead\."
         )
         with pytest.raises(DataSetError, match=pattern):
             LambdaDataSet(None, None, "exists")
@@ -187,8 +187,8 @@ class TestLambdaDataSetRelease:
 
     def test_release_not_callable(self):
         pattern = (
-            r"`release` function for LambdaDataSet must be a Callable\. "
-            r"Object of type `str` provided instead\."
+            r"'release' function for LambdaDataSet must be a Callable\. "
+            r"Object of type 'str' provided instead\."
         )
         with pytest.raises(DataSetError, match=pattern):
             LambdaDataSet(None, None, None, "release")

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -149,7 +149,7 @@ class TestMemoryDataSet:
     def test_saving_none(self):
         """Check the error when attempting to save the data set without
         providing the data"""
-        pattern = r"Saving `None` to a `DataSet` is not allowed"
+        pattern = r"Saving 'None' to a 'DataSet' is not allowed"
         with pytest.raises(DataSetError, match=pattern):
             MemoryDataSet().save(None)
 

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -319,7 +319,7 @@ class TestPartitionedDataSetLocal:
     )
     def test_filepath_arg_warning(self, pds_config, filepath_arg):
         pattern = (
-            f"`{filepath_arg}` key must not be specified in the dataset definition as it "
+            f"'{filepath_arg}' key must not be specified in the dataset definition as it "
             f"will be overwritten by partition path"
         )
         with pytest.warns(UserWarning, match=re.escape(pattern)):

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -258,17 +258,17 @@ class TestPartitionedDataSetLocal:
     @pytest.mark.parametrize(
         "dataset_config,error_pattern",
         [
-            ("UndefinedDatasetType", "Class `UndefinedDatasetType` not found"),
+            ("UndefinedDatasetType", "Class 'UndefinedDatasetType' not found"),
             (
                 "missing.module.UndefinedDatasetType",
-                r"Class `missing\.module\.UndefinedDatasetType` not found",
+                r"Class 'missing\.module\.UndefinedDatasetType' not found",
             ),
             (
                 FakeDataSet,
-                r"DataSet type `tests\.io\.test_partitioned_dataset\.FakeDataSet` "
-                r"is invalid\: all data set types must extend `AbstractDataSet`",
+                r"DataSet type 'tests\.io\.test_partitioned_dataset\.FakeDataSet' "
+                r"is invalid\: all data set types must extend 'AbstractDataSet'",
             ),
-            ({}, "`type` is missing from DataSet catalog configuration"),
+            ({}, "'type' is missing from DataSet catalog configuration"),
         ],
     )
     def test_invalid_dataset_config(self, dataset_config, error_pattern):
@@ -284,8 +284,8 @@ class TestPartitionedDataSetLocal:
     )
     def test_versioned_dataset_not_allowed(self, dataset_config):
         pattern = (
-            "`PartitionedDataSet` does not support versioning of the underlying "
-            "dataset. Please remove `versioned` flag from the dataset definition."
+            "'PartitionedDataSet' does not support versioning of the underlying "
+            "dataset. Please remove 'versioned' flag from the dataset definition."
         )
         with pytest.raises(DataSetError, match=re.escape(pattern)):
             PartitionedDataSet(str(Path.cwd()), dataset_config)
@@ -293,7 +293,7 @@ class TestPartitionedDataSetLocal:
     def test_no_partitions(self, tmpdir):
         pds = PartitionedDataSet(str(tmpdir), "pandas.CSVDataSet")
 
-        pattern = re.escape(f"No partitions found in `{tmpdir}`")
+        pattern = re.escape(f"No partitions found in '{tmpdir}'")
         with pytest.raises(DataSetError, match=pattern):
             pds.load()
 

--- a/tests/pipeline/test_modular_pipeline.py
+++ b/tests/pipeline/test_modular_pipeline.py
@@ -356,7 +356,7 @@ class TestPipelineHelper:
             ]
         )
 
-        pattern = r"Parameters should be specified in the `parameters` argument"
+        pattern = r"Parameters should be specified in the 'parameters' argument"
         with pytest.raises(ModularPipelineError, match=pattern):
             pipeline(raw_pipeline, inputs={"params:alpha": "params:beta"})
 

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -255,10 +255,10 @@ def duplicate_output_list_node():
 @pytest.mark.parametrize(
     "func, expected",
     [
-        (bad_input_type_node, r"`inputs` type must be one of "),
-        (bad_output_type_node, r"`outputs` type must be one of "),
+        (bad_input_type_node, r"'inputs' type must be one of "),
+        (bad_output_type_node, r"'outputs' type must be one of "),
         (bad_function_type_node, r"first argument must be a function"),
-        (no_input_or_output_node, r"it must have some `inputs` or `outputs`"),
+        (no_input_or_output_node, r"it must have some 'inputs' or 'outputs'"),
         (
             input_same_as_output_node,
             r"A node cannot have the same inputs and outputs: {\'A\'}",

--- a/tests/pipeline/test_node_run.py
+++ b/tests/pipeline/test_node_run.py
@@ -125,7 +125,7 @@ class TestNodeRunInvalidOutput:
     def test_node_not_list_output(self, mocked_dataset):
         pattern = r"The node definition contains a list of outputs "
         pattern += r"\['B', 'C'\], whereas the node function returned "
-        pattern += r"a `LambdaDataSet`"
+        pattern += r"a 'LambdaDataSet'"
         with pytest.raises(ValueError, match=pattern):
             node(one_in_one_out, "ds1", ["B", "C"]).run(dict(ds1=mocked_dataset))
 

--- a/tests/pipeline/test_pipeline_from_missing.py
+++ b/tests/pipeline/test_pipeline_from_missing.py
@@ -150,7 +150,7 @@ class TestPipelineMissing:
         log_record = caplog.records[0]
         assert log_record.levelname == "WARNING"
         assert (
-            "`exists()` not implemented for `LambdaDataSet`" in log_record.getMessage()
+            "'exists()' not implemented for 'LambdaDataSet'" in log_record.getMessage()
         )
 
     def test_all_no_exists_method(self, branched_pipeline, caplog, hook_manager):
@@ -160,7 +160,7 @@ class TestPipelineMissing:
 
         log_msgs = [record.getMessage() for record in caplog.records]
         expected_msg = (
-            "`exists()` not implemented for `LambdaDataSet`. "
+            "'exists()' not implemented for 'LambdaDataSet'. "
             "Assuming output does not exist."
         )
         assert expected_msg in log_msgs

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -156,7 +156,7 @@ class TestInvalidParallelRunner:
     def test_node_returning_none(self, is_async):
         pipeline = Pipeline([node(identity, "A", "B"), node(return_none, "B", "C")])
         catalog = DataCatalog({"A": MemoryDataSet("42")})
-        pattern = "Saving `None` to a `DataSet` is not allowed"
+        pattern = "Saving 'None' to a 'DataSet' is not allowed"
         with pytest.raises(DataSetError, match=pattern):
             ParallelRunner(is_async=is_async).run(pipeline, catalog)
 

--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -79,7 +79,7 @@ class TestSeqentialRunnerBranchlessPipeline:
         assert outputs["ds3"]["data"] == 42
 
     def test_node_returning_none(self, is_async, saving_none_pipeline, catalog):
-        pattern = "Saving `None` to a `DataSet` is not allowed"
+        pattern = "Saving 'None' to a 'DataSet' is not allowed"
         with pytest.raises(DataSetError, match=pattern):
             SequentialRunner(is_async=is_async).run(saving_none_pipeline, catalog)
 

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -81,9 +81,9 @@ class TestIsAsync:
     def test_thread_run(self, fan_out_fan_in, catalog):
         catalog.add_feed_dict(dict(A=42))
         pattern = (
-            "`ThreadRunner` doesn't support loading and saving the "
+            "'ThreadRunner' doesn't support loading and saving the "
             "node inputs and outputs asynchronously with threads. "
-            "Setting `is_async` to False."
+            "Setting 'is_async' to False."
         )
         with pytest.warns(UserWarning, match=pattern):
             result = ThreadRunner(is_async=True).run(fan_out_fan_in, catalog)
@@ -101,7 +101,7 @@ class TestInvalidThreadRunner:
     def test_node_returning_none(self):
         pipeline = Pipeline([node(identity, "A", "B"), node(return_none, "B", "C")])
         catalog = DataCatalog({"A": MemoryDataSet("42")})
-        pattern = "Saving `None` to a `DataSet` is not allowed"
+        pattern = "Saving 'None' to a 'DataSet' is not allowed"
         with pytest.raises(DataSetError, match=pattern):
             ThreadRunner().run(pipeline, catalog)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,7 +21,7 @@ class TestExtractObject:
 
     def test_load_obj_invalid_attribute(self):
         with pytest.raises(
-            AttributeError, match=r"Object `InvalidClass` cannot be loaded"
+            AttributeError, match=r"Object 'InvalidClass' cannot be loaded"
         ):
             load_obj("InvalidClass", "tests.test_utils")
 


### PR DESCRIPTION
## Description
This is part one in #1514 ; Putting these changes in a separate PR so that it doesn't bloat the actual implementation,

## Development notes
Replaced backticks with single quotes in log messages (and error messages, for consistency - previously both were used interchangeably). Comments and docstrings remain unchanged.

In some instances triple quotes were introduced due to nesting of single quotes; instances like `" ' [bt] [bt] ' "` become `""" " ' ' " """`

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1584"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

