### PR TITLE
Add show-docs command to Makefile to ease docs build/check process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,9 @@ build-docs:
 	pip install -e ".[docs]"
 	./docs/build-docs.sh "docs"
 
+show-docs:
+	open docs/build/html/index.html        
+
 linkcheck:
 	pip install -e ".[docs]"
 	./docs/build-docs.sh "linkcheck"


### PR DESCRIPTION


## Description
This PR is simply to extend the Kedro makefile to ease docs build/check process by adding a separate "show-docs" command to open the docs in the build location

## Development notes
Added 2 lines to Makefile and tested

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1958"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

