### PR TITLE
Document how users can use linting tools instead of `kedro lint`

### DIFF
--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -67,6 +67,7 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro jupyter convert`](#copy-tagged-cells)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
+  * [`kedro lint`](#lint-your-project)
   * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
   * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
   * [`kedro package`](#deploy-the-project)
@@ -371,6 +372,14 @@ kedro build-docs
 
 The `build-docs` command builds [project documentation](../tutorial/package_a_project.md#add-documentation-to-your-project) using the [Sphinx](https://www.sphinx-doc.org) framework. To further customise your documentation, please refer to `docs/source/conf.py` and the [Sphinx documentation](http://www.sphinx-doc.org/en/master/usage/configuration.html).
 
+
+#### Lint your project
+
+```bash
+kedro lint
+```
+
+Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8) and [`isort`](https://github.com/PyCQA/isort).
 
 
 #### Test your project

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -67,7 +67,6 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro jupyter convert`](#copy-tagged-cells)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
-  * [`kedro lint`](#lint-your-project)
   * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
   * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
   * [`kedro package`](#deploy-the-project)
@@ -372,14 +371,6 @@ kedro build-docs
 
 The `build-docs` command builds [project documentation](../tutorial/package_a_project.md#add-documentation-to-your-project) using the [Sphinx](https://www.sphinx-doc.org) framework. To further customise your documentation, please refer to `docs/source/conf.py` and the [Sphinx documentation](http://www.sphinx-doc.org/en/master/usage/configuration.html).
 
-
-#### Lint your project
-
-```bash
-kedro lint
-```
-
-Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8) and [`isort`](https://github.com/PyCQA/isort).
 
 
 #### Test your project

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -1,0 +1,84 @@
+# Linting
+
+## Introduction
+Lint, or a linter, is a static code analysis tool used to flag programming errors, bugs, stylistic errors and suspicious constructs.
+As a project grows and goes through various stages of development, it becomes important to maintain the code quality. Linting makes
+your code more readable, easy to debug and maintain, and stylistically consistent.
+## Set up linting tools
+There are a variety of linting tools available to use
+with your Kedro projects. This guide shows you how to use [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8), and [`isort`](https://github.com/PyCQA/isort) to lint your Kedro projects.
+- **`black`** is a [PEP 8](https://peps.python.org/pep-0008/) compliant opinionated Python code formatter. Read the full documentation [here](https://black.readthedocs.io/en/stable/).
+- **`flake8`** is a wrapper around [`pep8`](https://pypi.org/project/pep8/), [`pyflakes`](https://pypi.org/project/pyflakes/), and [`mccabe`](https://pypi.org/project/mccabe/). Read the full documentation [here](https://flake8.pycqa.org/en/latest/).
+- **`isort`** is a Python library used to sort imports alphabetically. Read the full documentation [here](https://pycqa.github.io/isort/).
+
+### Install linting tools
+You can install `black`, `flake8`, and `isort` by adding the following lines to your project's `src/requirements.txt` file:
+```text
+black==22.1.0 # Used for formatting code
+flake8>=3.7.9, <5.0 # Used for linting code
+isort~=5.0 # Used for linting code
+```
+To install all the project-specific dependencies, including the linting tools, navigate to the root directory of the project and run:
+```bash
+pip install -r src/requirements.txt
+```
+Alternatively, you can individually install the linting tools using the following shell commands:
+```bash
+pip install black
+pip install flake8
+pip install isort
+```
+
+### Run linting tools
+Use the following commands to run lint checks:
+```bash
+black --check <project_root>
+flake8 <project_root>
+isort --check <project_root>
+```
+You can also have `black` and `isort` automatically format your code by omitting the `--check` flag.
+
+## Automating linting with `pre-commit` hooks
+
+You can also automate linting by using [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks.
+These hooks are run before committing your code to your repositories to automatically point out formatting issues,
+making code reviews easier and less time-consuming.
+
+### Install `pre-commit`
+You can install `pre-commit` along with other dependencies by including it in the `src\requirements.txt` file of your
+Kedro project by adding the following line:
+```text
+pre-commit
+```
+You can also install is using the following command:
+```bash
+pip install pre-commit
+```
+### Add pre-commit configuration file
+Create a file named `.pre-commit-config.yaml`. You can add entries for the hooks you want to run before each `commit`.
+Below is a sample `YAML` file with entries for `black`,`flake8`, and `isort`:
+```yaml
+repos:
+  - repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        name: isort (python)
+
+  - repo: https://github.com/pycqa/flake8
+    rev: ''  # pick a git hash / tag to point to
+    hooks:
+      - id: flake8
+
+  - repo: https://github.com/psf/black
+    rev: 22.8.0
+    hooks:
+      - id: black
+          language_version: python3.9
+```
+### Install git hook scripts
+Run the following command to complete installation:
+```bash
+pre-commit install
+```
+This enables `pre-commit` hooks to run automatically every time you  `git commit`.

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -1,24 +1,36 @@
 # Linting
 
 ## Introduction
-Lint, or a linter, is a static code analysis tool used to flag programming errors, bugs, stylistic errors and suspicious constructs.
-As a project grows and goes through various stages of development, it becomes important to maintain the code quality. Linting makes
-your code more readable, easy to debug and maintain, and stylistically consistent.
+Linting tools are used to improve the quality of your code by checking for errors and making sure it meets a stylistic
+standard before it is run. As a project grows and goes through various stages of development, it becomes important to
+maintain the code quality. Linting makes your code more readable, easy to debug and maintain, and stylistically
+consistent.
+
 ## Set up linting tools
-There are a variety of linting tools available to use
-with your Kedro projects. This guide shows you how to use [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8), and [`isort`](https://github.com/PyCQA/isort) to lint your Kedro projects.
-- **`black`** is a [PEP 8](https://peps.python.org/pep-0008/) compliant opinionated Python code formatter. Read the full documentation [here](https://black.readthedocs.io/en/stable/).
-- **`flake8`** is a wrapper around [`pep8`](https://pypi.org/project/pep8/), [`pyflakes`](https://pypi.org/project/pyflakes/), and [`mccabe`](https://pypi.org/project/mccabe/). Read the full documentation [here](https://flake8.pycqa.org/en/latest/).
-- **`isort`** is a Python library used to sort imports alphabetically. Read the full documentation [here](https://pycqa.github.io/isort/).
+There are a variety of linting tools available to use with your Kedro projects. This guide shows you how to use
+[`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8), and
+[`isort`](https://github.com/PyCQA/isort) to lint your Kedro projects.
+- **`black`** is a [PEP 8](https://peps.python.org/pep-0008/) compliant opinionated Python code formatter. `black` can
+check for styling inconsistencies and reformat your files in place.
+[You can read more in the `black` documentation](https://black.readthedocs.io/en/stable/).
+- **`flake8`** is a wrapper around [`pep8`](https://pypi.org/project/pep8/),
+[`pyflakes`](https://pypi.org/project/pyflakes/), and [`mccabe`](https://pypi.org/project/mccabe/) which can flag
+programming errors and coding style inconsistencies with respect to [PEP 8](https://peps.python.org/pep-0008/),
+and check the cyclomatic complexity of your code base.
+[You can read more in the `flake8` documentation](https://flake8.pycqa.org/en/latest/).
+- **`isort`** is a Python library used to sort imports alphabetically, and automatically separated into sections and by
+type. [You can read more in the `isort` documentation](https://pycqa.github.io/isort/).
 
 ### Install linting tools
-You can install `black`, `flake8`, and `isort` by adding the following lines to your project's `src/requirements.txt` file:
+You can install `black`, `flake8`, and `isort` by adding the following lines to your project's `src/requirements.txt`
+file:
 ```text
-black==22.1.0 # Used for formatting code
-flake8>=3.7.9, <5.0 # Used for linting code
-isort~=5.0 # Used for linting code
+black # Used for formatting code
+flake8 # Used for linting code
+isort # Used for linting code
 ```
-To install all the project-specific dependencies, including the linting tools, navigate to the root directory of the project and run:
+To install all the project-specific dependencies, including the linting tools, navigate to the root directory of the
+project and run:
 ```bash
 pip install -r src/requirements.txt
 ```
@@ -34,9 +46,10 @@ Use the following commands to run lint checks:
 ```bash
 black --check <project_root>
 flake8 <project_root>
-isort --check <project_root>
+isort --profile black --check <project_root>
 ```
-You can also have `black` and `isort` automatically format your code by omitting the `--check` flag.
+You can also have `black` and `isort` automatically format your code by omitting the `--check` flag. Since `isort` and
+`black` both format your imports, adding `--profile black` to the `isort` run helps avoid potential conflicts.
 
 ## Automating linting with `pre-commit` hooks
 
@@ -45,17 +58,18 @@ These hooks are run before committing your code to your repositories to automati
 making code reviews easier and less time-consuming.
 
 ### Install `pre-commit`
-You can install `pre-commit` along with other dependencies by including it in the `src\requirements.txt` file of your
+You can install `pre-commit` along with other dependencies by including it in the `src/requirements.txt` file of your
 Kedro project by adding the following line:
 ```text
 pre-commit
 ```
-You can also install is using the following command:
+You can also install `pre-commit` using the following command:
 ```bash
 pip install pre-commit
 ```
-### Add pre-commit configuration file
-Create a file named `.pre-commit-config.yaml`. You can add entries for the hooks you want to run before each `commit`.
+### Add `pre-commit` configuration file
+Create a file named `.pre-commit-config.yaml` in your Kedro project root directory. You can add entries for the hooks
+you want to run before each `commit`.
 Below is a sample `YAML` file with entries for `black`,`flake8`, and `isort`:
 ```yaml
 repos:
@@ -64,6 +78,7 @@ repos:
     hooks:
       - id: isort
         name: isort (python)
+        args: ["--profile", "black"]
 
   - repo: https://github.com/pycqa/flake8
     rev: ''  # pick a git hash / tag to point to
@@ -74,11 +89,11 @@ repos:
     rev: 22.8.0
     hooks:
       - id: black
-          language_version: python3.9
+        language_version: python3.9
 ```
 ### Install git hook scripts
 Run the following command to complete installation:
 ```bash
 pre-commit install
 ```
-This enables `pre-commit` hooks to run automatically every time you  `git commit`.
+This enables `pre-commit` hooks to run automatically every time you execute `git commit`.

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -18,7 +18,7 @@ check for styling inconsistencies and reformat your files in place.
 programming errors and coding style inconsistencies with respect to [PEP 8](https://peps.python.org/pep-0008/),
 and check the cyclomatic complexity of your code base.
 [You can read more in the `flake8` documentation](https://flake8.pycqa.org/en/latest/).
-- **`isort`** is a Python library used to sort imports alphabetically, and automatically separated into sections and by
+- **`isort`** is a Python library used to sort imports alphabetically and automatically separate them into sections by
 type. [You can read more in the `isort` documentation](https://pycqa.github.io/isort/).
 
 ### Install linting tools
@@ -53,7 +53,7 @@ You can also have `black` and `isort` automatically format your code by omitting
 
 ## Automating linting with `pre-commit` hooks
 
-You can also automate linting by using [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks.
+You can automate linting by using [`pre-commit`](https://github.com/pre-commit/pre-commit) hooks.
 These hooks are run before committing your code to your repositories to automatically point out formatting issues,
 making code reviews easier and less time-consuming.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -146,6 +146,7 @@ Welcome to Kedro's documentation!
    development/commands_reference
    development/debugging
    development/automated_testing
+   development/linting
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
Signed-off-by: Ankita Katiyar <ankitakatiyar2401@gmail.com>

## Description
Resolves #1620 

## Development notes
Added a page to the "Development" section documenting how users can use linting tools, specifically `black`, `flake8` and `isort` to lint their code as a replacement for `kedro lint` command. Also, added an entry for the page under `index.rst` and removed mentions of `kedro lint` from [Kedro's command line interface page](https://kedro.readthedocs.io/en/stable/development/commands_reference.html).

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1904"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

