### PR TITLE
Patching pandas starter into official starter list

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -63,6 +63,7 @@ _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec(
         "standalone-datacatalog", _STARTERS_REPO, "standalone-datacatalog"
     ),
+    KedroStarterSpec("pandas-iris", _STARTERS_REPO, "pandas-iris"),
     KedroStarterSpec("pyspark", _STARTERS_REPO, "pyspark"),
     KedroStarterSpec("pyspark-iris", _STARTERS_REPO, "pyspark-iris"),
     KedroStarterSpec("spaceflights", _STARTERS_REPO, "spaceflights"),


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Found this while I am trying to do `kedro new --starter=pandas-iris` to test the rich logging😅.

This is a patch for #1592 where the `pandas-iris` starter is actually missed from the PR.



## Development notes
<!-- What have you changed, and how has this been tested? -->
* Adding the `pandas-iris` KedroStarterSpec into the list

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file (No need since we haven't release a version yet)
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1667"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

