### PR TITLE
Bump the upper bound for Flake8 dependency to <5.0

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,11 +20,12 @@
 * The file `conf/base/logging.yml` is now optional. See [our documentation](https://kedro.readthedocs.io/en/0.18.2/logging/logging.html) for details.
 
 ## Bug fixes and other changes
-* Bumped `pyyaml` upper-bound to make Kedro compatible with the [pyodide](https://pyodide.org/en/stable/usage/loading-packages.html#micropip) stack.
+* Bumped `pyyaml` upper bound to make Kedro compatible with the [pyodide](https://pyodide.org/en/stable/usage/loading-packages.html#micropip) stack.
 * Updated project template's Sphinx configuration to use `myst_parser` instead of `recommonmark`.
 * Reduced number of log lines by changing the logging level from `INFO` to `DEBUG` for low priority messages.
 * Kedro's framework-side logging configuration no longer performs file-based logging. Hence superfluous `info.log`/`errors.log` files are no longer created in your project root, and running Kedro on read-only file systems such as Databricks Repos is now possible.
 * The `root` logger is now set to the Python default level of `WARNING` rather than `INFO`. Kedro's logger is still set to emit `INFO` level messages.
+* Bumped the upper bound for the Flake8 dependency to <5.0.
 
 ## Upcoming deprecations for Kedro 0.19.0
 * `kedro.extras.ColorHandler` will be removed in 0.19.0.

--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -24,7 +24,7 @@ The generic project template bundles some typical dependencies, in `src/requirem
 
 ```text
 black==22.1.0 # Used for formatting code with `kedro lint`
-flake8>=3.7.9, <4.0 # Used for linting code with `kedro lint`
+flake8>=3.7.9, <5.0 # Used for linting code with `kedro lint`
 ipython==7.0 # Used for an IPython session with `kedro ipython`
 isort~=5.0 # Used for linting code with `kedro lint`
 jupyter~=1.0 # Used to open a Kedro-session in Jupyter Notebook & Lab

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,5 +1,5 @@
 black~=22.0
-flake8>=3.7.9, <4.0
+flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0
 isort~=5.0
 jupyter~=1.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,5 +1,5 @@
 black~=22.0
-flake8>=3.7.9, <4.0
+flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0
 isort~=5.0
 jupyter~=1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cookiecutter~=1.7.0
 dynaconf>=3.1.2,<4.0.0
 fsspec>=2021.4, <=2022.1
 gitpython~=3.0
-importlib_metadata>=4.4 # Compatible with Python 3.10 importlib.metadata
+importlib_metadata>=3.6; python_version < '3.10' # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
 jmespath>=0.9.5, <1.0
 pip-tools~=6.5
 pluggy~=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cookiecutter~=1.7.0
 dynaconf>=3.1.2,<4.0.0
 fsspec>=2021.4, <=2022.1
 gitpython~=3.0
-importlib_metadata>=3.6; python_version < '3.10' # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
+importlib_metadata>=3.6  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
 jmespath>=0.9.5, <1.0
 pip-tools~=6.5
 pluggy~=1.0.0


### PR DESCRIPTION
Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->
~Pending #1595 (as is any other code PR).~

FYI relaxed the `importlib_metadata` lower bound to be compatible with https://github.com/PyCQA/flake8/blob/c6882772e1640ff4c59f6d84986377813cf9236a/setup.cfg#L45.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1594"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

