### PR TITLE
Clean up duplicate `ExcelDataSet` entry

### DIFF
--- a/kedro/extras/datasets/pandas/__init__.py
+++ b/kedro/extras/datasets/pandas/__init__.py
@@ -6,7 +6,6 @@ __all__ = [
     "FeatherDataSet",
     "GBQTableDataSet",
     "GBQQueryDataSet",
-    "ExcelDataSet",
     "HDFDataSet",
     "JSONDataSet",
     "ParquetDataSet",


### PR DESCRIPTION
## Description
I noticed the `ExcelDataSet` was added twice to `../datasets/pandas/__init__.py` so I removed one entry.

## Development notes


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1610"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

