### PR TITLE
Restore accidentally-deleted PR naming conventions

### DIFF
--- a/docs/source/contribution/developer_contributor_guidelines.md
+++ b/docs/source/contribution/developer_contributor_guidelines.md
@@ -124,7 +124,7 @@ There are two special considerations when contributing a dataset:
 
 ## Create a pull request
 
-Create your pull request with a descriptive title. Before you submit it, consider the following:
+Create your pull request with [a descriptive title](#pull-request-title-conventions). Before you submit it, consider the following:
 
 * You should aim for cross-platform compatibility on Windows, macOS and Linux
 * We use [SemVer](https://semver.org/) for versioning
@@ -150,6 +150,17 @@ If Spark/PySpark/Hive tests for datasets are failing it might be due to the lack
 ```{note}
 We place [conftest.py](https://docs.pytest.org/en/latest/reference/fixtures.html) files in some test directories to make fixtures reusable by any tests in that directory. If you need to see which test fixtures are available and where they come from, you can issue the following command `pytest --fixtures path/to/the/test/location.py`.
 ```
+
+### Pull request title conventions
+
+The Kedro repository requires that you [squash and merge your pull request commits](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#squash-and-merge-your-pull-request-commits), and, in most cases, the [merge message for a squash merge](https://docs.github.com/en/free-pro-team@latest/github/collaborating-with-issues-and-pull-requests/about-pull-request-merges#merge-message-for-a-squash-merge) then defaults to the pull request title.
+
+For clarity, your pull request title should be descriptive, and we ask you to follow some guidelines suggested by [Chris Beams](https://github.com/cbeams) in his post [How to Write a Git Commit Message](https://chris.beams.io/posts/git-commit/#seven-rules). In particular, for your pull request title, we suggest that you:
+
+* [Limit the length to 50 characters](https://chris.beams.io/posts/git-commit/#limit-50)
+* [Capitalise the first letter of the first word](https://chris.beams.io/posts/git-commit/#capitalize)
+* [Omit the period at the end](https://chris.beams.io/posts/git-commit/#end)
+* [Use the imperative tense](https://chris.beams.io/posts/git-commit/#imperative)
 
 ### Hints on `pre-commit` usage
 [`pre-commit`](https://pre-commit.com) hooks run checks automatically on all the changed files on each commit but can be skipped with the `--no-verify` or `-n` flag:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -11,11 +11,11 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 import click
+import rich.pretty
+import rich.traceback
 import yaml
 from dynaconf import LazySettings
 from dynaconf.validator import ValidationError, Validator
-from rich.pretty import install as rich_pretty_install
-from rich.traceback import install as rich_traceback_install
 
 from kedro.pipeline import Pipeline
 
@@ -200,10 +200,10 @@ class _ProjectLogging(UserDict):
         # We suppress click here to hide tracebacks related to it conversely,
         # kedro is not suppressed to show its tracebacks for easier debugging.
         # sys.executable is used to get the kedro executable path to hide the top level traceback.
-        rich_traceback_install(
+        rich.traceback.install(
             show_locals=True, suppress=[click, str(Path(sys.executable).parent)]
         )
-        rich_pretty_install()
+        rich.pretty.install()
 
     def configure(self, logging_config: Dict[str, Any]) -> None:
         """Configure project logging using `logging_config` (e.g. from project


### PR DESCRIPTION
Signed-off-by: Deepyaman Datta <deepyaman.datta@utexas.edu>

## Description
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/commit/5ca2fca93a13428c875e0c75652ea3f9dbd728b3 accidentally dropped the PR naming conventions introduced in https://github.com/kedro-org/kedro/commit/a47ca06651a86052b24a8d34524611740eb1fe38 (or at least I don't see any justification in https://github.com/quantumblacklabs/private-kedro/pull/1169, having trawled through the comments therein).

Maybe it's just me, but I really do appreciate more standardized commit messages when contributing to and looking through change logs of other open source projects, and I think there is no downside to enforcing some convention. I would also be happy with a stricter convention (e.g. Conventional Commit), but Kedro hasn't followed anything as such so far, and that's OK.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1689"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

