### PR TITLE
Review fsspec upperbound

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cachetools~=4.1
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <=2022.1
+fsspec>=2021.4, <=2022.7
 gitpython~=3.0
 importlib_metadata>=3.6  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
 jmespath>=0.9.5, <1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cachetools~=4.1
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <=2022.7
+fsspec>=2021.4, <=2022.7.1
 gitpython~=3.0
 importlib_metadata>=3.6  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10.
 jmespath>=0.9.5, <1.0


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
#1804 review fsspec upperbound. We have a tight bound because fsspec use calendar versioning and we need to be conservative here to make sure it doesn't break.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1806"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

