### PR TITLE
Capitalise Kedro-Viz in the "Visualize layers" section

### DIFF
--- a/docs/source/tutorial/set_up_experiment_tracking.md
+++ b/docs/source/tutorial/set_up_experiment_tracking.md
@@ -225,7 +225,7 @@ After running the pipeline with `kedro run`, the plot will be saved and you will
 ![](../meta/images/expand-plot-comparison-view.gif)
 
 
-Read more about [creating plots and visualising them in Kedro Viz in the visualise pipeline section.](../tutorial/visualise_pipeline.md#visualise-charts-in-kedro-viz)
+Read more about [creating plots and visualising them in Kedro-Viz in the visualise pipeline section.](../tutorial/visualise_pipeline.md#visualise-charts-in-kedro-viz)
 
 ## View your metrics timeline
 

--- a/docs/source/tutorial/set_up_experiment_tracking.md
+++ b/docs/source/tutorial/set_up_experiment_tracking.md
@@ -225,7 +225,7 @@ After running the pipeline with `kedro run`, the plot will be saved and you will
 ![](../meta/images/expand-plot-comparison-view.gif)
 
 
-Read more about [creating plots and visualising them in Kedro viz in the visualise pipeline section.](../tutorial/visualise_pipeline.md#visualise-charts-in-kedro-viz)
+Read more about [creating plots and visualising them in Kedro Viz in the visualise pipeline section.](../tutorial/visualise_pipeline.md#visualise-charts-in-kedro-viz)
 
 ## View your metrics timeline
 

--- a/docs/source/tutorial/visualise_pipeline.md
+++ b/docs/source/tutorial/visualise_pipeline.md
@@ -74,7 +74,7 @@ regressor:
   layer: models
 ```
 
-Run kedro-viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
+Run Kedro-Viz again with `kedro viz` and observe how your visualisation has changed to indicate the layers:
 
 ![](../meta/images/pipeline_visualisation_with_layers.png)
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
This PR was created as it fixes #1896 and it would be a start of Hactoberfest'22 for me.


## Development notes
<!-- What have you changed, and how has this been tested? -->
`kedro-viz` was capitalised to `Kedro-Viz` in Visualize Layers section in the documentation as requested.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1899"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

