### PR TITLE
[WIP] Add a paginated (JSON) APIDataSet

### DIFF
--- a/kedro/extras/datasets/api/__init__.py
+++ b/kedro/extras/datasets/api/__init__.py
@@ -3,9 +3,10 @@ and returns them into either as string or json Dict.
 It uses the python requests library: https://requests.readthedocs.io/en/master/
 """
 
-__all__ = ["APIDataSet"]
+__all__ = ["APIDataSet", "PaginatedJSONAPIDataSet"]
 
 from contextlib import suppress
 
 with suppress(ImportError):
     from .api_dataset import APIDataSet
+    from .paginated_api_dataset import PaginatedJSONAPIDataSet

--- a/kedro/extras/datasets/api/paginated_api_dataset.py
+++ b/kedro/extras/datasets/api/paginated_api_dataset.py
@@ -2,6 +2,7 @@
 It uses the python requests library: https://requests.readthedocs.io/en/master/
 """
 import copy
+import logging
 from typing import Any, Dict, Iterable, Iterator, List, Union
 
 import jmespath
@@ -10,6 +11,12 @@ from requests.auth import AuthBase
 
 from kedro.extras.datasets.api import APIDataSet
 from kedro.io.core import DataSetError
+
+logger = logging.getLogger(__name__)
+
+
+def log_url(response: requests.Response, *args, **kwargs):
+    logger.debug("Response URL: %s", response.url)
 
 
 class PaginatedAPIDataSet(APIDataSet):
@@ -44,17 +51,33 @@ class PaginatedAPIDataSet(APIDataSet):
 
         # init session
         self._session = requests.Session()
-        self._session.auth = self._request_args.pop("auth", None)
-        headers = self._request_args.pop("headers", None)
-        if headers:
-            self._session.headers.update(headers)
+        self._session.auth = self._request_args["auth"]
+        self._session.hooks["response"].append(log_url)
+
+        # update session headers with provided headers
+        # requests' default headers:
+        # {'User-Agent': 'python-requests/2.27.1', 'Accept-Encoding': 'gzip, deflate', 'Accept': '*/*', 'Connection': 'keep-alive'}
+        if self._request_args["headers"]:
+            self._session.headers.update(self._request_args["headers"])
+
+        self._initial_request_args = {
+            # used in every request
+            "timeout": timeout,
+            # used in initial request
+            "url": url,
+            "method": method,
+            "params": params,
+            "data": data,
+            "json": json,
+        }
+        self._current_request_args = copy.deepcopy(self._initial_request_args)
 
     def _get_next_page(self, response: requests.Response) -> Union[str, None]:
         raise NotImplementedError
 
     def _execute_request(self) -> requests.Response:
         try:
-            response = self._session.request(**self._request_args)
+            response = self._session.request(**self._current_request_args)
             response.raise_for_status()
         except requests.exceptions.HTTPError as exc:
             raise DataSetError("Failed to fetch data", exc) from exc
@@ -64,23 +87,43 @@ class PaginatedAPIDataSet(APIDataSet):
             self._session.close()
         return response
 
-    def _load(self) -> Iterator[requests.Response]:  # type: ignore
-        # TODO: method overrides super class method, returns other type: iterator
+    def _execute_paginated_requests(self) -> Iterator[requests.Response]:  # type: ignore
 
-        # make a copy of the request arguments from init
-        request_args = copy.deepcopy(self._request_args)
+        # to be able to call .load() multiple times
+        # otherwise iterator is exhausted after first call
+        self._current_request_args = copy.deepcopy(self._initial_request_args)
 
-        while self._request_args["url"]:
+        # execute initial request
+        response = self._execute_request()
+        yield response
+
+        # there might be:
+        # a) only a single page -> no next url link found
+        # b) a wrong path_to_next_page -> no next url link found
+        url = self._get_next_page(response)
+        if url is None:
+            logger.debug(
+                "No next page link found with path_to_next_page %s",
+                self.path_to_next_page,
+            )
+
+        # remove keys from requests args, that are only needed for initial request
+        # TODO: "method"
+        # Is it possible to "post" multiple times to follow pagination?
+        # Possible 1 POST query request, followed by a series of "GET" requests
+        for key in ("url", "params", "data", "json"):
+            self._current_request_args.pop(key)
+
+        # handle pagination
+        self._current_request_args["url"] = url
+        while self._current_request_args["url"]:
             response = self._execute_request()
             yield response
-            self._request_args["url"] = self._get_next_page(response)
-
-            # params are only needed for first request
-            self._request_args.pop("params", None)
-
+            self._current_request_args["url"] = self._get_next_page(response)
         self._session.close()
-        # restore original state
-        self._request_args = request_args
+
+    def _load(self) -> Iterator[requests.Response]:  # type: ignore
+        return self._execute_paginated_requests()
 
 
 class PaginatedJSONAPIDataSet(PaginatedAPIDataSet):
