### PR TITLE
Fix/the `getpass.getuser()` call fails when no user is present

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,7 @@
 * Bumped the upper bound for the Flake8 dependency to <5.0.
 * `kedro jupyter notebook/lab` no longer reuses a Jupyter kernel.
 * Required `cookiecutter>=2.1.1` to address a [known command injection vulnerability](https://security.snyk.io/vuln/SNYK-PYTHON-COOKIECUTTER-2414281).
-* The `getpass.getuser()` call no longer fails if the user doesn't exist.
+* The session store no longer fails if a username cannot be found with `getpass.getuser`.
 
 
 ## Upcoming deprecations for Kedro 0.19.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,7 @@
 * Bumped the upper bound for the Flake8 dependency to <5.0.
 * `kedro jupyter notebook/lab` no longer reuses a Jupyter kernel.
 * Required `cookiecutter>=2.1.1` to address a [known command injection vulnerability](https://security.snyk.io/vuln/SNYK-PYTHON-COOKIECUTTER-2414281).
+* The `getpass.getuser()` call no longer fails if the user doesn't exist.
 
 
 ## Upcoming deprecations for Kedro 0.19.0

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -165,7 +165,7 @@ class KedroSession:
 
         try:
             session_data["username"] = getpass.getuser()
-        except:  # pylint: disable=broad-except
+        except:  # pylint: disable=bare-except
             logging.getLogger(__name__).debug("Unable to get username.")
 
         session._store.update(session_data)

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -163,7 +163,10 @@ class KedroSession:
         if extra_params:
             session_data["extra_params"] = extra_params
 
-        session_data["username"] = getpass.getuser()
+        try:
+            session_data["username"] = getpass.getuser()
+        except:  # pylint: disable=broad-except
+            logging.getLogger(__name__).debug("Unable to get username.")
 
         session._store.update(session_data)
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -165,8 +165,10 @@ class KedroSession:
 
         try:
             session_data["username"] = getpass.getuser()
-        except:  # pylint: disable=bare-except
-            logging.getLogger(__name__).debug("Unable to get username.")
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.getLogger(__name__).debug(
+                "Unable to get username. Full exception: %s", exc
+            )
 
         session._store.update(session_data)
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -496,6 +496,27 @@ class TestKedroSession:
         ]
         assert actual_log_messages == expected_log_messages
 
+    def test_get_username_error(
+        self, fake_project, mock_package_name, mocker, caplog
+    ):
+        """Test that username information is not added to the session store
+        if call to getuser() fails
+        """
+        caplog.set_level(logging.DEBUG, logger="kedro")
+
+        mocker.patch("kedro.framework.session.KedroSession._setup_logging")
+        mocker.patch("getpass.getuser", side_effect=FakeException)
+        session = KedroSession.create(mock_package_name, fake_project)
+        assert "username" not in session.store
+
+        expected_log_message = "Unable to get username."
+        actual_log_messages = [
+            rec.getMessage()
+            for rec in caplog.records
+            if rec.name == SESSION_LOGGER_NAME and rec.levelno == logging.DEBUG
+        ]
+        assert expected_log_message in actual_log_messages
+    
     @pytest.mark.usefixtures("mock_settings")
     def test_log_error(self, fake_project, mock_package_name):
         """Test logging the error by the session"""

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -516,7 +516,7 @@ class TestKedroSession:
             for rec in caplog.records
             if rec.name == SESSION_LOGGER_NAME and rec.levelno == logging.DEBUG
         ]
-        assert expected_log_messages == actual_log_messages
+        assert actual_log_messages == expected_log_messages
 
     @pytest.mark.usefixtures("mock_settings")
     def test_log_error(self, fake_project, mock_package_name):

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -496,27 +496,28 @@ class TestKedroSession:
         ]
         assert actual_log_messages == expected_log_messages
 
-    def test_get_username_error(
-        self, fake_project, mock_package_name, mocker, caplog
-    ):
+    def test_get_username_error(self, fake_project, mock_package_name, mocker, caplog):
         """Test that username information is not added to the session store
         if call to getuser() fails
         """
         caplog.set_level(logging.DEBUG, logger="kedro")
 
+        mocker.patch("subprocess.check_output")
         mocker.patch("kedro.framework.session.KedroSession._setup_logging")
-        mocker.patch("getpass.getuser", side_effect=FakeException)
+        mocker.patch("getpass.getuser", side_effect=FakeException("getuser error"))
         session = KedroSession.create(mock_package_name, fake_project)
         assert "username" not in session.store
 
-        expected_log_message = "Unable to get username."
+        expected_log_messages = [
+            "Unable to get username. Full exception: getuser error"
+        ]
         actual_log_messages = [
             rec.getMessage()
             for rec in caplog.records
             if rec.name == SESSION_LOGGER_NAME and rec.levelno == logging.DEBUG
         ]
-        assert expected_log_message in actual_log_messages
-    
+        assert expected_log_messages == actual_log_messages
+
     @pytest.mark.usefixtures("mock_settings")
     def test_log_error(self, fake_project, mock_package_name):
         """Test logging the error by the session"""


### PR DESCRIPTION
## Description

Fixes #1624.

## Development notes

We now wrap the call in a `try-except` block to prevent the failure.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1642"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

