### PR TITLE
Make core config accessible in dict get way 

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -371,7 +371,7 @@ jobs:
   docs_linkcheck:
     executor:
       name: docker
-      python_version: "3.7"
+      python_version: "3.8"
     steps:
       - setup
       - run:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,8 @@
 # Upcoming Release 0.18.4
 
 ## Major features and improvements
-* Made configuration patterns accessible with dictionary get syntax, by making `AbstractConfigLoader` inherit from `UserDict`. The hardcoded patterns are moved from the `KedroContext` to the config loader classes instead.
+* The config loader objects now implement `UserDict` and the configuration is accessed through `conf_loader['catalog']`
+* You can configure config file patterns through `settings.py` without creating a custom config loader
 
 ## Bug fixes and other changes
 * Fixed `kedro micropkg pull` for packages on PyPI.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 # Upcoming Release 0.18.4
 
 ## Major features and improvements
+* Made configuration patterns accessible with dictionary get syntax, by making `AbstractConfigLoader` inherit from `UserDict`. The hardcoded patterns are moved from the `KedroContext` to the config loader classes instead.
 
 ## Bug fixes and other changes
 * Fixed `kedro micropkg pull` for packages on PyPI.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,8 +143,7 @@ type_targets = {
         "pluggy._manager.PluginManager",
         "_DI",
         "_DO",
-        # The seven statements below were added after subclassing dict in AbstractConfigLoader. More
-        # explanation in: https://github.com/numpy/numpydoc/issues/275#issuecomment-654418024
+        # The statements below were added after subclassing UserDict in AbstractConfigLoader.
         "None.  Remove all items from D.",
         "a shallow copy of D",
         "a set-like object providing a view on D's items",
@@ -152,6 +151,9 @@ type_targets = {
         "v, remove specified key and return the corresponding value.",
         "None.  Update D from dict/iterable E and F.",
         "an object providing a view on D's values",
+        "(k, v), remove and return some (key, value) pair",
+        "D.get(k,d), also set D[k]=d if k not in D",
+        "None.  Update D from mapping/iterable E and F.",
     ),
     "py:data": (
         "typing.Any",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -143,6 +143,15 @@ type_targets = {
         "pluggy._manager.PluginManager",
         "_DI",
         "_DO",
+        # The seven statements below were added after subclassing dict in AbstractConfigLoader. More
+        # explanation in: https://github.com/numpy/numpydoc/issues/275#issuecomment-654418024
+        "None.  Remove all items from D.",
+        "a shallow copy of D",
+        "a set-like object providing a view on D's items",
+        "a set-like object providing a view on D's keys",
+        "v, remove specified key and return the corresponding value.",
+        "None.  Update D from dict/iterable E and F.",
+        "an object providing a view on D's values",
     ),
     "py:data": (
         "typing.Any",

--- a/docs/source/development/automated_testing.md
+++ b/docs/source/development/automated_testing.md
@@ -9,7 +9,7 @@ Software testing is the process of checking that the code you have written fulfi
 
 As a project grows larger, new code will increasingly rely on existing code. As these interdependencies grow, making changes in one part of the code base can unexpectedly break the intended functionality in another part.
 
-The major disadvantage of manual testing is that it is time-consuming. Manual tests are usually run once, directly after new functionality has been added. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes. 
+The major disadvantage of manual testing is that it is time-consuming. Manual tests are usually run once, directly after new functionality has been added. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes.
 
 The solution to this problem is automated testing. Automated testing allows many tests across the whole code base to be run in seconds, every time a new feature is added or an old one is changed. In this way, breaking changes can be discovered during development rather than in production.
 
@@ -48,7 +48,7 @@ src
 │           │   ...
 │           │   nodes.py
 │           │   ...
-│   
+│
 └───tests
 │   └───pipelines
 │       └───dataprocessing

--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -19,7 +19,7 @@ from kedro.framework.project import settings
 
 conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
-conf_catalog = conf_loader.get("catalog*", "catalog*/**")
+conf_catalog = conf_loader["catalog"]
 ```
 
 This recursively scans for configuration files firstly in the `conf/base/` (`base` being the default environment) and then in the `conf/local/` (`local` being the designated overriding environment) directory according to the following rules:
@@ -180,7 +180,7 @@ from kedro.framework.project import settings
 
 conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
-parameters = conf_loader.get("parameters*", "parameters*/**")
+parameters = conf_loader["parameters"]
 ```
 
 This will load configuration files from any subdirectories in `conf` that have a filename starting with `parameters`, or are located inside a folder with name starting with `parameters`.
@@ -189,7 +189,7 @@ This will load configuration files from any subdirectories in `conf` that have a
 Since `local` is set as the environment, the configuration path `conf/local` takes precedence in the example above. Hence any overlapping top-level keys from `conf/base` will be overwritten by the ones from `conf/local`.
 ```
 
-Calling `conf_loader.get()` in the example above will throw a `MissingConfigException` error if no configuration files match the given patterns in any of the specified paths. If this is a valid workflow for your application, you can handle it as follows:
+Calling `conf_loader[]` in the example above will throw a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
 
 ```python
 from kedro.config import ConfigLoader, MissingConfigException
@@ -199,7 +199,7 @@ conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
 
 try:
-    parameters = conf_loader.get("parameters*", "parameters*/**", "**/parameters*")
+    parameters = conf_loader["parameters"]
 except MissingConfigException:
     parameters = {}
 ```
@@ -315,7 +315,7 @@ from kedro.framework.project import settings
 
 conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
-credentials = conf_loader.get("credentials*", "credentials*/**")
+credentials = conf_loader["credentials"]
 ```
 
 This will load configuration files from `conf/base` and `conf/local` whose filenames start with `credentials`, or that are located inside a folder with a name that starts with `credentials`.
@@ -324,7 +324,7 @@ This will load configuration files from `conf/base` and `conf/local` whose filen
 Since `local` is set as the environment, the configuration path `conf/local` takes precedence in the example above. Hence, any overlapping top-level keys from `conf/base` will be overwritten by the ones from `conf/local`.
 ```
 
-Calling `conf_loader.get()` in the example above throws a `MissingConfigException` error if no configuration files match the given patterns in any of the specified paths. If this is a valid workflow for your application, you can handle it as follows:
+Calling `conf_loader[]` in the example above throws a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
 
 ```python
 from kedro.config import ConfigLoader, MissingConfigException
@@ -334,7 +334,7 @@ conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
 
 try:
-    credentials = conf_loader.get("credentials*", "credentials*/**")
+    credentials = conf_loader["credentials*"]
 except MissingConfigException:
     credentials = {}
 ```

--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -189,7 +189,7 @@ This will load configuration files from any subdirectories in `conf` that have a
 Since `local` is set as the environment, the configuration path `conf/local` takes precedence in the example above. Hence any overlapping top-level keys from `conf/base` will be overwritten by the ones from `conf/local`.
 ```
 
-Calling `conf_loader[]` in the example above will throw a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
+Calling `conf_loader[key]` in the example above will throw a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
 
 ```python
 from kedro.config import ConfigLoader, MissingConfigException
@@ -324,7 +324,7 @@ This will load configuration files from `conf/base` and `conf/local` whose filen
 Since `local` is set as the environment, the configuration path `conf/local` takes precedence in the example above. Hence, any overlapping top-level keys from `conf/base` will be overwritten by the ones from `conf/local`.
 ```
 
-Calling `conf_loader[]` in the example above throws a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
+Calling `conf_loader[key]` in the example above throws a `MissingConfigException` error if no configuration files match the given key. If this is a valid workflow for your application, you can handle it as follows:
 
 ```python
 from kedro.config import ConfigLoader, MissingConfigException

--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -334,7 +334,7 @@ conf_path = str(project_path / settings.CONF_SOURCE)
 conf_loader = ConfigLoader(conf_source=conf_path, env="local")
 
 try:
-    credentials = conf_loader["credentials*"]
+    credentials = conf_loader["credentials"]
 except MissingConfigException:
     credentials = {}
 ```

--- a/kedro/config/abstract_config.py
+++ b/kedro/config/abstract_config.py
@@ -1,11 +1,11 @@
 """This module provides ``kedro.abstract_config`` with the baseline
 class model for a `ConfigLoader` implementation.
 """
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from typing import Any, Dict
 
 
-class AbstractConfigLoader(ABC):
+class AbstractConfigLoader(dict):
     """``AbstractConfigLoader`` is the abstract base class
         for all `ConfigLoader` implementations.
     All user-defined `ConfigLoader` implementations should inherit
@@ -19,12 +19,13 @@ class AbstractConfigLoader(ABC):
         runtime_params: Dict[str, Any] = None,
         **kwargs  # pylint: disable=unused-argument
     ):
+        super().__init__()
         self.conf_source = conf_source
         self.env = env
         self.runtime_params = runtime_params
 
     @abstractmethod  # pragma: no cover
-    def get(self) -> Dict[str, Any]:
+    def get(self) -> Dict[str, Any]:  # type: ignore
         """Required method to get all configurations."""
         pass
 

--- a/kedro/config/abstract_config.py
+++ b/kedro/config/abstract_config.py
@@ -1,11 +1,11 @@
 """This module provides ``kedro.abstract_config`` with the baseline
 class model for a `ConfigLoader` implementation.
 """
-from abc import abstractmethod
+from collections import UserDict
 from typing import Any, Dict
 
 
-class AbstractConfigLoader(dict):
+class AbstractConfigLoader(UserDict):
     """``AbstractConfigLoader`` is the abstract base class
         for all `ConfigLoader` implementations.
     All user-defined `ConfigLoader` implementations should inherit
@@ -23,11 +23,6 @@ class AbstractConfigLoader(dict):
         self.conf_source = conf_source
         self.env = env
         self.runtime_params = runtime_params
-
-    @abstractmethod  # pragma: no cover
-    def get(self) -> Dict[str, Any]:  # type: ignore
-        """Required method to get all configurations."""
-        pass
 
 
 class BadConfigException(Exception):

--- a/kedro/config/config.py
+++ b/kedro/config/config.py
@@ -56,11 +56,11 @@ class ConfigLoader(AbstractConfigLoader):
         >>> conf_path = str(project_path / settings.CONF_SOURCE)
         >>> conf_loader = ConfigLoader(conf_source=conf_path, env="local")
         >>>
-        >>> conf_logging = conf_loader['logging']
+        >>> conf_logging = conf_loader["logging"]
         >>> logging.config.dictConfig(conf_logging)  # set logging conf
         >>>
-        >>> conf_catalog = conf_loader['catalog']
-        >>> conf_params = conf_loader['parameters']
+        >>> conf_catalog = conf_loader["catalog"]
+        >>> conf_params = conf_loader["parameters"]
 
     """
 

--- a/kedro/config/config.py
+++ b/kedro/config/config.py
@@ -2,7 +2,7 @@
 or more configuration files from specified paths.
 """
 from pathlib import Path
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, List
 
 from kedro.config import AbstractConfigLoader
 from kedro.config.common import _get_config_from_patterns, _remove_duplicates
@@ -69,6 +69,7 @@ class ConfigLoader(AbstractConfigLoader):
         conf_source: str,
         env: str = None,
         runtime_params: Dict[str, Any] = None,
+        config_patterns: Dict[str, List[str]] = None,
         *,
         base_env: str = "base",
         default_run_env: str = "local",
@@ -89,13 +90,13 @@ class ConfigLoader(AbstractConfigLoader):
         self.base_env = base_env
         self.default_run_env = default_run_env
 
-        core_config_patterns = {
+        self.config_patterns = {
             "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
             "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
             "credentials": ["credentials*", "credentials*/**", "**/credentials*"],
             "logging": ["logging*", "logging*/**", "**/logging*"],
         }
-        self.config_patterns = core_config_patterns
+        self.config_patterns.update(config_patterns or {})
 
         super().__init__(
             conf_source=conf_source,

--- a/kedro/config/templated_config.py
+++ b/kedro/config/templated_config.py
@@ -114,6 +114,14 @@ class TemplatedConfigLoader(AbstractConfigLoader):
                 obtained from the globals_pattern. In case of duplicate keys, the
                 ``globals_dict`` keys take precedence.
         """
+        core_config_patterns = {
+            "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
+            "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
+            "credentials": ["credentials*", "credentials*/**", "**/credentials*"],
+            "logging": ["logging*", "logging*/**", "**/logging*"],
+        }
+        self.config_patterns = core_config_patterns
+
         super().__init__(
             conf_source=conf_source, env=env, runtime_params=runtime_params
         )
@@ -132,12 +140,15 @@ class TemplatedConfigLoader(AbstractConfigLoader):
         globals_dict = deepcopy(globals_dict) or {}
         self._config_mapping = {**self._config_mapping, **globals_dict}
 
+    def __getitem__(self, key):
+        return self.get(*self.config_patterns[key])
+
     @property
     def conf_paths(self):
         """Property method to return deduplicated configuration paths."""
         return _remove_duplicates(self._build_conf_paths())
 
-    def get(self, *patterns: str) -> Dict[str, Any]:
+    def get(self, *patterns: str) -> Dict[str, Any]:  # type: ignore
         """Tries to resolve the template variables in the config dictionary
         provided by the ``ConfigLoader`` (super class) ``get`` method using the
         dictionary of replacement values obtained in the ``__init__`` method.

--- a/kedro/config/templated_config.py
+++ b/kedro/config/templated_config.py
@@ -5,7 +5,7 @@ with the values from the passed dictionary.
 import re
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, List, Optional
 
 import jmespath
 
@@ -92,6 +92,7 @@ class TemplatedConfigLoader(AbstractConfigLoader):
         conf_source: str,
         env: str = None,
         runtime_params: Dict[str, Any] = None,
+        config_patterns: Dict[str, List[str]] = None,
         *,
         base_env: str = "base",
         default_run_env: str = "local",
@@ -114,13 +115,13 @@ class TemplatedConfigLoader(AbstractConfigLoader):
                 obtained from the globals_pattern. In case of duplicate keys, the
                 ``globals_dict`` keys take precedence.
         """
-        core_config_patterns = {
+        self.config_patterns = {
             "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
             "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
             "credentials": ["credentials*", "credentials*/**", "**/credentials*"],
             "logging": ["logging*", "logging*/**", "**/logging*"],
         }
-        self.config_patterns = core_config_patterns
+        self.config_patterns.update(config_patterns or {})
 
         super().__init__(
             conf_source=conf_source, env=env, runtime_params=runtime_params

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -240,10 +240,7 @@ class KedroContext:
                 extra parameters passed at initialization.
         """
         try:
-            # '**/parameters*' reads modular pipeline configs
-            params = self.config_loader.get(
-                "parameters*", "parameters*/**", "**/parameters*"
-            )
+            params = self.config_loader["parameters"]
         except MissingConfigException as exc:
             warn(f"Parameters not found in your Kedro project config.\n{str(exc)}")
             params = {}
@@ -275,7 +272,7 @@ class KedroContext:
 
         """
         # '**/catalog*' reads modular pipeline configs
-        conf_catalog = self.config_loader.get("catalog*", "catalog*/**", "**/catalog*")
+        conf_catalog = self.config_loader["catalog"]
         # turn relative paths in conf_catalog into absolute paths
         # before initializing the catalog
         conf_catalog = _convert_paths_to_absolute_posix(
@@ -337,9 +334,7 @@ class KedroContext:
     def _get_config_credentials(self) -> Dict[str, Any]:
         """Getter for credentials specified in credentials directory."""
         try:
-            conf_creds = self.config_loader.get(
-                "credentials*", "credentials*/**", "**/credentials*"
-            )
+            conf_creds = self.config_loader["credentials"]
         except MissingConfigException as exc:
             warn(f"Credentials not found in your Kedro project config.\n{str(exc)}")
             conf_creds = {}

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -182,9 +182,7 @@ class KedroSession:
         return session
 
     def _get_logging_config(self) -> Dict[str, Any]:
-        logging_config = self._get_config_loader().get(
-            "logging*", "logging*/**", "**/logging*"
-        )
+        logging_config = self._get_config_loader()["logging"]
         # turn relative paths in logging config into absolute path
         # before initialising loggers
         logging_config = _convert_paths_to_absolute_posix(

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -93,6 +93,19 @@ use_proj_catalog = pytest.mark.usefixtures("proj_catalog")
 
 class TestConfigLoader:
     @use_config_dir
+    def test_load_core_config_dict_get(self, tmp_path):
+        """Make sure core config can be fetched with a dict [] access."""
+        conf = ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV)
+        params = conf["parameters"]
+        catalog = conf["catalog"]
+
+        assert params["param1"] == 1
+        assert catalog["trains"]["type"] == "MemoryDataSet"
+        assert catalog["cars"]["type"] == "pandas.CSVDataSet"
+        assert catalog["boats"]["type"] == "MemoryDataSet"
+        assert not catalog["cars"]["save_args"]["index"]
+
+    @use_config_dir
     def test_load_local_config(self, tmp_path):
         """Make sure that configs from `local/` override the ones
         from `base/`"""
@@ -238,6 +251,27 @@ class TestConfigLoader:
         )
         with pytest.raises(MissingConfigException, match=pattern):
             ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV).get("non-existent-pattern")
+
+    @use_config_dir
+    def test_key_not_found_dict_get(self, tmp_path):
+        """Check the error if no config files satisfy a given pattern"""
+        with pytest.raises(KeyError):
+            # pylint: disable=expression-not-assigned
+            ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV)["non-existent-pattern"]
+
+    @use_config_dir
+    def test_no_files_found_dict_get(self, tmp_path):
+        """Check the error if no config files satisfy a given pattern"""
+        pattern = (
+            r"No files found in "
+            r"\[\'.*base\', "
+            r"\'.*local\'\] "
+            r"matching the glob pattern\(s\): "
+            r"\[\'credentials\*\', \'credentials\*/\**\', \'\**/credentials\*\'\]"
+        )
+        with pytest.raises(MissingConfigException, match=pattern):
+            # pylint: disable=expression-not-assigned
+            ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV)["credentials"]
 
     def test_duplicate_paths(self, tmp_path, caplog):
         """Check that trying to load the same environment config multiple times logs a

--- a/tests/config/test_templated_config.py
+++ b/tests/config/test_templated_config.py
@@ -208,6 +208,15 @@ def proj_catalog_param_with_default(tmp_path, param_config_with_default):
 
 class TestTemplatedConfigLoader:
     @pytest.mark.usefixtures("proj_catalog_param")
+    def test_get_catalog_config_with_dict_get(self, tmp_path, template_config):
+        config_loader = TemplatedConfigLoader(
+            str(tmp_path), globals_dict=template_config
+        )
+        config_loader.default_run_env = ""
+        catalog = config_loader["catalog"]
+        assert catalog["boats"]["type"] == "SparkDataSet"
+    
+    @pytest.mark.usefixtures("proj_catalog_param")
     def test_catalog_parameterized_w_dict(self, tmp_path, template_config):
         """Test parameterized config with input from dictionary with values"""
         config_loader = TemplatedConfigLoader(

--- a/tests/config/test_templated_config.py
+++ b/tests/config/test_templated_config.py
@@ -215,7 +215,7 @@ class TestTemplatedConfigLoader:
         config_loader.default_run_env = ""
         catalog = config_loader["catalog"]
         assert catalog["boats"]["type"] == "SparkDataSet"
-    
+
     @pytest.mark.usefixtures("proj_catalog_param")
     def test_catalog_parameterized_w_dict(self, tmp_path, template_config):
         """Test parameterized config with input from dictionary with values"""


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/issues/1863

## Development notes

- Changed `AbstractConfigLoader` to inherit from `UserDict` 
- Moved regex patterns for core config locations from `KedroContext` to `ConfigLoader` and `TemplatedConfigLoader`
- Core config patterns are stored in a dictionary so they can be accessed with dict syntax
- `config_patterns` is added as an argument to the `ConfigLoader` and `TemplatedConfigLoader`

## To discuss
Is allowing users to access config in this way something we want for the future `0.19.0` version as well? How does this allow for using non file based config, e.g stored in a database?

**Discussion summary**

- This change opens up to ability for users to change the config file patterns.
- The pattern paths are added to the `ConfigLoader` and `TemplatedConfigLoader` and not to the `AbstractConfigLoader` to not make add assumptions about file based config in the base abstract class.
- This also means that (in the future) users will be able to point to a database. The implementation of reading from databases would not happen on the Kedro side: it's not possible for us to build functionality for all possible databases that users have. However, the improvements to `ConfigLoader`will enable users to implement their own DB access so they can load their config. 
- In `0.19.0` we will remove the custom `.get()` method and rely on `OmegaConf` for loading the actual config.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1870"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

