### PR TITLE
Keep plugin docstring from appearing in `kedro -h`

### DIFF
--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -19,7 +19,6 @@ from kedro.framework.project import pipelines
 
 @click.group(name="JSON")
 def commands():
-    """Kedro plugin for printing the pipeline in JSON format"""
     pass
 
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Resolves part of #1749 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1756"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

