### PR TITLE
Replace rather than reuse Jupyter kernel spec

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,7 @@
 * Reduced number of log lines by changing the logging level from `INFO` to `DEBUG` for low priority messages.
 * Kedro's framework-side logging configuration no longer performs file-based logging. Hence superfluous `info.log`/`errors.log` files are no longer created in your project root, and running Kedro on read-only file systems such as Databricks Repos is now possible.
 * The `root` logger is now set to the Python default level of `WARNING` rather than `INFO`. Kedro's logger is still set to emit `INFO` level messages.
+* `kedro jupyter notebook/lab` no longer reuses a Jupyter kernel.
 
 ## Upcoming deprecations for Kedro 0.19.0
 * `kedro.extras.ColorHandler` will be removed in 0.19.0.

--- a/docs/source/tools_integration/ipython.md
+++ b/docs/source/tools_integration/ipython.md
@@ -200,7 +200,11 @@ If you are not able to execute `kedro jupyter notebook` or `kedro jupyter lab` t
 
 ### Manage Jupyter kernels
 
-Behind the scenes, the `kedro jupyter notebook` and `kedro jupyter lab` commands create a Jupyter kernel named `kedro_<project_package_name>` if it does not already exist. This kernel is identical to the [default IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html) but with a slightly customised [kernel specification](https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs) that automatically loads `kedro.extras.extensions.ipython` when the kernel is started. The kernel specification is installed at a user level rather than system-wide.
+Behind the scenes, the `kedro jupyter notebook` and `kedro jupyter lab` commands create a Jupyter kernel named `kedro_<project_package_name>`. This kernel is identical to the [default IPython kernel](https://ipython.readthedocs.io/en/stable/install/kernel_install.html) but with a slightly customised [kernel specification](https://jupyter-client.readthedocs.io/en/stable/kernels.html#kernel-specs) that automatically loads `kedro.extras.extensions.ipython` when the kernel is started. The kernel specification is installed at a user level rather than system-wide.
+
+```{note}
+If a Jupyter kernel with the name `kedro_<project_package_name>` already exists then it is replaced. This ensures that the kernel always points to the correct Python executable. For example, if you change conda environment in a Kedro project then you should re-run `kedro jupyter notebook/lab` to replace the kernel specification with one that points to the new environment.
+```
 
 As each Kedro project has its own Jupyter kernel, you can switch between multiple Kedro projects from a single Jupyter instance simply by selecting the appropriate kernel.
 

--- a/kedro/framework/cli/jupyter.py
+++ b/kedro/framework/cli/jupyter.py
@@ -97,7 +97,8 @@ def jupyter_lab(
 
 
 def _create_kernel(kernel_name: str, display_name: str) -> None:
-    """Creates an IPython kernel for the kedro project, if one does not already exist.
+    """Creates an IPython kernel for the kedro project. If one with the same kernel_name
+    exists already it will be replaced.
 
     Installs the default IPython kernel (which points towards `sys.executable`)
     and customises it to make the launch command load the kedro extension.
@@ -136,18 +137,12 @@ def _create_kernel(kernel_name: str, display_name: str) -> None:
     # checked are importable, so we don't run _check_module_importable on them.
     # pylint: disable=import-outside-toplevel
     from ipykernel.kernelspec import install
-    from jupyter_client.kernelspec import find_kernel_specs
 
     try:
-        if kernel_name in find_kernel_specs():
-            secho(
-                f"Jupyter kernel {kernel_name} already exists and will be used.",
-                fg="green",
-            )
-            return
-
         # Install with user=True rather than system-wide to minimise footprint and
-        # ensure that we have permissions to write there.
+        # ensure that we have permissions to write there. Under the hood this calls
+        # jupyter_client.KernelSpecManager.install_kernel_spec, which automatically
+        # removes an old kernel spec if it already exists.
         kernel_path = install(
             user=True,
             kernel_name=kernel_name,

--- a/tests/framework/cli/test_jupyter.py
+++ b/tests/framework/cli/test_jupyter.py
@@ -143,11 +143,11 @@ class TestCreateKernel:
         kernel_files = {file.name for file in Path(kernel_spec.resource_dir).iterdir()}
         assert kernel_files == {"logo-32x32.png", "logo-64x64.png", "kernel.json"}
 
-    def test_kernel_installs_once(self, mocker):
-        _create_kernel("my_kernel_name", "My display name")
-        install_mock = mocker.patch("ipykernel.kernelspec.install")
-        _create_kernel("my_kernel_name", "My display name")
-        install_mock.assert_not_called()
+    def test_kernel_install_replaces(self):
+        _create_kernel("my_kernel_name", "My display name 1")
+        _create_kernel("my_kernel_name", "My display name 2")
+        kernel_spec = get_kernel_spec("my_kernel_name")
+        assert kernel_spec.display_name == "My display name 2"
 
     def test_error(self, mocker):
         mocker.patch("ipykernel.kernelspec.install", side_effect=ValueError)


### PR DESCRIPTION
## Description
As demonstrated in my very uncompelling live demo, the current behaviour of reusing a Jupyter kernel can lead to inconsistent environments which is very confusing.

There's no real reason to reuse an exist kernel instead of just creating one fresh every time. The performance hit is negligible and launching Jupyter isn't fast anyway.

## Development notes
As well as unit test updated, I've manually tested:
* `conda activate A`
* run `kedro jupyter lab` ➡️  Jupyter kernel `kedro_spaceflights` pointing to Python executable in A
* `conda activate B`
* run `kedro jupyter lab` in conda environment B ➡️  Jupyter kernel `kedro_spaceflights` now points to Python executable in B

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
