### PR TITLE
Use fsspec's infer_storage_options

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,9 @@
 
 ## Bug fixes and other changes
 
+## Minor breaking changes to the API
+* Removed `kedro.io.core.CLOUD_PROTOCOLS`, which was previously used to patch `fsspec.utils.infer_storage_options`. In recent `fsspec` versions this patching is no longer required. 
+
 ## Upcoming deprecations for Kedro 0.19.0
 
 # Release 0.18.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cachetools~=4.1
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <=2022.1
+fsspec>=2021.4, <=2022.1 # TODO: when fsspec is released, say 2022.x, update to >=2022.x, <2023.y (use 6 month interval)
 gitpython~=3.0
 importlib_metadata>=3.6  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
 jmespath>=0.9.5, <1.0

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -94,6 +94,7 @@ class TestCoreFunctions:
         ],
     )
     def test_parse_filepath(self, filepath, expected_result):
+        # TODO: delete this test completely once it passes
         from fsspec.utils import infer_storage_options
 
         assert infer_storage_options(filepath).items() >= expected_result.items()

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -1,11 +1,12 @@
 from decimal import Decimal
 from fractions import Fraction
 from pathlib import PurePosixPath
-from typing import Any, List
+from typing import Any, List, re
+from urllib.parse import urlsplit
 
 import pytest
 
-from kedro.io.core import AbstractDataSet, _parse_filepath, get_filepath_str
+from kedro.io.core import AbstractDataSet, get_filepath_str
 
 # List sourced from https://docs.python.org/3/library/stdtypes.html#truth-value-testing.
 # Excludes None, as None values are not shown in the str representation.
@@ -93,4 +94,6 @@ class TestCoreFunctions:
         ],
     )
     def test_parse_filepath(self, filepath, expected_result):
-        assert _parse_filepath(filepath) == expected_result
+        from fsspec.utils import infer_storage_options
+
+        assert infer_storage_options(filepath).items() >= expected_result.items()


### PR DESCRIPTION
## Description
Closes: #1632.

Thanks to https://github.com/fsspec/filesystem_spec/pull/988 we no longer need to write our own version of fsspec's `infer_storage_options`. However, we do need to wait until they do a release before we can use that code.

The tests in this PR will only pass once fsspec do that release and we edit our requirements.txt to include that new version of fsspec. So we need to keep an eye on fsspec to see when that release happens. When it does:
* edit requirements.txt as in the `TODO` to get the new fsspec version in as a dependency
* re-run tests
* assuming they pass, remove `test_parse_filepath` completely (it's no longer needed since it will all be tested on the fsspec side)
* merge this PR

Note that removing `CLOUD_PROTOCOLS` was only ever used in `_parse_filepath` and never advertised anywhere, so even though it's not got `_` in front of it I think it's fine to remove. If anyone wanted to use it to modify the list then they would have raised an issue to modify it on the kedro side (which has happened in the past). So I think we can safely remove this variable.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1714"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

