### PR TITLE
Capitalized kedro-viz in Visualise Layers

### DIFF
--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -74,7 +74,7 @@ regressor:
   layer: models
 ```
 
-Run kedro-viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
+Run Kedro-Viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
 
 ![](../meta/images/pipeline_visualisation_with_layers.png)
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
This PR was created to fix the issue #1896 and as a start of Hactoberfest'22 for me.

## Development notes
<!-- What have you changed, and how has this been tested? -->
`kedro-viz` was capitalised to `Kedro-Viz` in Visualize Layers section in the documentation as requested.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1897"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

