### PR TITLE
Split up the documentation page about Hooks

### DIFF
--- a/docs/source/data/kedro_io.md
+++ b/docs/source/data/kedro_io.md
@@ -469,7 +469,7 @@ def create_partitions() -> Dict[str, Callable[[], Any]]:
 ```
 
 ```{note}
-When using lazy saving the dataset will be written _after_ the `after_node_run` [hook](../extend_kedro/hooks).
+When using lazy saving the dataset will be written _after_ the `after_node_run` [hook](../hooks/hooks).
 ```
 
 ### Incremental loads with `IncrementalDataSet`

--- a/docs/source/development/debugging.md
+++ b/docs/source/development/debugging.md
@@ -7,7 +7,7 @@ If you're running your Kedro pipeline from the CLI or you can't/don't want to ru
 * If you have long running nodes or pipelines, inserting `print` statements and running them multiple times quickly becomes a time-consuming procedure.
 * Debugging nodes outside the `run` session isn't very helpful because getting access to the local scope within the `node` can be hard, especially if you're dealing with large data or memory datasets, where you need to chain a few nodes together or re-run your pipeline to produce the data for debugging purposes.
 
-This guide provides examples on how to instantiate a [post-mortem](https://docs.python.org/3/library/pdb.html#pdb.post_mortem) debugging session with [`pdb`](https://docs.python.org/3/library/pdb.html) using [Hooks](../extend_kedro/hooks.md) when an uncaught error occurs during a pipeline run. Note that [ipdb](https://pypi.org/project/ipdb/) could be integrated in the same manner.
+This guide provides examples on how to instantiate a [post-mortem](https://docs.python.org/3/library/pdb.html#pdb.post_mortem) debugging session with [`pdb`](https://docs.python.org/3/library/pdb.html) using [Hooks](../hooks/hooks.md) when an uncaught error occurs during a pipeline run. Note that [ipdb](https://pypi.org/project/ipdb/) could be integrated in the same manner.
 
 If you are looking for guides on how to setup debugging with IDEs, please visit the guide for [VSCode](./set_up_vscode.md#debugging) and [PyCharm](./set_up_pycharm.md#debugging).
 

--- a/docs/source/extend_kedro/common_use_cases.md
+++ b/docs/source/extend_kedro/common_use_cases.md
@@ -8,7 +8,7 @@ The execution timeline of a Kedro pipeline can be thought of as a sequence of ac
 
 At different points in the lifecycle of these components, you may want to add extra behaviour. For example, you could add extra computation for profiling purposes _before_ and _after_ a node runs or _before_ and _after_ the I/O actions of a dataset, namely the `load` and `save` actions.
 
-This can now achieved by using [Hooks](./hooks.md), to define the extra behaviour and at which point in the execution timeline it should be injected.
+This can now achieved by using [Hooks](../hooks/hooks.md), to define the extra behaviour and at which point in the execution timeline it should be injected.
 
 ## Use Case 2: How to integrate Kedro with additional data sources
 

--- a/docs/source/hooks/common_use_cases.md
+++ b/docs/source/hooks/common_use_cases.md
@@ -1,0 +1,115 @@
+# Common use cases
+
+## Use Hooks to extend a node's behaviour
+
+You can add extra behaviour before and after a node's execution by using the [`before_node_run` and `after_node_run` Hooks](/kedro.framework.hooks.specs.NodeSpecs). Furthermore, you can apply extra behaviour to not only an individual node or an entire Kedro pipeline, but also to a _subset_ of nodes based on their tags or namespaces. For example, let's say we want to add the following extra behaviours to a node:
+
+```python
+from kedro.pipeline.node import Node
+
+
+def say_hello(node: Node):
+    """An extra behaviour for a node to say hello before running."""
+    print(f"Hello from {node.name}")
+```
+
+Then you can either add it to a single node based on the node's name:
+
+```python
+# <your_project>/src/<your_project>/hooks.py
+
+from kedro.framework.hooks import hook_impl
+from kedro.pipeline.node import Node
+
+
+class ProjectHooks:
+    @hook_impl
+    def before_node_run(self, node: Node):
+        # adding extra behaviour to a single node
+        if node.name == "hello":
+            say_hello(node)
+```
+
+Or add it to a group of nodes based on their tags:
+
+
+```python
+# <your_project>/src/<your_project>/hooks.py
+
+from kedro.framework.hooks import hook_impl
+from kedro.pipeline.node import Node
+
+
+class ProjectHooks:
+    @hook_impl
+    def before_node_run(self, node: Node):
+        if "hello" in node.tags:
+            say_hello(node)
+```
+
+Or add it to all nodes in the entire pipeline:
+
+```python
+# <your_project>/src/<your_project>/hooks.py
+
+from kedro.framework.hooks import hook_impl
+from kedro.pipeline.node import Node
+
+
+class ProjectHooks:
+    @hook_impl
+    def before_node_run(self, node: Node):
+        # adding extra behaviour to all nodes in the pipeline
+        say_hello(node)
+```
+
+If your use case takes advantage of a decorator, for example to retry a node's execution using a library such as [tenacity](https://tenacity.readthedocs.io/en/latest/), you can still decorate the node's function directly:
+
+```python
+from tenacity import retry
+
+
+@retry
+def my_flaky_node_function():
+    ...
+```
+
+Or applying it in the `before_node_run` Hook as follows:
+
+```python
+# <your_project>/src/<your_project>/hooks.py
+from tenacity import retry
+
+from kedro.framework.hooks import hook_impl
+from kedro.pipeline.node import Node
+
+
+class ProjectHooks:
+    @hook_impl
+    def before_node_run(self, node: Node):
+        # adding retrying behaviour to nodes tagged as flaky
+        if "flaky" in node.tags:
+            node.func = retry(node.func)
+```
+## Use Hooks to customise the dataset load and save methods
+We recommend using the `before_dataset_loaded`/`after_dataset_loaded` and `before_dataset_saved`/`after_dataset_saved` Hooks to customise the dataset `load` and `save` methods where appropriate.
+
+For example, you can add logging about the dataset load runtime as follows:
+
+```python
+@property
+def _logger(self):
+    return logging.getLogger(self.__class__.__name__)
+
+
+@hook_impl
+def before_dataset_loaded(self, dataset_name: str) -> None:
+    start = time.time()
+    self._logger.info("Loading dataset %s started at %0.3f", dataset_name, start)
+
+
+@hook_impl
+def after_dataset_loaded(self, dataset_name: str, data: Any) -> None:
+    end = time.time()
+    self._logger.info("Loading dataset %s ended at %0.3f", dataset_name, end)
+```

--- a/docs/source/hooks/hooks.md
+++ b/docs/source/hooks/hooks.md
@@ -1,0 +1,138 @@
+# Hooks
+
+## Introduction
+
+Hooks are a mechanism to add extra behaviour to Kedro's main execution in an easy and consistent manner. Some examples may include:
+
+* Adding a log statement after the data catalog is loaded
+* Adding data validation to the inputs before a node runs, and to the outputs after a node has run. This makes it possible to integrate with other tools like [Great-Expectations](https://docs.greatexpectations.io/en/latest/)
+* Adding machine learning metrics tracking, e.g. using [MLflow](https://mlflow.org/), throughout a pipeline run
+
+## Concepts
+
+A Hook is comprised of a Hook specification and Hook implementation. To add Hooks to your project you will need to:
+
+* Create or modify the file `<your_project>/src/<package_name>/hooks.py` to define a Hook implementation for an existing Kedro-defined Hook specification
+* Register your Hook implementation in the [`src/<your_project>/settings.py`](../kedro_project_setup/settings.md) file under the `HOOKS` key
+
+### Hook specification
+
+Kedro defines Hook specifications for particular execution points where users can inject additional behaviour. Currently, the following Hook specifications are provided in [kedro.framework.hooks](/kedro.framework.hooks):
+
+* `after_catalog_created`
+* `before_node_run`
+* `after_node_run`
+* `on_node_error`
+* `before_pipeline_run`
+* `after_pipeline_run`
+* `on_pipeline_error`
+* `before_dataset_loaded`
+* `after_dataset_loaded`
+* `before_dataset_saved`
+* `after_dataset_saved`
+
+The naming convention for non-error Hooks is `<before/after>_<noun>_<past_participle>`, in which:
+
+* `<before/after>` and `<past_participle>` refers to when the Hook executed, e.g. `before <something> was run` or `after <something> was created`.
+* `<noun>` refers to the relevant component in the Kedro execution timeline for which this Hook adds extra behaviour, e.g. `catalog`, `node` and `pipeline`.
+
+The naming convention for error hooks is `on_<noun>_error`, in which:
+
+* `<noun>` refers to the relevant component in the Kedro execution timeline that throws the error.
+
+[kedro.framework.hooks](/kedro.framework.hooks) lists the full specifications for which you can inject additional behaviours by providing an implementation.
+
+
+#### CLI hooks
+
+Lastly, Kedro defines a small set of CLI hooks that inject additional behaviour around execution of a Kedro CLI command:
+
+* `before_command_run`
+* `after_command_run`
+
+This is what the [`kedro-telemetry`](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry) plugin relies on under the hood in order to be able to collect CLI usage statistics.
+
+### Hook implementation
+
+You should provide an implementation for the specification that describes the point at which you want to inject additional behaviour. The Hook implementation should have the same name as the specification. The Hook must provide a concrete implementation with a subset of the corresponding specification's parameters (you do not need to use them all).
+
+To declare a Hook implementation, use the `@hook_impl` decorator.
+
+For example, the full signature of the [`after_data_catalog_created`](/kedro.framework.hooks.specs.DataCatalogSpecs) Hook specification is:
+
+```python
+@hook_spec
+def after_catalog_created(
+    self,
+    catalog: DataCatalog,
+    conf_catalog: Dict[str, Any],
+    conf_creds: Dict[str, Any],
+    save_version: str,
+    load_versions: Dict[str, str],
+) -> None:
+    pass
+```
+
+However, if you just want to use this Hook to list the contents of a data catalog after it is created, your Hook implementation can be as simple as:
+
+```python
+# <your_project>/src/<your_project>/hooks.py
+import logging
+
+from kedro.framework.hooks import hook_impl
+from kedro.io import DataCatalog
+
+
+class DataCatalogHooks:
+    @property
+    def _logger(self):
+        return logging.getLogger(self.__class__.__name__)
+
+    @hook_impl
+    def after_catalog_created(self, catalog: DataCatalog) -> None:
+        self._logger.info(catalog.list())
+```
+
+```{note}
+The name of a module that contains Hooks implementation is arbitrary and is not restricted to `hooks.py`.
+```
+
+We recommend that you group related Hook implementations under a namespace, preferably a class, within a `hooks.py` file that you create in your project.
+
+#### Registering your Hook implementations with Kedro
+
+Hook implementations should be registered with Kedro using the [`<your_project>/src/<package_name>/settings.py`](../kedro_project_setup/settings.md) file under the `HOOKS` key.
+
+You can register more than one implementation for the same specification. They will be called in LIFO (last-in, first-out) order.
+
+The following example sets up a Hook so that the `after_data_catalog_created` implementation is called every time after a data catalog is created.
+
+```python
+# <your_project>/src/<your_project>/settings.py
+from <your_project>.hooks import ProjectHooks, DataCatalogHooks
+
+HOOKS = (ProjectHooks(), DataCatalogHooks())
+```
+
+Kedro also has auto-discovery enabled by default. This means that any installed plugins that declare a Hooks entry-point will be registered. To learn more about how to enable this for your custom plugin, see our [plugin development guide](../extend_kedro/plugins.md#hooks).
+
+```{note}
+Auto-discovered Hooks will run *first*, followed by the ones specified in `settings.py`.
+```
+
+
+#### Disable auto-registered plugins' Hooks
+
+Auto-registered plugins' Hooks can be disabled via `settings.py` as follows:
+
+```python
+# <your_project>/src/<your_project>/settings.py
+
+DISABLE_HOOKS_FOR_PLUGINS = ("<plugin_name>",)
+```
+
+where `<plugin_name>` is the name of an installed plugin for which the auto-registered Hooks must be disabled.
+
+## Under the hood
+
+Under the hood, we use [pytest's pluggy](https://pluggy.readthedocs.io/en/latest/) to implement Kedro's Hook mechanism. We recommend reading their documentation if you have more questions about the underlying implementation.

--- a/docs/source/hooks/hooks_examples.md
+++ b/docs/source/hooks/hooks_examples.md
@@ -1,261 +1,6 @@
-# Hooks
+# Hooks examples
 
-## Introduction
-
-Hooks are a mechanism to add extra behaviour to Kedro's main execution in an easy and consistent manner. Some examples may include:
-
-* Adding a log statement after the data catalog is loaded
-* Adding data validation to the inputs before a node runs, and to the outputs after a node has run. This makes it possible to integrate with other tools like [Great-Expectations](https://docs.greatexpectations.io/en/latest/)
-* Adding machine learning metrics tracking, e.g. using [MLflow](https://mlflow.org/), throughout a pipeline run
-
-## Concepts
-
-A Hook is comprised of a Hook specification and Hook implementation. To add Hooks to your project you will need to:
-
-* Create or modify the file `<your_project>/src/<package_name>/hooks.py` to define a Hook implementation for an existing Kedro-defined Hook specification
-* Register your Hook implementation in the [`src/<your_project>/settings.py`](../kedro_project_setup/settings.md) file under the `HOOKS` key
-
-### Hook specification
-
-Kedro defines Hook specifications for particular execution points where users can inject additional behaviour. Currently, the following Hook specifications are provided in [kedro.framework.hooks](/kedro.framework.hooks):
-
-* `after_catalog_created`
-* `before_node_run`
-* `after_node_run`
-* `on_node_error`
-* `before_pipeline_run`
-* `after_pipeline_run`
-* `on_pipeline_error`
-* `before_dataset_loaded`
-* `after_dataset_loaded`
-* `before_dataset_saved`
-* `after_dataset_saved`
-
-The naming convention for non-error Hooks is `<before/after>_<noun>_<past_participle>`, in which:
-
-* `<before/after>` and `<past_participle>` refers to when the Hook executed, e.g. `before <something> was run` or `after <something> was created`.
-* `<noun>` refers to the relevant component in the Kedro execution timeline for which this Hook adds extra behaviour, e.g. `catalog`, `node` and `pipeline`.
-
-The naming convention for error hooks is `on_<noun>_error`, in which:
-
-* `<noun>` refers to the relevant component in the Kedro execution timeline that throws the error.
-
-[kedro.framework.hooks](/kedro.framework.hooks) lists the full specifications for which you can inject additional behaviours by providing an implementation.
-
-
-#### CLI hooks
-
-Lastly, Kedro defines a small set of CLI hooks that inject additional behaviour around execution of a Kedro CLI command:
-
-* `before_command_run`
-* `after_command_run`
-
-This is what the [`kedro-telemetry`](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry) plugin relies on under the hood in order to be able to collect CLI usage statistics.
-
-### Hook implementation
-
-You should provide an implementation for the specification that describes the point at which you want to inject additional behaviour. The Hook implementation should have the same name as the specification. The Hook must provide a concrete implementation with a subset of the corresponding specification's parameters (you do not need to use them all).
-
-To declare a Hook implementation, use the `@hook_impl` decorator.
-
-For example, the full signature of the [`after_data_catalog_created`](/kedro.framework.hooks.specs.DataCatalogSpecs) Hook specification is:
-
-```python
-@hook_spec
-def after_catalog_created(
-    self,
-    catalog: DataCatalog,
-    conf_catalog: Dict[str, Any],
-    conf_creds: Dict[str, Any],
-    save_version: str,
-    load_versions: Dict[str, str],
-) -> None:
-    pass
-```
-
-However, if you just want to use this Hook to list the contents of a data catalog after it is created, your Hook implementation can be as simple as:
-
-```python
-# <your_project>/src/<your_project>/hooks.py
-import logging
-
-from kedro.framework.hooks import hook_impl
-from kedro.io import DataCatalog
-
-
-class DataCatalogHooks:
-    @property
-    def _logger(self):
-        return logging.getLogger(self.__class__.__name__)
-
-    @hook_impl
-    def after_catalog_created(self, catalog: DataCatalog) -> None:
-        self._logger.info(catalog.list())
-```
-
-```{note}
-The name of a module that contains Hooks implementation is arbitrary and is not restricted to `hooks.py`.
-```
-
-We recommend that you group related Hook implementations under a namespace, preferably a class, within a `hooks.py` file that you create in your project.
-
-#### Registering your Hook implementations with Kedro
-
-Hook implementations should be registered with Kedro using the [`<your_project>/src/<package_name>/settings.py`](../kedro_project_setup/settings.md) file under the `HOOKS` key.
-
-You can register more than one implementation for the same specification. They will be called in LIFO (last-in, first-out) order.
-
-The following example sets up a Hook so that the `after_data_catalog_created` implementation is called every time after a data catalog is created.
-
-```python
-# <your_project>/src/<your_project>/settings.py
-from <your_project>.hooks import ProjectHooks, DataCatalogHooks
-
-HOOKS = (ProjectHooks(), DataCatalogHooks())
-```
-
-Kedro also has auto-discovery enabled by default. This means that any installed plugins that declare a Hooks entry-point will be registered. To learn more about how to enable this for your custom plugin, see our [plugin development guide](plugins.md#hooks).
-
-```{note}
-Auto-discovered Hooks will run *first*, followed by the ones specified in `settings.py`.
-```
-
-
-#### Disable auto-registered plugins' Hooks
-
-Auto-registered plugins' Hooks can be disabled via `settings.py` as follows:
-
-```python
-# <your_project>/src/<your_project>/settings.py
-
-DISABLE_HOOKS_FOR_PLUGINS = ("<plugin_name>",)
-```
-
-where `<plugin_name>` is the name of an installed plugin for which the auto-registered Hooks must be disabled.
-
-## Common use cases
-
-### Use Hooks to extend a node's behaviour
-
-You can add extra behaviour before and after a node's execution by using the [`before_node_run` and `after_node_run` Hooks](/kedro.framework.hooks.specs.NodeSpecs). Furthermore, you can apply extra behaviour to not only an individual node or an entire Kedro pipeline, but also to a _subset_ of nodes based on their tags or namespaces. For example, let's say we want to add the following extra behaviours to a node:
-
-```python
-from kedro.pipeline.node import Node
-
-
-def say_hello(node: Node):
-    """An extra behaviour for a node to say hello before running."""
-    print(f"Hello from {node.name}")
-```
-
-Then you can either add it to a single node based on the node's name:
-
-```python
-# <your_project>/src/<your_project>/hooks.py
-
-from kedro.framework.hooks import hook_impl
-from kedro.pipeline.node import Node
-
-
-class ProjectHooks:
-    @hook_impl
-    def before_node_run(self, node: Node):
-        # adding extra behaviour to a single node
-        if node.name == "hello":
-            say_hello(node)
-```
-
-Or add it to a group of nodes based on their tags:
-
-
-```python
-# <your_project>/src/<your_project>/hooks.py
-
-from kedro.framework.hooks import hook_impl
-from kedro.pipeline.node import Node
-
-
-class ProjectHooks:
-    @hook_impl
-    def before_node_run(self, node: Node):
-        if "hello" in node.tags:
-            say_hello(node)
-```
-
-Or add it to all nodes in the entire pipeline:
-
-```python
-# <your_project>/src/<your_project>/hooks.py
-
-from kedro.framework.hooks import hook_impl
-from kedro.pipeline.node import Node
-
-
-class ProjectHooks:
-    @hook_impl
-    def before_node_run(self, node: Node):
-        # adding extra behaviour to all nodes in the pipeline
-        say_hello(node)
-```
-
-If your use case takes advantage of a decorator, for example to retry a node's execution using a library such as [tenacity](https://tenacity.readthedocs.io/en/latest/), you can still decorate the node's function directly:
-
-```python
-from tenacity import retry
-
-
-@retry
-def my_flaky_node_function():
-    ...
-```
-
-Or applying it in the `before_node_run` Hook as follows:
-
-```python
-# <your_project>/src/<your_project>/hooks.py
-from tenacity import retry
-
-from kedro.framework.hooks import hook_impl
-from kedro.pipeline.node import Node
-
-
-class ProjectHooks:
-    @hook_impl
-    def before_node_run(self, node: Node):
-        # adding retrying behaviour to nodes tagged as flaky
-        if "flaky" in node.tags:
-            node.func = retry(node.func)
-```
-### Use Hooks to customise the dataset load and save methods
-We recommend using the `before_dataset_loaded`/`after_dataset_loaded` and `before_dataset_saved`/`after_dataset_saved` Hooks to customise the dataset `load` and `save` methods where appropriate.
-
-For example, you can add logging about the dataset load runtime as follows:
-
-```python
-@property
-def _logger(self):
-    return logging.getLogger(self.__class__.__name__)
-
-
-@hook_impl
-def before_dataset_loaded(self, dataset_name: str) -> None:
-    start = time.time()
-    self._logger.info("Loading dataset %s started at %0.3f", dataset_name, start)
-
-
-@hook_impl
-def after_dataset_loaded(self, dataset_name: str, data: Any) -> None:
-    end = time.time()
-    self._logger.info("Loading dataset %s ended at %0.3f", dataset_name, end)
-```
-
-## Under the hood
-
-Under the hood, we use [pytest's pluggy](https://pluggy.readthedocs.io/en/latest/) to implement Kedro's Hook mechanism. We recommend reading their documentation if you have more questions about the underlying implementation.
-
-## Hooks examples
-
-### Add memory consumption tracking
+## Add memory consumption tracking
 
 This example illustrates how to track memory consumption using `memory_profiler`.
 
@@ -348,7 +93,7 @@ The output should look similar to the following:
 ...
 ```
 
