### PR TITLE
Update Error message for `VersionNotFoundError` to handle Permission related issues better

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Updated error message for `VersionNotFoundError` to handle insufficient permission issues for cloud storage.
 
 ## Upcoming deprecations for Kedro 0.19.0
 

--- a/docs/source/deployment/databricks.md
+++ b/docs/source/deployment/databricks.md
@@ -159,7 +159,7 @@ Then press `Confirm` button. Your cluster will be restarted to apply the changes
 
 Congratulations, you are now ready to run your Kedro project from the Databricks!
 
-[Create your Databricks notebook](https://docs.databricks.com/notebooks/notebooks-manage.html#create-a-notebook) and remember to [attach it to the cluster](https://docs.databricks.com/notebooks/notebooks-manage.html#attach-a-notebook-to-a-cluster) you have just configured.
+[Create your Databricks notebook](https://docs.databricks.com/notebooks/notebooks-manage.html#create-a-notebook) and remember to [attach it to the cluster](https://docs.databricks.com/notebooks/notebooks-manage.html#attach) you have just configured.
 
 In your newly-created notebook, put each of the below code snippets into a separate cell, then [run all cells](https://docs.databricks.com/notebooks/notebooks-use.html#run-notebooks):
 

--- a/docs/source/deployment/databricks.md
+++ b/docs/source/deployment/databricks.md
@@ -159,7 +159,7 @@ Then press `Confirm` button. Your cluster will be restarted to apply the changes
 
 Congratulations, you are now ready to run your Kedro project from the Databricks!
 
-[Create your Databricks notebook](https://docs.databricks.com/notebooks/notebooks-manage.html#create-a-notebook) and remember to [attach it to the cluster](https://docs.databricks.com/notebooks/notebooks-manage.html#attach) you have just configured.
+[Create your Databricks notebook](https://docs.databricks.com/notebooks/notebooks-manage.html#create-a-notebook) and remember to [attach it to the cluster](https://docs.databricks.com/notebooks/notebooks-manage.html#attach-a-notebook-to-a-cluster) you have just configured.
 
 In your newly-created notebook, put each of the below code snippets into a separate cell, then [run all cells](https://docs.databricks.com/notebooks/notebooks-use.html#run-notebooks):
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -541,7 +541,8 @@ class AbstractVersionedDataSet(AbstractDataSet[_DI, _DO], abc.ABC):
         protocol = getattr(self, "_protocol", None)
         if not most_recent:
             if protocol in CLOUD_PROTOCOLS:
-                message = f"Did not find any versions for {self}. This could be due to insufficient permission."
+                message = f"Did not find any versions for {self} This could be " \
+                          f"due to insufficient permission."
             else:
                 message = f"Did not find any versions for {self}"
             raise VersionNotFoundError(message)

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -542,7 +542,7 @@ class AbstractVersionedDataSet(AbstractDataSet[_DI, _DO], abc.ABC):
         if not most_recent:
             if protocol in CLOUD_PROTOCOLS:
                 message = (
-                    f"Did not find any versions for {self} This could be "
+                    f"Did not find any versions for {self}. This could be "
                     f"due to insufficient permission."
                 )
             else:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -541,8 +541,10 @@ class AbstractVersionedDataSet(AbstractDataSet[_DI, _DO], abc.ABC):
         protocol = getattr(self, "_protocol", None)
         if not most_recent:
             if protocol in CLOUD_PROTOCOLS:
-                message = f"Did not find any versions for {self} This could be " \
-                          f"due to insufficient permission."
+                message = (
+                    f"Did not find any versions for {self} This could be "
+                    f"due to insufficient permission."
+                )
             else:
                 message = f"Did not find any versions for {self}"
             raise VersionNotFoundError(message)

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -538,9 +538,13 @@ class AbstractVersionedDataSet(AbstractDataSet[_DI, _DO], abc.ABC):
         most_recent = next(
             (path for path in version_paths if self._exists_function(path)), None
         )
-
+        protocol = getattr(self, "_protocol", None)
         if not most_recent:
-            raise VersionNotFoundError(f"Did not find any versions for {self}")
+            if protocol in CLOUD_PROTOCOLS:
+                message = f"Did not find any versions for {self}. This could be due to insufficient permission."
+            else:
+                message = f"Did not find any versions for {self}"
+            raise VersionNotFoundError(message)
 
         return PurePath(most_recent).parent.name
 

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -653,13 +653,13 @@ class TestDataCatalogVersioned:
         assert "ds3__csv" in catalog.datasets.__dict__
         assert "jalapeño" in catalog.datasets.__dict__
 
-    def test_no_versions_cloud_protocol(self):
+    def test_no_version_cloud(self):
         """Check the error if no versions are available for load from cloud storage"""
         version = Version(load=None, save=None)
-        versioned_dataset = CSVDataSet("s3://bucket/file.csv", version=version)
+        ds = CSVDataSet("s3://bucket/file.csv", version=version)
         pattern = re.escape(
-            f"Did not find any versions for {versioned_dataset} "
+            f"Did not find any versions for {ds} "
             f"This could be due to insufficient permission."
         )
         with pytest.raises(DataSetError, match=pattern):
-            versioned_dataset.load()
+            ds.load()

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -19,7 +19,7 @@ from kedro.io import (
     LambdaDataSet,
     MemoryDataSet,
 )
-from kedro.io.core import VERSION_FORMAT, generate_timestamp, Version
+from kedro.io.core import VERSION_FORMAT, Version, generate_timestamp
 
 
 @pytest.fixture
@@ -656,10 +656,10 @@ class TestDataCatalogVersioned:
     def test_no_version_cloud(self):
         """Check the error if no versions are available for load from cloud storage"""
         version = Version(load=None, save=None)
-        ds = CSVDataSet(
-            "s3://bucket/file.csv",
-            version=version)
-        pattern = re.escape(f"Did not find any versions for {ds} "
-                            f"This could be due to insufficient permission.")
+        ds = CSVDataSet("s3://bucket/file.csv", version=version)
+        pattern = re.escape(
+            f"Did not find any versions for {ds} "
+            f"This could be due to insufficient permission."
+        )
         with pytest.raises(DataSetError, match=pattern):
             ds.load()

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -653,13 +653,13 @@ class TestDataCatalogVersioned:
         assert "ds3__csv" in catalog.datasets.__dict__
         assert "jalapeño" in catalog.datasets.__dict__
 
-    def test_no_version_cloud(self):
+    def test_no_versions_with_cloud_protocol(self):
         """Check the error if no versions are available for load from cloud storage"""
         version = Version(load=None, save=None)
-        ds = CSVDataSet("s3://bucket/file.csv", version=version)
+        versioned_dataset = CSVDataSet("s3://bucket/file.csv", version=version)
         pattern = re.escape(
-            f"Did not find any versions for {ds} "
+            f"Did not find any versions for {versioned_dataset}. "
             f"This could be due to insufficient permission."
         )
         with pytest.raises(DataSetError, match=pattern):
-            ds.load()
+            versioned_dataset.load()

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -656,12 +656,9 @@ class TestDataCatalogVersioned:
     def test_no_version_cloud(self):
         """Check the error if no versions are available for load from cloud storage"""
         version = Version(load=None, save=None)
-        dummy_credentials = \
-            {'client_kwargs': {'aws_access_key_id': 'FAKE', 'aws_secret_access_key': 'FAKE'}}
         ds = CSVDataSet(
             "s3://bucket/file.csv",
-            version=version,
-            credentials=dummy_credentials)
+            version=version)
         pattern = re.escape(f"Did not find any versions for {ds} "
                             f"This could be due to insufficient permission.")
         with pytest.raises(DataSetError, match=pattern):

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -19,7 +19,7 @@ from kedro.io import (
     LambdaDataSet,
     MemoryDataSet,
 )
-from kedro.io.core import VERSION_FORMAT, generate_timestamp
+from kedro.io.core import VERSION_FORMAT, generate_timestamp, Version
 
 
 @pytest.fixture
@@ -652,3 +652,17 @@ class TestDataCatalogVersioned:
         assert "ds2_spark" in catalog.datasets.__dict__
         assert "ds3__csv" in catalog.datasets.__dict__
         assert "jalapeño" in catalog.datasets.__dict__
+
+    def test_no_version_cloud(self):
+        """Check the error if no versions are available for load from cloud storage"""
+        version = Version(load=None, save=None)
+        dummy_credentials = \
+            {'client_kwargs': {'aws_access_key_id': 'FAKE', 'aws_secret_access_key': 'FAKE'}}
+        ds = CSVDataSet(
+            "s3://bucket/file.csv",
+            version=version,
+            credentials=dummy_credentials)
+        pattern = re.escape(f"Did not find any versions for {ds} "
+                            f"This could be due to insufficient permission.")
+        with pytest.raises(DataSetError, match=pattern):
+            ds.load()

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -653,13 +653,13 @@ class TestDataCatalogVersioned:
         assert "ds3__csv" in catalog.datasets.__dict__
         assert "jalapeño" in catalog.datasets.__dict__
 
-    def test_no_version_cloud(self):
+    def test_no_versions_cloud_protocol(self):
         """Check the error if no versions are available for load from cloud storage"""
         version = Version(load=None, save=None)
-        ds = CSVDataSet("s3://bucket/file.csv", version=version)
+        versioned_dataset = CSVDataSet("s3://bucket/file.csv", version=version)
         pattern = re.escape(
-            f"Did not find any versions for {ds} "
+            f"Did not find any versions for {versioned_dataset} "
             f"This could be due to insufficient permission."
         )
         with pytest.raises(DataSetError, match=pattern):
-            ds.load()
+            versioned_dataset.load()


### PR DESCRIPTION
Signed-off-by: Ankita Katiyar [110245118+ankatiyar@users.noreply.github.com](mailto:110245118+ankatiyar@users.noreply.github.com)

## Description
Resolves #1768

## Development notes
Fresh PR to resolve the issue.
Closing https://github.com/kedro-org/kedro/pull/1809 in favour of this solution - `PermissionError` was being handled outside of Kedro in some cases. This PR is a workaround as the error message is insufficient and it's hard to pinpoint the source of error precisely in case of cloud storage.

### Proposed Solution
As a result, this PR modifies the error message for `VersionNotFoundError` to indicate that this error could be happening due to insufficient permission in case of cloud storage i.e. S3, GCS etc.



## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1881"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

