### PR TITLE
Fix Docstring example for PickleDataSet

### DIFF
--- a/docs/source/deployment/aws_sagemaker.md
+++ b/docs/source/deployment/aws_sagemaker.md
@@ -111,9 +111,9 @@ s3:
 
 ### Update the project settings
 
-Now you need to tell Kedro to use the [`TemplatedConfigLoader`](/kedro.config.TemplatedConfigLoader) instead of the default `ConfigLoader` class  by setting the `CONFIG_LOADER_CLASS` accordingly. 
+Now you need to tell Kedro to use the [`TemplatedConfigLoader`](/kedro.config.TemplatedConfigLoader) instead of the default `ConfigLoader` class  by setting the `CONFIG_LOADER_CLASS` accordingly.
 
-You also need to point Kedro to your `globals.yml` file. 
+You also need to point Kedro to your `globals.yml` file.
 
 To make both changes, open the `src/kedro_tutorial/settings.py` file and set the `CONFIG_LOADER_CLASS` and `CONFIG_LOADER_ARGS` variables:
 

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -42,9 +42,7 @@ class PickleDataSet(AbstractVersionedDataSet[Any, Any]):
         >>>   backend: joblib
         >>>   credentials: s3_credentials
         >>>   save_args:
-        >>>     compression: lz4
-        >>>   load_args:
-        >>>     compression: lz4
+        >>>     compress: lz4
 
     Example using Python API:
     ::


### PR DESCRIPTION
## Description
Fixes #1976 

## Development notes
I simply changed the `save_args` and removed the `load_args` in the example to make the catalog entry not throwing an error if used as is.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1977"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

