### PR TITLE
Fix issue with specifying format for SparkHiveDataSet

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -39,6 +39,7 @@
 * The Kedro IPython extension now surfaces errors when it cannot load a Kedro project.
 * Relaxed `delta-spark` upper bound to allow compatibility with Spark 3.1.x and 3.2.x.
 * Added `gdrive` to list of cloud protocols, enabling Google Drive paths for datasets.
+* Fix save format argument for `SparkHiveDataSet`.
 
 ## Upcoming deprecations for Kedro 0.19.0
 * The Kedro IPython extension will no longer be available as `%load_ext kedro.extras.extensions.ipython`; use `%load_ext kedro.ipython` instead.

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -114,7 +114,7 @@ class SparkHiveDataSet(AbstractDataSet[DataFrame, DataFrame]):
         self._save_args = deepcopy(self.DEFAULT_SAVE_ARGS)
         if save_args is not None:
             self._save_args.update(save_args)
-        self._format = self._save_args.get("format") or "hive"
+        self._format = self._save_args.pop("format", None) or "hive"
         self._eager_checkpoint = self._save_args.pop("eager_checkpoint", None) or True
 
     def _describe(self) -> Dict[str, Any]:

--- a/tests/extras/datasets/spark/test_spark_hive_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_hive_dataset.py
@@ -301,3 +301,11 @@ class TestSparkHiveDataSet:
             r"table_doesnt_exist\], \[\], false\n",
         ):
             dataset.load()
+
+    def test_save_delta_format(self):
+        dataset = SparkHiveDataSet(database='default_1',
+                                   table='delta_table',
+                                   format='delta')
+        dataset.save(_generate_spark_df_one())
+        dataset.load()
+        assert dataset._format == 'delta'

--- a/tests/extras/datasets/spark/test_spark_hive_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_hive_dataset.py
@@ -303,9 +303,9 @@ class TestSparkHiveDataSet:
             dataset.load()
 
     def test_save_delta_format(self):
-        dataset = SparkHiveDataSet(database='default_1',
-                                   table='delta_table',
-                                   format='delta')
+        dataset = SparkHiveDataSet(
+            database="default_1", table="delta_table", save_args={"format": "delta"}
+        )
         dataset.save(_generate_spark_df_one())
         dataset.load()
-        assert dataset._format == 'delta'
+        assert dataset._format == "delta"

--- a/tests/extras/datasets/spark/test_spark_hive_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_hive_dataset.py
@@ -302,10 +302,13 @@ class TestSparkHiveDataSet:
         ):
             dataset.load()
 
-    def test_save_delta_format(self):
+    def test_save_delta_format(self, mocker):
         dataset = SparkHiveDataSet(
             database="default_1", table="delta_table", save_args={"format": "delta"}
         )
+        mocked_save = mocker.patch("pyspark.sql.DataFrameWriter.saveAsTable")
         dataset.save(_generate_spark_df_one())
-        dataset.load()
+        mocked_save.assert_called_with(
+            "default_1.delta_table", mode="errorifexists", format="delta"
+        )
         assert dataset._format == "delta"


### PR DESCRIPTION
## Description
The current implementation of `SparkHiveDataSet` contains a bug that prevents a user from specifying a save format. This issue is discussed in #1528 .


## Development notes
The proposed fix for this is to `pop` the format argument if it exists.
A unit test has also been added to assert that the dataset has the required format and that the table can be saved.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1857"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

