### PR TITLE
Fix the case of `Excel` in docs

### DIFF
--- a/docs/source/data/data_catalog.md
+++ b/docs/source/data/data_catalog.md
@@ -151,7 +151,7 @@ airplanes:
   backend: pickle
 ```
 
-### Example 6: Loads an excel file from Google Cloud Storage
+### Example 6: Loads an Excel file from Google Cloud Storage
 
 ```yaml
 rockets:
@@ -164,7 +164,7 @@ rockets:
     sheet_name: Sheet1
 ```
 
-### Example 7: Loads a multi-sheet excel file from a local file system
+### Example 7: Loads a multi-sheet Excel file from a local file system
 
 ```yaml
 trains:

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -65,11 +65,11 @@ class ExcelDataSet(
         >>> reloaded = data_set.load()
         >>> assert data.equals(reloaded)
 
-    Note: To save a multi-sheet excel file, no special ``save_args`` are required.
+    Note: To save a multi-sheet Excel file, no special ``save_args`` are required.
     Instead, return a dictionary of ``Dict[str, pd.DataFrame]`` where the string
     keys are your sheet names.
 
-    Example adding a catalog entry for multi-sheet excel file with the ``YAML API``:
+    Example adding a catalog entry for multi-sheet Excel file with the ``YAML API``:
 
     .. code-block:: yaml
 
@@ -79,7 +79,7 @@ class ExcelDataSet(
         >>>   load_args:
         >>>     sheet_name: [Sheet1, Sheet2, Sheet3]
 
-    Example multi-sheet excel file using Python API:
+    Example multi-sheet Excel file using Python API:
     ::
 
         >>> from kedro.extras.datasets.pandas import ExcelDataSet
@@ -119,7 +119,7 @@ class ExcelDataSet(
                 `s3://`. If prefix is not provided, `file` protocol (local filesystem) will be used.
                 The prefix should be any protocol supported by ``fsspec``.
                 Note: `http(s)` doesn't support versioning.
-            engine: The engine used to write to excel files. The default
+            engine: The engine used to write to Excel files. The default
                 engine is 'openpyxl'.
             load_args: Pandas options for loading Excel files.
                 Here you can find all available arguments:


### PR DESCRIPTION
Signed-off-by: ankatiyar <ankitakatiyar2401@gmail.com>

## Description
Resolves #1780 

## Development notes
Updating mentions of `excel` written in lowercase to `Excel`. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1822"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

