### PR TITLE
Bump `blacken-docs` hook version to fix regression

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,10 +41,10 @@ repos:
                 )
 
     - repo: https://github.com/asottile/blacken-docs
-      rev: v1.9.2
+      rev: v1.12.1
       hooks:
           - id: blacken-docs
-            additional_dependencies: [black==21.5b1]
+            additional_dependencies: [black~=22.0]
             entry: blacken-docs --skip-errors
 
     - repo: https://github.com/asottile/pyupgrade

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -698,7 +698,7 @@ Check your source directory. If you defined a different source directory (`sourc
     * `register_pipelines()`, to replace `_get_pipelines()`
     * `register_config_loader()`, to replace `_create_config_loader()`
     * `register_catalog()`, to replace `_create_catalog()`
-These can be defined in `src/<package-name>/hooks.py` and added to `.kedro.yml` (or `pyproject.toml`). The order of execution is: plugin hooks, `.kedro.yml` hooks, hooks in `ProjectContext.hooks`.
+These can be defined in `src/<python_package>/hooks.py` and added to `.kedro.yml` (or `pyproject.toml`). The order of execution is: plugin hooks, `.kedro.yml` hooks, hooks in `ProjectContext.hooks`.
 * Added ability to disable auto-registered Hooks using `.kedro.yml` (or `pyproject.toml`) configuration file.
 
 ## Bug fixes and other changes
@@ -1307,7 +1307,7 @@ The breaking changes were introduced in the following project template files:
 - `<project-name>/.ipython/profile_default/startup/00-kedro-init.py`
 - `<project-name>/kedro_cli.py`
 - `<project-name>/src/tests/test_run.py`
-- `<project-name>/src/<package-name>/run.py`
+- `<project-name>/src/<python_package>/run.py`
 - `<project-name>/.kedro.yml` (new file)
 
 The easiest way to migrate your project from Kedro 0.14.* to Kedro 0.15.0 is to create a new project (by using `kedro new`) and move code and files bit by bit as suggested in the detailed guide below:

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -303,7 +303,7 @@ Call the `run()` method of the `KedroSession` defined in `kedro.framework.sessio
 kedro run
 ```
 
-`KedroContext` can be extended in `run.py` (`src/project-name/run.py`). In order to use the extended `KedroContext` you need to set `context_path` in [`pyproject.toml`](../faq/architecture_overview.md#kedro-project) configuration file.
+`KedroContext` can be extended in `run.py` (`src/<package_name>/run.py`). In order to use the extended `KedroContext` you need to set `context_path` in [`pyproject.toml`](../faq/architecture_overview.md#kedro-project) configuration file.
 
 #### Modifying a `kedro run`
 

--- a/docs/source/extend_kedro/create_kedro_starters.md
+++ b/docs/source/extend_kedro/create_kedro_starters.md
@@ -55,7 +55,7 @@ When you create an Iris dataset example project by calling `kedro new`, you supp
 
 **project_name**
 
-The human-readable `project-name` variable is used in the [README.md](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris/README.md) for the new project.
+The human-readable `project_name` variable is used in the [README.md](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris/README.md) for the new project.
 
 **repo_name**
 

--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -4,7 +4,7 @@ This section contains detailed information about configuration, for which the re
 
 ## Configuration root
 
-We recommend that you keep all configuration files in the `conf` directory of a Kedro project. However, if you prefer, you may point Kedro to any other directory and change the configuration paths by setting the `CONF_SOURCE` variable in [`src/<project-package>/settings.py`](settings.md) as follows:
+We recommend that you keep all configuration files in the `conf` directory of a Kedro project. However, if you prefer, you may point Kedro to any other directory and change the configuration paths by setting the `CONF_SOURCE` variable in [`src/<python_package>/settings.py`](settings.md) as follows:
 ```python
 CONF_SOURCE = "new_conf"
 ```
@@ -47,7 +47,7 @@ kedro run --env=test
 
 If no `env` option is specified, this will default to using the `local` environment to overwrite `conf/base`.
 
-If, for some reason, your project does not have any other environments apart from `base`, i.e. no `local` environment to default to, you will need to customise `KedroContext` to take `env="base"` in the constructor and then specify your custom `KedroContext` subclass in `src/<python-package>/settings.py` under the `CONTEXT_CLASS` key.
+If, for some reason, your project does not have any other environments apart from `base`, i.e. no `local` environment to default to, you will need to customise `KedroContext` to take `env="base"` in the constructor and then specify your custom `KedroContext` subclass in `src/<python_package>/settings.py` under the `CONTEXT_CLASS` key.
 
 If you set the `KEDRO_ENV` environment variable to the name of your environment, Kedro will load that environment for your `kedro run`, `kedro ipython`, `kedro jupyter notebook` and `kedro jupyter lab` sessions:
 
@@ -61,7 +61,7 @@ If you specify both the `KEDRO_ENV` environment variable and provide the `--env`
 
 ## Template configuration
 
-Kedro also provides an extension [TemplatedConfigLoader](/kedro.config.TemplatedConfigLoader) class that allows you to template values in configuration files. To apply templating in your project, you will need to set the `CONFIG_LOADER_CLASS` constant in your `src/<project-name>/settings.py`:
+Kedro also provides an extension [TemplatedConfigLoader](/kedro.config.TemplatedConfigLoader) class that allows you to template values in configuration files. To apply templating in your project, you will need to set the `CONFIG_LOADER_CLASS` constant in your `src/<python_package>/settings.py`:
 
 ```python
 from kedro.config import TemplatedConfigLoader  # new import

--- a/docs/source/nodes_and_pipelines/pipeline_introduction.md
+++ b/docs/source/nodes_and_pipelines/pipeline_introduction.md
@@ -18,7 +18,7 @@ def mean(xs, n):
 
 
 def mean_sos(xs, n):
-    return sum(x ** 2 for x in xs) / n
+    return sum(x**2 for x in xs) / n
 
 
 def variance(m, m2):

--- a/docs/source/nodes_and_pipelines/slice_a_pipeline.md
+++ b/docs/source/nodes_and_pipelines/slice_a_pipeline.md
@@ -14,7 +14,7 @@ def mean(xs, n):
 
 
 def mean_sos(xs, n):
-    return sum(x ** 2 for x in xs) / n
+    return sum(x**2 for x in xs) / n
 
 
 def variance(m, m2):

--- a/docs/source/tools_integration/pyspark.md
+++ b/docs/source/tools_integration/pyspark.md
@@ -19,7 +19,7 @@ Optimal configuration for Spark depends on the setup of your Spark cluster.
 
 Before any `PySpark` operations are performed, you should initialise your [`SparkSession`](https://spark.apache.org/docs/latest/sql-getting-started.html#starting-point-sparksession) in your custom project context class, which is the entrypoint for your Kedro project. This ensures that a `SparkSession` has been initialised before the Kedro pipeline is run.
 
-Below is an example implementation to initialise the `SparkSession` in `<project-name>/src/<package-name>/<custom_context>.py` by reading configuration from the `spark.yml` configuration file created in the previous section:
+Below is an example implementation to initialise the `SparkSession` in `<project-name>/src/<python_package>/custom_context.py` by reading configuration from the `spark.yml` configuration file created in the previous section:
 
 ```python
 from typing import Any, Dict, Union
@@ -70,10 +70,10 @@ Call `SparkSession.builder.getOrCreate()` to obtain the `SparkSession` anywhere 
 
 We don't recommend storing Spark session on the context object, as it cannot be serialised and therefore prevents the context from being initialised for some plugins.
 
-Now, you need to configure Kedro to use `CustomContext`. All you need to do is just set `CONTEXT_CLASS` in `<project-name>/src/<package-name>/settings.py` as follow:
+Now, you need to configure Kedro to use `CustomContext`. Set `CONTEXT_CLASS` in `<project-name>/src/<python_package>/settings.py` as follows:
 
 ```python
-from <package-name>.<custom_context> import CustomContext
+from <python_package>.custom_context import CustomContext
 
 CONTEXT_CLASS = CustomContext
 ```


### PR DESCRIPTION
Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
<!-- Why was this PR created? -->
Closes #1565 

## Development notes
<!-- What have you changed, and how has this been tested? -->
I somehow got into the business of standardizing `<project-name>` and `<python_package>`, since I missed the `--skip-errors` flag in the `blacken-docs` entrypoint (I forgot that there were two things that needed to be blackened that were actually failing the build).

On that note:

* It's a bit inconsistent to have `<project-name>` and `<python_package>` (dash and underscore, respectively), but I guess that's fair enough, since the actual package name really can't have a dash.
* You have a couple instances in https://github.com/kedro-org/kedro/blob/0.18.1/kedro/framework/session/session.py#L76-L87 with inexplicably roundabout terms for `<python_package>`, but I left them as is.
* A number of files use `<project-root>` or `<project_root>` instead of `<project-name>` and, while I think this could be standardized, there are instances like `<path-to-your-project-root>` in https://github.com/kedro-org/kedro/blob/0.18.1/docs/source/development/commands_reference.md that don't make sense as `<path-to-your-project-name>`. Maybe something to update in the lexicon?

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1602"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

