### PR TITLE
Update docs on how to update Jupyter logging width

### DIFF
--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -66,7 +66,7 @@ You must provide a value for both `COLUMNS` and `LINES` even if you only wish to
 
 ### Rich logging in Jupyter
 
-Rich also formats the logs in JupyterLab and Jupyter Notebook. The size of the output console does not adapt to your window but can be controlled through the `JUPYTER_COLUMNS` and `JUPYTER_LINES` environment variables, which default to 115 and 100 respectively.
+Rich also formats the logs in JupyterLab and Jupyter Notebook. The size of the output console does not adapt to your window but can be controlled through the `JUPYTER_COLUMNS` and `JUPYTER_LINES` environment variables. The default values (115 and 100 respectively) should be suitable for most users, but if you require a different output console size then you should alter the values of `JUPYTER_COLUMNS` and `JUPYTER_LINES`.
 
 ## Perform logging in your project
 

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -64,6 +64,10 @@ export COLUMNS=120 LINES=25
 You must provide a value for both `COLUMNS` and `LINES` even if you only wish to change the width of the log message. Rich's default values for these variables are `COLUMNS=80` and `LINE=25`.
 ```
 
+### Rich logging in Jupyter
+
+Rich also formats the logs in JupyterLab and Jupyter Notebook. The size of the output console does not adapt to your window but can be controlled through the `JUPYTER_COLUMNS` and `JUPYTER_LINES` environment variables, which default to 115 and 100 respectively.
+
 ## Perform logging in your project
 
 To perform logging in your own code (e.g. in a node), you are advised to do as follows:


### PR DESCRIPTION
## Description
Closes #1575.

I managed to complete a PR on rich (https://github.com/Textualize/rich/pull/2332), which does two things:
* increases rich Jupyter console size, so our messages appear much less narrowly wrapped now
* introduces two new environment variables so that users can configure this width themselves

This is a very good outcome because it means (a) we can continue doing rich logging in Jupyter and (b) there's no horrible hacking at all on our side 🎉 So all that's left here is a small piece of documentation.

![image](https://user-images.githubusercontent.com/49395058/174577220-673471a4-1dcf-4f0f-bb63-02e6c932d4f1.png)

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1634"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