-### Add data validation
+## Add data validation
 
 This example adds data validation to node inputs and outputs using [Great Expectations](https://docs.greatexpectations.io/en/latest/).
 
@@ -419,13 +164,13 @@ class DataValidationHooks:
             )
 ```
 
-* Register Hooks implementation, as described [above](#registering-your-hook-implementations-with-kedro) and run Kedro.
+* Register Hooks implementation, as described in [hooks](hooks.md#registering-your-hook-implementations-with-kedro) and run Kedro.
 
 `Great Expectations` example report:
 
 ![](../meta/images/data_validation.png)
 
-### Add observability to your pipeline
+## Add observability to your pipeline
 
 This example adds observability to your pipeline using [statsd](https://statsd.readthedocs.io/en/v3.3/configure.html) and makes it possible to visualise dataset size and node execution time using [Grafana](https://grafana.com/).
 
@@ -469,13 +214,13 @@ class PipelineMonitoringHooks:
         self._client.incr("run")
 ```
 
-* Register Hooks implementation, as described [above](#registering-your-hook-implementations-with-kedro) and run Kedro.
+* Register Hooks implementation, as described in [hooks](hooks.md#registering-your-hook-implementations-with-kedro) and run Kedro.
 
 `Grafana` example page:
 
 ![](../meta/images/pipeline_observability.png)
 
-### Add metrics tracking to your model
+## Add metrics tracking to your model
 
 This examples adds metrics tracking using [MLflow](https://mlflow.org/).
 
@@ -536,13 +281,13 @@ class ModelTrackingHooks:
         mlflow.end_run()
 ```
 
-* Register Hooks implementation, as described [above](#registering-your-hook-implementations-with-kedro) and run Kedro.
+* Register Hooks implementation, as described in [hooks](hooks.md#registering-your-hook-implementations-with-kedro) and run Kedro.
 
 `MLflow` example page:
 
 ![](../meta/images/mlflow.png)
 
-### Modify node inputs using `before_node_run` hook
+## Modify node inputs using `before_node_run` hook
 
 If the `before_node_run` hook is implemented _and_ returns a dictionary, that dictionary is used to update the corresponding node inputs.
 
@@ -579,4 +324,4 @@ In the example above, the `before_node_run` hook implementation must return data
 ```
 
 
-To apply the changes once you have implemented a new hook, you need to register it, as described [above](#registering-your-hook-implementations-with-kedro), and then run Kedro.
+To apply the changes once you have implemented a new hook, you need to register it, as described in [hooks](hooks.md#registering-your-hook-implementations-with-kedro), and then run Kedro.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -116,10 +116,17 @@ Welcome to Kedro's documentation!
    :caption: Extend Kedro
 
    extend_kedro/common_use_cases
-   extend_kedro/hooks
    extend_kedro/custom_datasets
    extend_kedro/plugins
    extend_kedro/create_kedro_starters
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Hooks
+
+   hooks/hooks
+   hooks/common_use_cases
+   hooks/hooks_examples
 
 
 .. toctree::

--- a/docs/source/kedro_project_setup/settings.md
+++ b/docs/source/kedro_project_setup/settings.md
@@ -10,8 +10,8 @@ By default, all code in `settings.py` is commented out. In the case that setting
 
 | Setting                     | Default value                                     | Use                                                                                                                |
 | --------------------------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `HOOKS`                     | `tuple()`                                         | Inject additional behaviour into the execution timeline with [project Hooks](../extend_kedro/hooks.md).            |
-| `DISABLE_HOOKS_FOR_PLUGINS` | `tuple()`                                         | Disable [auto-registration of Hooks from plugins](../extend_kedro/hooks.md#disable-auto-registered-plugins-hooks). |
+| `HOOKS`                     | `tuple()`                                         | Inject additional behaviour into the execution timeline with [project Hooks](../hooks/hooks.md).            |
+| `DISABLE_HOOKS_FOR_PLUGINS` | `tuple()`                                         | Disable [auto-registration of Hooks from plugins](../hooks/hooks.md#disable-auto-registered-plugins-hooks). |
 | `SESSION_STORE_CLASS`       | `kedro.framework.session.session.BaseSessionStore`| Customise how [session data](session.md) is stored.                                                                |
 | `SESSION_STORE_ARGS`        | `dict()`                                          | Keyword arguments for the `SESSION_STORE_CLASS` constructor.                                                       |
 | `CONTEXT_CLASS`             | `kedro.framework.context.KedroContext`            | Customise how Kedro library components are managed.                                                                |


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

## Description
<!-- Why was this PR created? -->
Hooks documentation is pretty long. We should make a separate section just on Hooks with several new pages. We could also put some of the large code snippets in collapsible blocks.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
