### PR TITLE
Fix links to data catalog docs from datasets' docs

### DIFF
--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -29,7 +29,7 @@ class CSVDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
     Example adding a catalog entry with
     `YAML API
     <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -27,7 +27,7 @@ class GBQTableDataSet(AbstractDataSet[None, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -36,7 +36,7 @@ class GenericDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
 
     Example using `YAML API
     <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -26,7 +26,7 @@ class HDFDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -28,7 +28,7 @@ class JSONDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -29,7 +29,7 @@ class ParquetDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -104,7 +104,7 @@ class SQLTableDataSet(AbstractDataSet[pd.DataFrame, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 
@@ -273,7 +273,7 @@ class SQLQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -27,7 +27,7 @@ class PickleDataSet(AbstractVersionedDataSet[Any, Any]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -20,7 +20,7 @@ class PickleDataSet(AbstractDataSet[Any, Any]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -20,7 +20,7 @@ class DeltaTableDataSet(AbstractDataSet[None, DeltaTable]):
 
         Example adding a catalog entry with
         `YAML API <https://kedro.readthedocs.io/en/stable/05_data/\
-            01_data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+            01_data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
         .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -162,7 +162,7 @@ class SparkDataSet(AbstractVersionedDataSet[DataFrame, DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -27,7 +27,7 @@ class SparkHiveDataSet(AbstractDataSet[DataFrame, DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -20,7 +20,7 @@ class SparkJDBCDataSet(AbstractDataSet[DataFrame, DataFrame]):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -42,7 +42,7 @@ class PartitionedDataSet(AbstractDataSet):
 
     Example adding a catalog entry with
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-        data_catalog.html#using-the-data-catalog-with-the-yaml-api>`_:
+        data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
 
     .. code-block:: yaml
 


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
These links were broken for a while, but the `stable` branch was only rebuilt last week so we didn't see the error before.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Fix the doclinks

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1747"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

