### PR TITLE
Enable rich in the REPL

### DIFF
--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -14,6 +14,7 @@ import click
 import yaml
 from dynaconf import LazySettings
 from dynaconf.validator import ValidationError, Validator
+from rich.pretty import install as rich_pretty_install
 from rich.traceback import install as rich_traceback_install
 
 from kedro.pipeline import Pipeline
@@ -202,6 +203,7 @@ class _ProjectLogging(UserDict):
         rich_traceback_install(
             show_locals=True, suppress=[click, str(Path(sys.executable).parent)]
         )
+        rich_pretty_install()
 
     def configure(self, logging_config: Dict[str, Any]) -> None:
         """Configure project logging using `logging_config` (e.g. from project


### PR DESCRIPTION
## Description
One final small piece to get some more benefits of rich: https://rich.readthedocs.io/en/stable/introduction.html#rich-in-the-repl.

This is a pretty minor change. In reality the only effect it will have is that when IPython/Juptyer shows something in the REPL (without explicitly writing `print`) it will highlight it nicely.

Before:
![image](https://user-images.githubusercontent.com/49395058/177177531-520f460a-f4a1-45f6-b8f9-e15b4bcc3ace.png)

After (don't worry about text being cut off here; there's a scroll bar I didn't show):
![image](https://user-images.githubusercontent.com/49395058/177177554-bbf5dcb7-995a-4797-8ded-cb683899a4e1.png)

## Future

We can make this look even nicer without much effort, e.g. to achieve indentation. This would be a Part 2 to integrating rich into kedro. I'll make tickets for it in due course.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1672"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