@@ -100,8 +143,8 @@ class PaginatedJSONAPIDataSet(PaginatedAPIDataSet):
         >>>         "limit": 500
         >>>     }
         >>> )
-        >>> for r in data_set.load()
-        >>>     print(r)
+        >>> for response in data_set.load()
+        >>>     print(response)
 
     """
 

--- a/kedro/extras/datasets/api/paginated_api_dataset.py
+++ b/kedro/extras/datasets/api/paginated_api_dataset.py
@@ -1,0 +1,108 @@
+"""``PaginatedAPIDataSet`` loads the data from HTTP(S) APIs while traversing pagination.
+It uses the python requests library: https://requests.readthedocs.io/en/master/
+"""
+import copy
+from typing import Any, Dict, Iterable, Iterator, List, Union
+
+import jmespath
+import requests
+from requests.auth import AuthBase
+
+from kedro.extras.datasets.api import APIDataSet
+from kedro.io.core import DataSetError
+
+
+class PaginatedAPIDataSet(APIDataSet):
+    """``PaginatedJSONAPIDataSet`` loads the data from HTTP(S) APIs while traversing pagination.
+    It uses the python requests library: https://requests.readthedocs.io/en/master/
+
+    Implement logic to find in _get_next_page().
+
+    """
+
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        url: str,
+        method: str = "GET",
+        data: Any = None,
+        params: Dict[str, Any] = None,
+        headers: Dict[str, Any] = None,
+        auth: Union[Iterable[str], AuthBase] = None,
+        json: Union[List, Dict[str, Any]] = None,
+        timeout: int = 60,
+        credentials: Union[Iterable[str], AuthBase] = None,
+        # multiple keys possible to access link to next page in nested json
+        # separate keys with ".", like "key1.key2"
+        # TODO: set a value or set to None?
+        path_to_next_page: str = "next",
+    ):
+        super().__init__(
+            url, method, data, params, headers, auth, json, timeout, credentials
+        )
+        self.path_to_next_page = path_to_next_page
+
+        # init session
+        self._session = requests.Session()
+        self._session.auth = self._request_args.pop("auth", None)
+        headers = self._request_args.pop("headers", None)
+        if headers:
+            self._session.headers.update(headers)
+
+    def _get_next_page(self, response: requests.Response) -> Union[str, None]:
+        raise NotImplementedError
+
+    def _execute_request(self) -> requests.Response:
+        try:
+            response = self._session.request(**self._request_args)
+            response.raise_for_status()
+        except requests.exceptions.HTTPError as exc:
+            raise DataSetError("Failed to fetch data", exc) from exc
+        except OSError as exc:
+            raise DataSetError("Failed to connect to the remote server") from exc
+        return response
+
+    def _load(self) -> Iterator[requests.Response]:  # type: ignore
+        # TODO: method overrides super class method, returns other type: iterator
+
+        # make a copy of the request arguments from init
+        request_args = copy.deepcopy(self._request_args)
+
+        while self._request_args["url"]:
+            response = self._execute_request()
+            yield response
+            self._request_args["url"] = self._get_next_page(response)
+
+            # params are only needed for first request
+            self._request_args.pop("params", None)
+
+        # TODO: An exception can be raised earlier, so the connection might not be closed
+        self._session.close()
+        # restore original state
+        self._request_args = request_args
+
+
+class PaginatedJSONAPIDataSet(PaginatedAPIDataSet):
+    """``PaginatedJSONAPIDataSet`` loads the data from HTTP(S) APIs.
+    It uses the python requests library: https://requests.readthedocs.io/en/master/
+
+    Example:
+    ::
+
+        >>> from kedro.extras.datasets.api import PaginatedAPIDataSet
+        >>>
+        >>>
+        >>> data_set = PaginatedAPIDataSet(
+        >>>     url="https://pokeapi.co/api/v2/pokemon",
+        >>>     path_to_next_page="next",
+        >>>     params={
+        >>>         "limit": 500
+        >>>     }
+        >>> )
+        >>> for r in data_set.load()
+        >>>     print(r)
+
+    """
+
+    def _get_next_page(self, response: requests.Response) -> Union[str, None]:
+        return jmespath.search(self.path_to_next_page, response.json())

--- a/kedro/extras/datasets/api/paginated_api_dataset.py
+++ b/kedro/extras/datasets/api/paginated_api_dataset.py
@@ -60,6 +60,8 @@ class PaginatedAPIDataSet(APIDataSet):
             raise DataSetError("Failed to fetch data", exc) from exc
         except OSError as exc:
             raise DataSetError("Failed to connect to the remote server") from exc
+        finally:
+            self._session.close()
         return response
 
     def _load(self) -> Iterator[requests.Response]:  # type: ignore
@@ -76,7 +78,6 @@ class PaginatedAPIDataSet(APIDataSet):
             # params are only needed for first request
             self._request_args.pop("params", None)
 
-        # TODO: An exception can be raised earlier, so the connection might not be closed
         self._session.close()
         # restore original state
         self._request_args = request_args

--- a/tests/extras/datasets/api/test_paginated_api_dataset.py
+++ b/tests/extras/datasets/api/test_paginated_api_dataset.py
@@ -1,9 +1,19 @@
 # pylint: disable=no-member
+
 from types import GeneratorType
+
+import pytest
 
 from kedro.extras.datasets.api import PaginatedJSONAPIDataSet
 
+TEST_HEADERS = {"key": "value"}
 TEST_URL = "http://example.com/api/test"
+TEST_PARAMS = {"param": "value"}
+TEST_URL_WITH_PARAMS = TEST_URL + "?param=value"
+
+TEST_URL_WITH_PARAMS_PAGINATED = TEST_URL_WITH_PARAMS + "&page=2"
+TEST_JSON_RESPONSE_DATA_PAGINATED = {"key": 1, "next": TEST_URL_WITH_PARAMS_PAGINATED}
+TEST_JSON_RESPONSE_DATA_END_PAGINATED = {"key": 2, "next": None}
 
 
 class TestPaginatedJSONAPIDataSet:
@@ -12,3 +22,27 @@ class TestPaginatedJSONAPIDataSet:
         requests_mock.get(TEST_URL)
         responses = api_data_set.load()
         assert isinstance(responses, GeneratorType)
+
+    def test_headers_are_set(self):
+        api_data_set = PaginatedJSONAPIDataSet(url=TEST_URL, headers=TEST_HEADERS)
+        assert set(TEST_HEADERS.items()).issubset(api_data_set._session.headers.items())
+        assert api_data_set._session.headers["Connection"] == "keep-alive"
+
+    def test_load_handles_pagination(self, requests_mock):
+        requests_mock.register_uri(
+            "GET", TEST_URL_WITH_PARAMS, json=TEST_JSON_RESPONSE_DATA_PAGINATED
+        )
+        requests_mock.register_uri(
+            "GET",
+            TEST_URL_WITH_PARAMS_PAGINATED,
+            json=TEST_JSON_RESPONSE_DATA_END_PAGINATED,
+        )
+
+        api_data_set = PaginatedJSONAPIDataSet(
+            url=TEST_URL, params=TEST_PARAMS, path_to_next_page="next"
+        )
+        responses = list(api_data_set.load())
+        expected_num_respones = 2
+        assert len(responses) == expected_num_respones
+        assert responses[0].json()["key"] == 1
+        assert responses[1].json()["key"] == 2

--- a/tests/extras/datasets/api/test_paginated_api_dataset.py
+++ b/tests/extras/datasets/api/test_paginated_api_dataset.py
@@ -1,0 +1,14 @@
+# pylint: disable=no-member
+from types import GeneratorType
+
+from kedro.extras.datasets.api import PaginatedJSONAPIDataSet
+
+TEST_URL = "http://example.com/api/test"
+
+
+class TestPaginatedJSONAPIDataSet:
+    def test_load_returns_generator(self, requests_mock):
+        api_data_set = PaginatedJSONAPIDataSet(url=TEST_URL)
+        requests_mock.get(TEST_URL)
+        responses = api_data_set.load()
+        assert isinstance(responses, GeneratorType)


### PR DESCRIPTION
## Description
This PR is my approach to implement a paginated (JSON) APIDataSet, as described in #1525. This is my first PR to this project.

## Development notes
I added a `PaginatedAPIDataSet`and `PaginatedJSONAPIDataSet`, which implements a `_get_next_page()` method.

`make test`and `make lint`are failing locally, due to files I did not touch. I am not sure, what happened there. I committed with `--no-verify` to be able to push to GitHub.

I left a few TODOs in my code, as this is still work in progress.

I am very glad to get some feedback on these questions:

- Adding `PaginatedAPIDataSet` and `PaginatedJSONAPIDataSet` allows other PaginatedAPIDataSets to be added, e.g. XML or other formats, or other ways to traverse pagination. What do you think? Is this overkill?
- The `PaginatedAPIDataSet` needs to make multiple requests to an API, so I went for a `requests.Session` object and needed to change `_execute_request()`.
- PaginatedAPIDataSet needs access to `_request_args`, which is changed during `load()`, I am not sure, if this needs to be the same after calling load() once.
- As you suggested `PaginatedAPIDataSet` yields `requests.Response` objects. This is caught by mypy, because the return type differs (`requests.Response` vs. `Iterator[requests.Response])` in the overwritten method. How to deal with this?

I will of course add more tests to bring test coverage up to 100%.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [x] Waiting for #1633 to be accepted
- [ ] Add load_args

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1587"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

