### PR TITLE
Relax delta-spark version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 ## Bug fixes and other changes
 * Use default `False` value for rich logging `set_locals`, to make sure credentials and other sensitive data isn't shown in logs.
 * The Kedro IPython extension now surfaces errors when it cannot load a Kedro project.
+* Relaxed `delta-spark` upper bound to allow compatibility with Spark 3.x.x
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@
 * Update documentation for `rich` logging.
 * Updated Prefect deployment documentation to allow for reruns with saved versioned datasets.
 * The Kedro IPython extension now surfaces errors when it cannot load a Kedro project.
-* Relaxed `delta-spark` upper bound to allow compatibility with Spark 3.x.x
+* Relaxed `delta-spark` upper bound to allow compatibility with Spark 3.1.x and 3.2.x.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ spark_require = {
     "spark.SparkDataSet": [SPARK, HDFS, S3FS],
     "spark.SparkHiveDataSet": [SPARK, HDFS, S3FS],
     "spark.SparkJDBCDataSet": [SPARK, HDFS, S3FS],
-    "spark.DeltaTableDataSet": [SPARK, HDFS, S3FS, "delta-spark~=1.0"],
+    "spark.DeltaTableDataSet": [SPARK, HDFS, S3FS, "delta-spark>=1.0, <3.0"],
 }
 tensorflow_required = {
     "tensorflow.TensorflowModelDataset": [


### PR DESCRIPTION
## Description

Open source user noted we don't support Spark 3.2.x since the delta requirement is strict. I'm raising this PR since I don't think the breaking changes to the delta API will affect us.

## Development notes
Using CircleCI to test this.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1779"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

