### PR TITLE
Make CircleCI show wider logs in e2e tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -193,6 +193,9 @@ jobs:
     executor:
       name: docker
       python_version: <<parameters.python_version>>
+    environment:
+      COLUMNS: 120
+      LINES: 25
     steps:
       - setup
       - run:
@@ -206,6 +209,8 @@ jobs:
     executor: win/default
     environment:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
+      COLUMNS: 120
+      LINES: 25
     steps:
       - checkout
       - win_setup_conda:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,7 +22,7 @@ tasks:
       export PIP_USER=no
       cd /workspace
       pip install -e /workspace/kedro --no-deps
-      yes project | kedro new -s pandas-iris
+      yes project | kedro new -s pandas-iris --checkout main
     command: |
       pip install -e /workspace/kedro --no-deps
       cd /workspace/project

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -50,6 +50,20 @@ To use plain rather than rich logging, swap the `rich` handler for the `console`
 +  handlers: [console, info_file_handler, error_file_handler]
 ```
 
+### Rich logging in a dumb terminal
+
+Rich [detects whether your terminal is capable](https://rich.readthedocs.io/en/stable/console.html#terminal-detection) of displaying richly formatted messages. If your terminal is "dumb" then formatting is automatically stripped out so that the logs are just plain text. This is likely to happen if you perform `kedro run` on CI (e.g. GitHub Actions or CircleCI).
+
+If you find that the default wrapping of the log messages is too narrow but do not wish to switch to using the `console` logger on CI then the simplest way to control the log message wrapping is through altering the `COLUMNS` and `LINES` environment variables. For example:
+
+```bash
+export COLUMNS=120 LINES=25
+```
+
+```{note}
+You must provide a value for both `COLUMNS` and `LINES` even if you only wish to change the width of the log message. Rich's default values for these variables are `COLUMNS=80` and `LINE=25`.
+```
+
 ## Perform logging in your project
 
 To perform logging in your own code (e.g. in a node), you are advised to do as follows:

--- a/features/ipython.feature
+++ b/features/ipython.feature
@@ -6,5 +6,4 @@ Feature: IPython target in new project
     When I execute the kedro command "ipython"
     Then I should get a message including "An enhanced Interactive Python"
     And I should get a message including "Kedro project project-dummy"
-    And I should get a message including "Defined global variable `context`,"
-    And I should get a message including "`session`, `catalog` and `pipelines`"
+    And I should get a message including "Defined global variable `context`, `session`, `catalog` and `pipelines`"

--- a/features/ipython.feature
+++ b/features/ipython.feature
@@ -6,4 +6,4 @@ Feature: IPython target in new project
     When I execute the kedro command "ipython"
     Then I should get a message including "An enhanced Interactive Python"
     And I should get a message including "Kedro project project-dummy"
-    And I should get a message including "Defined global variable `'context', 'session', 'catalog' and 'pipelines'"
+    And I should get a message including "Defined global variable 'context', 'session', 'catalog' and 'pipelines'"

--- a/features/ipython.feature
+++ b/features/ipython.feature
@@ -6,4 +6,4 @@ Feature: IPython target in new project
     When I execute the kedro command "ipython"
     Then I should get a message including "An enhanced Interactive Python"
     And I should get a message including "Kedro project project-dummy"
-    And I should get a message including "Defined global variable `'context', 'session', 'catalog' and `'pipelines'"
+    And I should get a message including "Defined global variable `'context', 'session', 'catalog' and 'pipelines'"

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -464,7 +464,7 @@ def check_correct_nodes_run(context, node):
     expected_log_line = f"Running node: {node}"
     info_log = context.root_project_dir / "logs" / "info.log"
     stdout = context.result.stdout
-    assert node in stdout, (
+    assert expected_log_line in stdout, (
         "Expected the following message segment to be printed on stdout: "
         f"{expected_log_line},\nbut got {stdout}"
     )


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/pull/1569 needed to alter our e2e tests a bit because the `kedro run` output gets wrapped very narrow on CircleCI. While looking into the Jupyter-rich fix I found there's actually a workaround here using some environment variables.

I've added it to our docs since I think other users might have the same question and it's not at all clear from the rich docs how to do this.

Take a look at the `kedro run` output in this Github actions to see what difference this makes:
Before (width = 80): https://github.com/datajoely/kedro-rich/runs/5887275947?check_suite_focus=true
After (width = 120): https://github.com/AntonyMilneQB/kedro-rich/runs/6784240105?check_suite_focus=true

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1597"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

