### PR TITLE
Replace Discord links in docs with links to Slack

### DIFF
--- a/docs/source/contribution/contribute_to_kedro.md
+++ b/docs/source/contribution/contribute_to_kedro.md
@@ -3,7 +3,8 @@
 We welcome any and all contributions to Kedro, at whatever level you can manage. For example, you could:
 
 - Join the community on [Slack](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw)
-- Troubleshoot other users' questions or get answers to your own queries on [GitHub discussions](https://github.com/kedro-org/kedro/discussions)
+- Review Kedro's [GitHub isusses](https://github.com/kedro-org/kedro/issues) or raise your own issue to report a bug or feature request
+- Start a conversation about the Kedro project on [GitHub discussions](https://github.com/kedro-org/kedro/discussions)
 - Make a pull request on the [kedro-community Github repo](https://github.com/kedro-org/kedro-community) to update the curated list of Kedro community content.
 - Report a bug or propose a new feature on [GitHub issues](https://github.com/kedro-org/kedro/issues)
 - [Review other contributors' PRs](https://github.com/kedro-org/kedro/pulls)

--- a/docs/source/contribution/contribute_to_kedro.md
+++ b/docs/source/contribution/contribute_to_kedro.md
@@ -2,7 +2,7 @@
 
 We welcome any and all contributions to Kedro, at whatever level you can manage. For example, you could:
 
-- Join the community on [Discord](https://discord.gg/akJDeVaxnB)
+- Join the community on [Slack](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw)
 - Troubleshoot other users' questions or get answers to your own queries on [GitHub discussions](https://github.com/kedro-org/kedro/discussions)
 - Make a pull request on the [kedro-community Github repo](https://github.com/kedro-org/kedro-community) to update the curated list of Kedro community content.
 - Report a bug or propose a new feature on [GitHub issues](https://github.com/kedro-org/kedro/issues)

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -23,7 +23,7 @@ In this section, we detail:
 - Guide the community to use the right channel:
   - [Github](https://github.com/kedro-org/kedro/) for feature requests and bug reports
   - [GitHub discussions](https://github.com/kedro-org/kedro/discussions)
-  - [Discord](https://discord.gg/akJDeVaxnB)
+  - [Slack](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw)
 
 ## Requirements to become a maintainer
 
@@ -46,7 +46,7 @@ We look for commitment markers with the following:
 Quarterly, existing maintainers will curate a list of contributors that have shown regular activity on the project over the prior months and want to become maintainers. From this list, maintainer candidates are selected and proposed for a vote.
 
 Following a successful vote, candidates are added to the `kedro-developers` team on the Kedro GitHub organisation
-and the `kedro-team` group on the Kedro Discord organisation.
+and the `kedro-team` channel on the Kedro Slack organisation.
 
 ## Voting process
 

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -22,8 +22,10 @@ In this section, we detail:
 - Make sure that ongoing pull requests are moving forward at the right pace or closing them
 - Guide the community to use the right channel:
   - [Github](https://github.com/kedro-org/kedro/) for feature requests and bug reports
-  - [GitHub discussions](https://github.com/kedro-org/kedro/discussions)
+  - [GitHub discussions](https://github.com/kedro-org/kedro/discussions) to discuss
+    the Kedro project
   - [Slack](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw)
+    for questions and to support other users
 
 ## Requirements to become a maintainer
 

--- a/docs/source/faq/faq.md
+++ b/docs/source/faq/faq.md
@@ -1,7 +1,7 @@
 # Frequently asked questions
 
 The following lists a set of questions that we have been asked about Kedro in the past. If you have a different
- question which isn't answered here, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+question which isn't answered here, check out the [searchable archive from our retired Discord server](https://linen-discord.kedro.org) or post a new query on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## What is Kedro?
 
@@ -172,4 +172,4 @@ If you're an academic, Kedro can also help you, for example, as a tool to solve 
 
 ## How can I get my question answered?
 
-If your question isn't answered above, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+If your question isn't answered above, check out the [searchable archive from our retired Discord server](https://linen-discord.kedro.org/community or post a new query on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).

--- a/docs/source/faq/faq.md
+++ b/docs/source/faq/faq.md
@@ -1,7 +1,7 @@
 # Frequently asked questions
 
 The following lists a set of questions that we have been asked about Kedro in the past. If you have a different
- question which isn't answered here, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+ question which isn't answered here, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## What is Kedro?
 
@@ -172,4 +172,4 @@ If you're an academic, Kedro can also help you, for example, as a tool to solve 
 
 ## How can I get my question answered?
 
-If your question isn't answered above, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+If your question isn't answered above, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).

--- a/docs/source/faq/faq.md
+++ b/docs/source/faq/faq.md
@@ -1,7 +1,7 @@
 # Frequently asked questions
 
 The following lists a set of questions that we have been asked about Kedro in the past. If you have a different
- question which isn't answered here, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Discord Server](https://discord.gg/akJDeVaxnB).
+ question which isn't answered here, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## What is Kedro?
 
@@ -172,4 +172,4 @@ If you're an academic, Kedro can also help you, for example, as a tool to solve 
 
 ## How can I get my question answered?
 
-If your question isn't answered above, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Discord Server](https://discord.gg/akJDeVaxnB).
+If your question isn't answered above, check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -28,7 +28,7 @@ You should see an ASCII art graphic and the Kedro version number: for example,
 
 ![](../meta/images/kedro_graphic.png)
 
-If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out the [searchable archive from our retired Discord server](https://linen-discord.kedro.org) or post a new query on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## Install a development version
 

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -28,7 +28,7 @@ You should see an ASCII art graphic and the Kedro version number: for example,
 
 ![](../meta/images/kedro_graphic.png)
 
-If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Discord Server](https://discord.gg/akJDeVaxnB).
+If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## Install a development version
 

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -28,7 +28,7 @@ You should see an ASCII art graphic and the Kedro version number: for example,
 
 ![](../meta/images/kedro_graphic.png)
 
-If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+If you do not see the graphic displayed, or have any issues with your installation, see the [frequently asked questions](../faq/faq.md), check out [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or talk to the community on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 ## Install a development version
 

--- a/docs/source/get_started/prerequisites.md
+++ b/docs/source/get_started/prerequisites.md
@@ -1,6 +1,7 @@
 # Installation prerequisites
 
-- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you
+  encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), the [searchable archive from our retired Discord server](https://linen-discord.kedro.org) or post a new query on the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 - To work with Kedro, we highly recommend that you [download and install Anaconda](https://www.anaconda.com/products/individual#Downloads) (Python 3.x version).
 

--- a/docs/source/get_started/prerequisites.md
+++ b/docs/source/get_started/prerequisites.md
@@ -1,6 +1,6 @@
 # Installation prerequisites
 
-- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or the  [Discord Server](https://discord.gg/akJDeVaxnB).
+- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 - To work with Kedro, we highly recommend that you [download and install Anaconda](https://www.anaconda.com/products/individual#Downloads) (Python 3.x version).
 

--- a/docs/source/get_started/prerequisites.md
+++ b/docs/source/get_started/prerequisites.md
@@ -1,6 +1,6 @@
 # Installation prerequisites
 
-- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or the [Slack organization](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
+- Kedro supports macOS, Linux and Windows (7 / 8 / 10 and Windows Server 2016+). If you encounter any problems on these platforms, please check the [frequently asked questions](../faq/faq.md), [GitHub Discussions](https://github.com/kedro-org/kedro/discussions) or the [Slack organisation](https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw).
 
 - To work with Kedro, we highly recommend that you [download and install Anaconda](https://www.anaconda.com/products/individual#Downloads) (Python 3.x version).
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,7 +41,7 @@ Welcome to Kedro's documentation!
 
 .. image:: https://img.shields.io/badge/slack-chat-blueviolet.svg?label=Kedro%20Slack&logo=slack&style=flat-square
     :target: https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw
-    :alt: Kedro's Slack organization
+    :alt: Kedro's Slack organisation
 
 .. image:: https://img.shields.io/badge/code%20style-black-black.svg
     :target: https://github.com/psf/black

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -39,9 +39,9 @@ Welcome to Kedro's documentation!
     :target: https://kedro.readthedocs.io/
     :alt: Docs build status
 
-.. image:: https://img.shields.io/discord/778216384475693066.svg?color=7289da&label=Kedro%20Discord&logo=discord&style=flat-square
-    :target: https://discord.gg/akJDeVaxnB
-    :alt: Discord Server
+.. image:: https://img.shields.io/badge/slack-chat-blueviolet.svg?label=Kedro%20Slack&logo=slack&style=flat-square
+    :target: https://join.slack.com/t/kedro-org/shared_invite/zt-1eicp0iw6-nkBvDlfAYb1AUJV7DgBIvw
+    :alt: Kedro's Slack organization
 
 .. image:: https://img.shields.io/badge/code%20style-black-black.svg
     :target: https://github.com/psf/black


### PR DESCRIPTION
Signed-off-by: Bharath Saiguhan <bharathsaiguhan@protonmail.com>

## Description
PR to replace mentions of Discord in the docs with links to the new Kedro Slack organization.

Note: Additional changes to be made once consensus is reached regarding where would be an appropriate location to place the rationale for the switch from Discord to Slack. More at the [relevant GitHub discussion](https://github.com/kedro-org/kedro/discussions/1986) for more.

## Development notes
All mentions (🤞🏽) of Discord in the docs were changed to Slack invite links (where there were links to the Discord server previously), or reworded to mention the Slack organization explicitly.

Changes were then confirmed by `make build-docs` (to see the changes visually) as well as with `make linkcheck` (to make sure links were _actually_ working).

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes

Should close #1983 once additional changes are made.

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/1988"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

