### PR TITLE
Add anchors to `data_catalog.md` examples

### DIFF
--- a/docs/source/data/data_catalog.md
+++ b/docs/source/data/data_catalog.md
@@ -50,7 +50,7 @@ Data Catalog accepts two different groups of `*_args` parameters that serve diff
 The `fs_args` is used to configure the interaction with a filesystem.
 All the top-level parameters of `fs_args` (except `open_args_load` and `open_args_save`) will be passed in an underlying filesystem class.
 
-Example 1: Provide the `project` value to the underlying filesystem class (`GCSFileSystem`) to interact with Google Cloud Storage (GCS)
+### Example 1: Provide the `project` value to the underlying filesystem class (`GCSFileSystem`) to interact with Google Cloud Storage (GCS)
 
 ```yaml
 test_dataset:
@@ -61,7 +61,7 @@ test_dataset:
 
 The `open_args_load` and `open_args_save` parameters are passed to the filesystem's `open` method to configure how a dataset file (on a specific filesystem) is opened during a load or save operation, respectively.
 
-Example 2: Load data from a local binary file using `utf-8` encoding
+### Example 2: Load data from a local binary file using `utf-8` encoding
 
 ```yaml
 test_dataset:
@@ -74,7 +74,7 @@ test_dataset:
 
 `load_args` and `save_args` configure how a third-party library (e.g. `pandas` for `CSVDataSet`) loads/saves data from/to a file.
 
-Example 3: Save data to a CSV file without row names (index) using `utf-8` encoding
+### Example 3: Save data to a CSV file without row names (index) using `utf-8` encoding
 
 ```yaml
 test_dataset:
@@ -91,7 +91,7 @@ The YAML API allows you to configure your datasets in a YAML configuration file,
 
 Here are some examples of data configuration in a `catalog.yml`:
 
-Example 1: Loads / saves a CSV file from / to a local file system
+### Example 1: Loads / saves a CSV file from / to a local file system
 
 ```yaml
 bikes:
@@ -99,7 +99,7 @@ bikes:
   filepath: data/01_raw/bikes.csv
 ```
 
-Example 2: Loads and saves a CSV on a local file system, using specified load and save arguments
+### Example 2: Loads and saves a CSV on a local file system, using specified load and save arguments
 
 ```yaml
 cars:
@@ -114,7 +114,7 @@ cars:
 
 ```
 
-Example 3: Loads and saves a compressed CSV on a local file system
+### Example 3: Loads and saves a compressed CSV on a local file system
 
 ```yaml
 boats:
@@ -128,7 +128,7 @@ boats:
       mode: 'rb'
 ```
 
-Example 4: Loads a CSV file from a specific S3 bucket, using credentials and load arguments
+### Example 4: Loads a CSV file from a specific S3 bucket, using credentials and load arguments
 
 ```yaml
 motorbikes:
@@ -142,7 +142,7 @@ motorbikes:
     na_values: ['#NA', NA]
 ```
 
-Example 5: Loads / saves a pickle file from / to a local file system
+### Example 5: Loads / saves a pickle file from / to a local file system
 
 ```yaml
 airplanes:
@@ -151,7 +151,7 @@ airplanes:
   backend: pickle
 ```
 
-Example 6: Loads an excel file from Google Cloud Storage
+### Example 6: Loads an excel file from Google Cloud Storage
 
 ```yaml
 rockets:
@@ -164,7 +164,7 @@ rockets:
     sheet_name: Sheet1
 ```
 
-Example 7: Saves an image created with Matplotlib on Google Cloud Storage
+### Example 7: Saves an image created with Matplotlib on Google Cloud Storage
 
 ```yaml
 results_plot:
@@ -175,7 +175,7 @@ results_plot:
   credentials: my_gcp_credentials
 ```
 
-Example 8: Loads / saves an HDF file on local file system storage, using specified load and save arguments
+### Example 8: Loads / saves an HDF file on local file system storage, using specified load and save arguments
 
 ```yaml
 skateboards:
@@ -189,7 +189,7 @@ skateboards:
     dropna: True
 ```
 
-Example 9: Loads / saves a parquet file on local file system storage, using specified load and save arguments
+### Example 9: Loads / saves a parquet file on local file system storage, using specified load and save arguments
 
 ```yaml
 trucks:
@@ -206,7 +206,7 @@ trucks:
     partition_on: [name]
 ```
 
-Example 10: Loads / saves a Spark table on S3, using specified load and save arguments
+### Example 10: Loads / saves a Spark table on S3, using specified load and save arguments
 
 ```yaml
 weather:
@@ -222,7 +222,7 @@ weather:
     header: True
 ```
 
-Example 11: Loads / saves a SQL table using credentials, a database connection, using specified load and save arguments
+### Example 11: Loads / saves a SQL table using credentials, a database connection, using specified load and save arguments
 
 ```yaml
 scooters:
@@ -236,7 +236,7 @@ scooters:
     if_exists: replace
 ```
 
-Example 12: Loads an SQL table with credentials, a database connection, and applies a SQL query to the table
+### Example 12: Loads an SQL table with credentials, a database connection, and applies a SQL query to the table
 
 ```yaml
 scooters_query:
@@ -249,7 +249,7 @@ scooters_query:
 
 When you use [`pandas.SQLTableDataSet`](/kedro.extras.datasets.pandas.SQLTableDataSet) or [`pandas.SQLQueryDataSet`](/kedro.extras.datasets.pandas.SQLQueryDataSet), you must provide a database connection string. In the above example, we pass it using the `scooters_credentials` key from the credentials (see the details in the [Feeding in credentials](#feeding-in-credentials) section below). `scooters_credentials` must have a top-level key `con` containing a [SQLAlchemy compatible](https://docs.sqlalchemy.org/en/13/core/engines.html#database-urls) connection string. As an alternative to credentials, you could explicitly put `con` into `load_args` and `save_args` (`pandas.SQLTableDataSet` only).
 
-Example 13: Loads data from an API endpoint, example US corn yield data from USDA
+### Example 13: Loads data from an API endpoint, example US corn yield data from USDA
 
 ```yaml
 us_corn_yield_data:
@@ -273,7 +273,7 @@ usda_credentials:
   - password
 ```
 
-Example 14: Loads data from Minio (S3 API Compatible Storage)
+### Example 14: Loads data from Minio (S3 API Compatible Storage)
 
 ```yaml
 test:
@@ -297,7 +297,7 @@ The easiest way to setup MinIO is to run a Docker image. After the following com
 
 `docker run -p 9000:9000 -e "MINIO_ACCESS_KEY=token" -e "MINIO_SECRET_KEY=key" minio/minio server /data`
 
-Example 15: Loads a model saved as a pickle from Azure Blob Storage
+### Example 15: Loads a model saved as a pickle from Azure Blob Storage
 
 ```yaml
 ml_model:
@@ -313,7 +313,8 @@ dev_abs:
   account_name: accountname
   account_key: key
 ```
-Example 16: Loads a CSV file stored in a remote location through SSH
+
+### Example 16: Loads a CSV file stored in a remote location through SSH
 
 ```{note}
 This example requires [Paramiko](https://www.paramiko.org) to be installed (`pip install paramiko`).


### PR DESCRIPTION
## Description
Today we cannot link to a particular example on the data catalog docs, this PR intruces these as headings so that they function as anchors.

## Development notes

Slight doc changes

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1770"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

