### PR TITLE
Add dot nested credentials support

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,7 @@
 * Updated Experiment Tracking docs with working examples.
 * Modified implementation of the Kedro IPython extension to use `local_ns` rather than a global variable.
 * Refactored `ShelveStore` to it's own module to ensure multiprocessing works with it.
+* Added dot nested credentials support.
 
 ## Minor breaking changes to the API
 

--- a/docs/source/data/data_catalog.md
+++ b/docs/source/data/data_catalog.md
@@ -403,6 +403,11 @@ CSVDataSet(
 )
 ```
 
+```{note}
+You can use the same dot notation as the one used with `globals.yml` to reference
+nested keys in the credentials file.
+```
+
 
 ## Load multiple datasets with similar configuration
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -9,6 +9,7 @@ import difflib
 import logging
 import re
 from collections import defaultdict
+from functools import reduce
 from typing import Any, Dict, List, Optional, Set, Type, Union
 
 from kedro.io.core import (
@@ -45,7 +46,11 @@ def _get_credentials(
 
     """
     try:
-        return credentials[credentials_name]
+        return reduce(
+            lambda credentials, key: credentials[key],
+            credentials_name.split("."),
+            credentials,
+        )
     except KeyError as exc:
         raise KeyError(
             f"Unable to find credentials '{credentials_name}': check your data "


### PR DESCRIPTION
## Description
Added dot nested credentials support. With this feature, it is possible to replicate the same functionality seen in nested entries with the globals file. Check out the example below:

```yml
# catalog
dataset:
  type: pandas.CSVDataSet
  filepath: abfs://....csv
  credentials: azure.storage.credentials
```

```yml
# credentials
azure:
  storage:
    credentials:
      account_name: test
      anon: false
```

## Development notes
* Modified the `get_credentials` function to reduce the credentials dict with `split(".")` parts, instead of accessing directly with `dict[key]`
* Added two test cases, one for sane dot nested credentials, and another for dot nested but missing the key

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1975"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

