### PR TITLE
Enable dotted keys in params passed to `kedro run`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,7 +14,8 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
-* Use default `False` value for rich logging `set_locals`, to make sure credentials and other sensitive data isn't shown in logs.
+* Set default `False` value for rich logging `set_locals`, to make sure credentials and other sensitive data isn't shown in logs.
+* Enabled dotted keys in params passed to `kedro run`.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -1,4 +1,5 @@
 """Utilities for use with click."""
+import csv
 import difflib
 import logging
 import re
@@ -428,9 +429,8 @@ def _split_params(ctx, param, value):
                 f"cannot be an empty string."
             )
         value = item[1].strip()
-        result = _update_value_nested_dict(
-            result, _try_convert_to_numeric(value), key.split(".")
-        )
+        [path] = list(csv.reader([key], delimiter="."))
+        result = _update_value_nested_dict(result, _try_convert_to_numeric(value), path)
     return result
 
 

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -647,8 +647,17 @@ class TestRunCommand:
             ("foo.nested:bar", {"foo": {"nested": "bar"}}),
             ("foo.nested:123.45", {"foo": {"nested": 123.45}}),
             (
-                "foo.nested_1.double_nest:123.45,foo.nested_2:1a",
-                {"foo": {"nested_1": {"double_nest": 123.45}, "nested_2": "1a"}},
+                "foo.nested_1.double_nested:123.45,foo.nested_2:1a",
+                {"foo": {"nested_1": {"double_nested": 123.45}, "nested_2": "1a"}},
+            ),
+            (
+                'foo.nested_1.double_nested:123.45,foo."nested_2.not_double_nested":1a',
+                {
+                    "foo": {
+                        "nested_1": {"double_nested": 123.45},
+                        "nested_2.not_double_nested": "1a",
+                    }
+                },
             ),
         ],
     )


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1765"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

