### PR TITLE
Fix WINDOW CI PYTHON 3.10 fail pip-compile

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,8 @@
+# PEP-518 https://peps.python.org/pep-0518/
+[build-system]
+# Minimum requirements for the build system to execute.
+requires = ["setuptools>=38.0", "wheel"]  # PEP 518 specifications.
+
 [tool.black]
 exclude = "/templates/|^features/steps/test_starter"
 


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Fixed fail CI due to pip-compile at https://github.com/kedro-org/kedro/pull/1630

PEP517 and PEP518 are relatively new specifications related to the Python build system. It causes some issue with some of the libraries that we depends on ob.
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1639"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

