### PR TITLE
Expose the loaded_version and saved_version for `AbstractVersionedDataSet`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 * The config loader objects now implement `UserDict` and the configuration is accessed through `conf_loader['catalog']`
 * You can configure config file patterns through `settings.py` without creating a custom config loader
+* Expose latest load version when version is `None`.
 
 ## Bug fixes and other changes
 * Fixed `kedro micropkg pull` for packages on PyPI.

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -345,6 +345,8 @@ class DataCatalog:
         )
 
         result = dataset.load()
+        if isinstance(dataset, AbstractVersionedDataSet):
+            self._logger.info(f"Debug - load_version={dataset._loaded_version}")
 
         return result
 
@@ -380,7 +382,8 @@ class DataCatalog:
         dataset = self._get_dataset(name)
 
         self._logger.info("Saving data to '%s' (%s)...", name, type(dataset).__name__)
-
+        if isinstance(dataset, AbstractVersionedDataSet):
+            self._logger.info(f"Debug - save_version={dataset._saved_version}")
         dataset.save(data)
 
     def exists(self, name: str) -> bool:


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

## Description
<!-- Why was this PR created? -->
Related #1580 

### How current load version is determined when version=None?
Currently, this `load_version` information is buried deep down in the framework, and it is determined only when a dataset is loaded at runtime.
The details of how "latest" version is in a method called `resolve_load_version`, which further calls `_fetch_latest_load_version`

https://github.com/kedro-org/kedro/blob/b2e59facaa5f97f693287be590b4b4d297db344e/kedro/io/core.py#L558-L564

###  How version is determined?
```python
  def resolve_load_version(self) -> Optional[str]:
      """Compute the version the dataset should be loaded with."""
      if not self._version:  # Not version at all - not sure when will this path executed?
          return None 
      if self._version.load:  # when load-version is specified in CLI or config
          return self._version.load
      return self._fetch_latest_load_version().  # When version=None
```

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1951"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

# Alternatives
### 1st attempt - Add new attributes in `AbstractVersionedDataSet`
It may not be a bad idea to add new attributes at all - we can update the `load_version` `save_version` or the `version_cache`, but that way we also lost the initial input which makes things complicated.


[8fe0b1a](https://github.com/kedro-org/kedro/pull/1951/commits/8fe0b1a855e4870d01874cefbcb60b0cdbc7ac85)
![image](https://user-images.githubusercontent.com/18221871/196691588-37cdb8a9-23c8-4a8f-888f-10b9f7125d98.png)



# More Context
- [ ] https://github.com/quantumblacklabs/private-kedro/pull/404
> Currently every call to `AbstractVersionedDataSet.load()` resolves the load version once again. This may result in inconsistent versioned being passed to different nodes (if new version is created mid-run).
