### PR TITLE
Add deprecation warnings in the docs for commands being removed in 0.19.0

### DIFF
--- a/docs/source/development/automated_testing.md
+++ b/docs/source/development/automated_testing.md
@@ -9,7 +9,7 @@ Software testing is the process of checking that the code you have written fulfi
 
 As a project grows larger, new code will increasingly rely on existing code. As these interdependencies grow, making changes in one part of the code base can unexpectedly break the intended functionality in another part.
 
-The major disadvantage of manual testing is that it is time-consuming. Manual tests are usually run once, directly after new functionality has been added. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes. 
+The major disadvantage of manual testing is that it is time-consuming. Manual tests are usually run once, directly after new functionality has been added. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes.
 
 The solution to this problem is automated testing. Automated testing allows many tests across the whole code base to be run in seconds, every time a new feature is added or an old one is changed. In this way, breaking changes can be discovered during development rather than in production.
 
@@ -48,7 +48,7 @@ src
 │           │   ...
 │           │   nodes.py
 │           │   ...
-│   
+│
 └───tests
 │   └───pipelines
 │       └───dataprocessing

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -275,8 +275,9 @@ def run(
 
 #### Build the project's dependency tree
 
-{_This command will be deprecated from Kedro version 0.19.0._}
-
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 ```bash
 kedro build-reqs
 ```
@@ -368,7 +369,9 @@ The above command will take the bundled `.tar.gz` file and do the following:
 
 #### Build the project documentation
 
-{_This command will be deprecated from Kedro version 0.19.0._}
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 
 ```bash
 kedro build-docs
@@ -379,7 +382,9 @@ The `build-docs` command builds [project documentation](../tutorial/package_a_pr
 
 #### Lint your project
 
-{_This command will be deprecated from Kedro version 0.19.0._}
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 
 ```bash
 kedro lint
@@ -390,7 +395,9 @@ Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](
 
 #### Test your project
 
-{_This command will be deprecated from Kedro version 0.19.0._}
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 
 The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
 
@@ -510,7 +517,9 @@ To reload these variables (e.g. if you updated `catalog.yml`) use the `%reload_k
 
 ##### Copy tagged cells
 
-{_This command will be deprecated from Kedro version 0.19.0._}
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 
 To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
 
@@ -520,7 +529,9 @@ kedro jupyter convert --all
 
 ##### Strip output cells
 
-{_This command will be deprecated from Kedro version 0.19.0._}
+```{note}
+_This command will be deprecated from Kedro version 0.19.0._
+```
 
 Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -275,15 +275,15 @@ def run(
 
 #### Build the project's dependency tree
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ```bash
 kedro build-reqs
 ```
 
 This command runs [`pip-compile`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) on the project's `src/requirements.txt` file and will create `src/requirements.lock` with the compiled requirements.
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 `kedro build-reqs` has two optional arguments to specify which file to compile the requirements from and where to save the compiled requirements to. These arguments are `--input-file` and `--output-file` respectively.
 
@@ -370,37 +370,37 @@ The above command will take the bundled `.tar.gz` file and do the following:
 
 #### Build the project documentation
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ```bash
 kedro build-docs
 ```
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 The `build-docs` command builds [project documentation](../tutorial/package_a_project.md#add-documentation-to-your-project) using the [Sphinx](https://www.sphinx-doc.org) framework. To further customise your documentation, please refer to `docs/source/conf.py` and the [Sphinx documentation](http://www.sphinx-doc.org/en/master/usage/configuration.html).
 
 
 #### Lint your project
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ```bash
 kedro lint
 ```
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8) and [`isort`](https://github.com/PyCQA/isort).
 
 
 #### Test your project
 
+The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
+
 ___
 _This command will be deprecated from Kedro version 0.19.0._
 ___
-
-The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
 
 ```bash
 kedro test
@@ -518,11 +518,11 @@ To reload these variables (e.g. if you updated `catalog.yml`) use the `%reload_k
 
 ##### Copy tagged cells
 
+To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
+
 ___
 _This command will be deprecated from Kedro version 0.19.0._
 ___
-
-To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
 
 ```bash
 kedro jupyter convert --all
@@ -530,11 +530,11 @@ kedro jupyter convert --all
 
 ##### Strip output cells
 
+Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
+
 ___
 _This command will be deprecated from Kedro version 0.19.0._
 ___
-
-Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
 
 ```bash
 kedro activate-nbstripout

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -279,11 +279,11 @@ def run(
 kedro build-reqs
 ```
 
-This command runs [`pip-compile`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) on the project's `src/requirements.txt` file and will create `src/requirements.lock` with the compiled requirements.
-
 ___
 _This command will be deprecated from Kedro version 0.19.0._
 ___
+
+This command runs [`pip-compile`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) on the project's `src/requirements.txt` file and will create `src/requirements.lock` with the compiled requirements.
 
 `kedro build-reqs` has two optional arguments to specify which file to compile the requirements from and where to save the compiled requirements to. These arguments are `--input-file` and `--output-file` respectively.
 
@@ -398,13 +398,13 @@ Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](
 
 The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ```bash
 kedro test
 ```
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 ### Project development
 
@@ -520,24 +520,25 @@ To reload these variables (e.g. if you updated `catalog.yml`) use the `%reload_k
 
 To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ```bash
 kedro jupyter convert --all
 ```
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 ##### Strip output cells
 
 Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
 
+```bash
+kedro activate-nbstripout
+```
+
 ___
 _This command will be deprecated from Kedro version 0.19.0._
 ___
 
-```bash
-kedro activate-nbstripout
-```
 
 This command adds a `git hook` which clears all notebook output cells before committing anything to `git`. It needs to run only once per local repository.

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -58,16 +58,16 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro new`](#create-a-new-kedro-project)
 
 * Project-specific Kedro commands
-  * [`kedro activate-nbstripout`](#strip-output-cells)
-  * [`kedro build-docs`](#build-the-project-documentation)
-  * [`kedro build-reqs`](#build-the-projects-dependency-tree)
+  * [`kedro activate-nbstripout`](#strip-output-cells)(deprecated from version 0.19.0)
+  * [`kedro build-docs`](#build-the-project-documentation) (deprecated from version 0.19.0)
+  * [`kedro build-reqs`](#build-the-projects-dependency-tree) (deprecated from version 0.19.0)
   * [`kedro catalog list`](#list-datasets-per-pipeline-per-type)
   * [`kedro catalog create`](#create-a-data-catalog-yaml-configuration-file)
   * [`kedro ipython`](#notebooks)
-  * [`kedro jupyter convert`](#copy-tagged-cells)
+  * [`kedro jupyter convert`](#copy-tagged-cells) (deprecated from version 0.19.0)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
-  * [`kedro lint`](#lint-your-project)
+  * [`kedro lint`](#lint-your-project) (deprecated from version 0.19.0)
   * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
   * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
   * [`kedro package`](#deploy-the-project)
@@ -76,7 +76,7 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro registry describe <pipeline_name>`](#describe-a-registered-pipeline)
   * [`kedro registry list`](#list-all-registered-pipelines-in-your-project)
   * [`kedro run`](#run-the-project)
-  * [`kedro test`](#test-your-project)
+  * [`kedro test`](#test-your-project) (deprecated from version 0.19.0)
 
 ## Global Kedro commands
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -58,16 +58,16 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro new`](#create-a-new-kedro-project)
 
 * Project-specific Kedro commands
-  * [`kedro activate-nbstripout`](#strip-output-cells)
-  * [`kedro build-docs`](#build-the-project-documentation)
-  * [`kedro build-reqs`](#build-the-projects-dependency-tree)
+  * [`kedro activate-nbstripout (deprecated from version 0.19.0)`](#strip-output-cells)
+  * [`kedro build-docs (deprecated from version 0.19.0)`](#build-the-project-documentation)
+  * [`kedro build-reqs (deprecated from version 0.19.0)`](#build-the-projects-dependency-tree)
   * [`kedro catalog list`](#list-datasets-per-pipeline-per-type)
   * [`kedro catalog create`](#create-a-data-catalog-yaml-configuration-file)
   * [`kedro ipython`](#notebooks)
-  * [`kedro jupyter convert`](#copy-tagged-cells)
+  * [`kedro jupyter convert (deprecated from version 0.19.0)`](#copy-tagged-cells)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
-  * [`kedro lint`](#lint-your-project)
+  * [`kedro lint (deprecated from version 0.19.0)`](#lint-your-project)
   * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
   * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
   * [`kedro package`](#deploy-the-project)
@@ -76,7 +76,7 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro registry describe <pipeline_name>`](#describe-a-registered-pipeline)
   * [`kedro registry list`](#list-all-registered-pipelines-in-your-project)
   * [`kedro run`](#run-the-project)
-  * [`kedro test`](#test-your-project)
+  * [`kedro test (deprecated from version 0.19.0)`](#test-your-project)
 
 ## Global Kedro commands
 
@@ -275,6 +275,10 @@ def run(
 
 #### Build the project's dependency tree
 
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
+
 ```bash
 kedro build-reqs
 ```
@@ -366,6 +370,10 @@ The above command will take the bundled `.tar.gz` file and do the following:
 
 #### Build the project documentation
 
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
+
 ```bash
 kedro build-docs
 ```
@@ -375,6 +383,10 @@ The `build-docs` command builds [project documentation](../tutorial/package_a_pr
 
 #### Lint your project
 
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
+
 ```bash
 kedro lint
 ```
@@ -383,6 +395,10 @@ Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](
 
 
 #### Test your project
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
 
 The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
 
@@ -501,6 +517,11 @@ The [Kedro IPython extension](../tools_integration/ipython.md) will make the fol
 To reload these variables (e.g. if you updated `catalog.yml`) use the `%reload_kedro` line magic, which can also be used to see the error message if any of the variables above are undefined.
 
 ##### Copy tagged cells
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
+
 To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
 
 ```bash
@@ -508,6 +529,11 @@ kedro jupyter convert --all
 ```
 
 ##### Strip output cells
+
+___
+_This command will be deprecated from Kedro version 0.19.0._
+___
+
 Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
 
 ```bash

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -58,16 +58,16 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro new`](#create-a-new-kedro-project)
 
 * Project-specific Kedro commands
-  * [`kedro activate-nbstripout (deprecated from version 0.19.0)`](#strip-output-cells)
-  * [`kedro build-docs (deprecated from version 0.19.0)`](#build-the-project-documentation)
-  * [`kedro build-reqs (deprecated from version 0.19.0)`](#build-the-projects-dependency-tree)
+  * [`kedro activate-nbstripout`](#strip-output-cells)
+  * [`kedro build-docs`](#build-the-project-documentation)
+  * [`kedro build-reqs`](#build-the-projects-dependency-tree)
   * [`kedro catalog list`](#list-datasets-per-pipeline-per-type)
   * [`kedro catalog create`](#create-a-data-catalog-yaml-configuration-file)
   * [`kedro ipython`](#notebooks)
-  * [`kedro jupyter convert (deprecated from version 0.19.0)`](#copy-tagged-cells)
+  * [`kedro jupyter convert`](#copy-tagged-cells)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
-  * [`kedro lint (deprecated from version 0.19.0)`](#lint-your-project)
+  * [`kedro lint`](#lint-your-project)
   * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
   * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
   * [`kedro package`](#deploy-the-project)
@@ -76,7 +76,7 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro registry describe <pipeline_name>`](#describe-a-registered-pipeline)
   * [`kedro registry list`](#list-all-registered-pipelines-in-your-project)
   * [`kedro run`](#run-the-project)
-  * [`kedro test (deprecated from version 0.19.0)`](#test-your-project)
+  * [`kedro test`](#test-your-project)
 
 ## Global Kedro commands
 
@@ -275,13 +275,11 @@ def run(
 
 #### Build the project's dependency tree
 
+{_This command will be deprecated from Kedro version 0.19.0._}
+
 ```bash
 kedro build-reqs
 ```
-
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
 
 This command runs [`pip-compile`](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) on the project's `src/requirements.txt` file and will create `src/requirements.lock` with the compiled requirements.
 
@@ -370,41 +368,35 @@ The above command will take the bundled `.tar.gz` file and do the following:
 
 #### Build the project documentation
 
+{_This command will be deprecated from Kedro version 0.19.0._}
+
 ```bash
 kedro build-docs
 ```
-
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
 
 The `build-docs` command builds [project documentation](../tutorial/package_a_project.md#add-documentation-to-your-project) using the [Sphinx](https://www.sphinx-doc.org) framework. To further customise your documentation, please refer to `docs/source/conf.py` and the [Sphinx documentation](http://www.sphinx-doc.org/en/master/usage/configuration.html).
 
 
 #### Lint your project
 
+{_This command will be deprecated from Kedro version 0.19.0._}
+
 ```bash
 kedro lint
 ```
-
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
 
 Your project is linted with [`black`](https://github.com/psf/black), [`flake8`](https://gitlab.com/pycqa/flake8) and [`isort`](https://github.com/PyCQA/isort).
 
 
 #### Test your project
 
+{_This command will be deprecated from Kedro version 0.19.0._}
+
 The following runs all `pytest` unit tests found in `src/tests`, including coverage (see the file `.coveragerc`):
 
 ```bash
 kedro test
 ```
-
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
 
 ### Project development
 
@@ -518,27 +510,22 @@ To reload these variables (e.g. if you updated `catalog.yml`) use the `%reload_k
 
 ##### Copy tagged cells
 
+{_This command will be deprecated from Kedro version 0.19.0._}
+
 To copy the code from [cells tagged](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#cell-tags) with a `node` tag into Python files under `src/<package_name>/nodes/` in a Kedro project:
 
 ```bash
 kedro jupyter convert --all
 ```
 
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 ##### Strip output cells
+
+{_This command will be deprecated from Kedro version 0.19.0._}
 
 Output cells of Jupyter Notebook should not be tracked by git, especially if they contain sensitive information. To strip them out:
 
 ```bash
 kedro activate-nbstripout
 ```
-
-___
-_This command will be deprecated from Kedro version 0.19.0._
-___
-
 
 This command adds a `git hook` which clears all notebook output cells before committing anything to `git`. It needs to run only once per local repository.


### PR DESCRIPTION
Signed-off-by: Jannic Holzer <jannic.holzer@quantumblack.com>

## Description
In Kedro version 0.19.0, six commands are being deprecated (#1617). This PR adds deprecation notices for these commands to the documentation.

## Development notes

I manually checked that the docs still build successfully.


## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1912"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

