### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/source/tools_integration/pyspark.md
+++ b/docs/source/tools_integration/pyspark.md
@@ -80,7 +80,7 @@ CONTEXT_CLASS = CustomContext
 
 ## Use Kedro's built-in Spark datasets to load and save raw data
 
-We recommend using Kedro's built-in Spark datasets to load raw data into Spark's [DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql.html#dataframe-apis), as well as to write them back to storage. Some of our built-in Spark datasets include:
+We recommend using Kedro's built-in Spark datasets to load raw data into Spark's [DataFrame](https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/dataframe.html), as well as to write them back to storage. Some of our built-in Spark datasets include:
 
 * [spark.DeltaTableDataSet](/kedro.extras.datasets.spark.DeltaTableDataSet)
 * [spark.SparkDataSet](/kedro.extras.datasets.spark.SparkDataSet)

--- a/kedro/extras/datasets/api/__init__.py
+++ b/kedro/extras/datasets/api/__init__.py
@@ -1,6 +1,6 @@
 """``APIDataSet`` loads the data from HTTP(S) APIs
 and returns them into either as string or json Dict.
-It uses the python requests library: https://requests.readthedocs.io/en/master/
+It uses the python requests library: https://requests.readthedocs.io/en/latest/
 """
 
 __all__ = ["APIDataSet"]

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -1,5 +1,5 @@
 """``APIDataSet`` loads the data from HTTP(S) APIs.
-It uses the python requests library: https://requests.readthedocs.io/en/master/
+It uses the python requests library: https://requests.readthedocs.io/en/latest/
 """
 from typing import Any, Dict, Iterable, List, Union
 
@@ -11,7 +11,7 @@ from kedro.io.core import AbstractDataSet, DataSetError
 
 class APIDataSet(AbstractDataSet):
     """``APIDataSet`` loads the data from HTTP(S) APIs.
-    It uses the python requests library: https://requests.readthedocs.io/en/master/
+    It uses the python requests library: https://requests.readthedocs.io/en/latest/
 
     Example:
     ::
@@ -52,19 +52,19 @@ class APIDataSet(AbstractDataSet):
             url: The API URL endpoint.
             method: The Method of the request, GET, POST, PUT, DELETE, HEAD, etc...
             data: The request payload, used for POST, PUT, etc requests
-                https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests
+                https://requests.readthedocs.io/en/latest/user/quickstart/#more-complicated-post-requests
             params: The url parameters of the API.
-                https://requests.readthedocs.io/en/master/user/quickstart/#passing-parameters-in-urls
+                https://requests.readthedocs.io/en/latest/user/quickstart/#passing-parameters-in-urls
             headers: The HTTP headers.
-                https://requests.readthedocs.io/en/master/user/quickstart/#custom-headers
+                https://requests.readthedocs.io/en/latest/user/quickstart/#custom-headers
             auth: Anything ``requests`` accepts. Normally it's either ``('login', 'password')``,
                 or ``AuthBase``, ``HTTPBasicAuth`` instance for more complex cases. Any
                 iterable will be cast to a tuple.
             json: The request payload, used for POST, PUT, etc requests, passed in
                 to the json kwarg in the requests object.
-                https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests
+                https://requests.readthedocs.io/en/latest/user/quickstart/#more-complicated-post-requests
             timeout: The wait time in seconds for a response, defaults to 1 minute.
-                https://requests.readthedocs.io/en/master/user/quickstart/#timeouts
+                https://requests.readthedocs.io/en/latest/user/quickstart/#timeouts
             credentials: same as ``auth``. Allows specifying ``auth`` secrets in
                 credentials.yml.
 

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -251,14 +251,14 @@ class SparkDataSet(AbstractVersionedDataSet):
                 It is dependent on the selected file format. You can find
                 a list of read options for each supported format
                 in Spark DataFrame read documentation:
-                https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql.html#dataframe-apis
+                https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html
             save_args: Save args passed to Spark DataFrame write options.
                 Similar to load_args this is dependent on the selected file
                 format. You can pass ``mode`` and ``partitionBy`` to specify
                 your overwrite mode and partitioning respectively. You can find
                 a list of options for each format in Spark DataFrame
                 write documentation:
-                https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql.html#dataframe-apis
+                https://spark.apache.org/docs/latest/api/python/getting_started/quickstart_df.html
             version: If specified, should be an instance of
                 ``kedro.io.core.Version``. If its ``load`` attribute is
                 None, the latest version will be loaded. If its ``save``

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -88,11 +88,11 @@ class SparkJDBCDataSet(AbstractDataSet):
             load_args: Provided to underlying PySpark ``jdbc`` function along
                 with the JDBC URL and the name of the table. To find all
                 supported arguments, see here:
-                https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrameWriter.jdbc.html
+                https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.jdbc.html
             save_args: Provided to underlying PySpark ``jdbc`` function along
                 with the JDBC URL and the name of the table. To find all
                 supported arguments, see here:
-                https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrameWriter.jdbc.html
+                https://spark.apache.org/docs/latest/api/python/reference/pyspark.sql/api/pyspark.sql.DataFrameWriter.jdbc.html
 
         Raises:
             DataSetError: When either ``url`` or ``table`` is empty or


### PR DESCRIPTION
## Description
The docs links check is failing

## Development notes
- Updated spark links
- Update requests.readthedocs.io links

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1635"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

