### PR TITLE
Use `show_locals` False default for rich logging

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Use default `False` value for rich logging `set_locals`, to make sure credentials and other sensitive data isn't shown in logs.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -200,9 +200,7 @@ class _ProjectLogging(UserDict):
         # We suppress click here to hide tracebacks related to it conversely,
         # kedro is not suppressed to show its tracebacks for easier debugging.
         # sys.executable is used to get the kedro executable path to hide the top level traceback.
-        rich.traceback.install(
-            show_locals=True, suppress=[click, str(Path(sys.executable).parent)]
-        )
+        rich.traceback.install(suppress=[click, str(Path(sys.executable).parent)])
         rich.pretty.install()
 
     def configure(self, logging_config: Dict[str, Any]) -> None:


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
When we added `rich` as our default logger we set `show_locals=True` to enable display of local variables. However, this can lead to credentials being shown in logs: https://github.com/kedro-org/kedro/issues/1712

## Development notes
Instead just use the default value for `show_locals` which is False. 

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1726"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

