### PR TITLE
Add _SINGLE_PROCESS property to CachedDataSet

### DIFF
--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -27,6 +27,12 @@ class CachedDataSet(AbstractDataSet):
     class as shown above.
     """
 
+    # this dataset cannot be used with ``ParallelRunner``,
+    # therefore it has the attribute ``_SINGLE_PROCESS = True``
+    # for parallelism within a Spark pipeline please consider
+    # ``ThreadRunner`` instead
+    _SINGLE_PROCESS = True
+
     def __init__(
         self,
         dataset: Union[AbstractDataSet, Dict],

--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -29,8 +29,7 @@ class CachedDataSet(AbstractDataSet):
 
     # this dataset cannot be used with ``ParallelRunner``,
     # therefore it has the attribute ``_SINGLE_PROCESS = True``
-    # for parallelism within a Spark pipeline please consider
-    # ``ThreadRunner`` instead
+    # for parallelism please consider ``ThreadRunner`` instead
     _SINGLE_PROCESS = True
 
     def __init__(


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/1888

## Development notes
The CachedDataSet cannot be used with the ParellelRunner this PR adds the `_SINGLE_PROCESS` property just like in [DeltaTableDataSet](https://github.com/kedro-org/kedro/blob/main/kedro/extras/datasets/spark/deltatable_dataset.py#L60-L64)

Before, this PR trying to use CachedDataSet and ParallelRunner together was failing.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1905"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

