### PR TITLE
Fix sticky table of content for Kedro doc page

### DIFF
--- a/docs/source/tutorial/set_up_experiment_tracking.md
+++ b/docs/source/tutorial/set_up_experiment_tracking.md
@@ -43,7 +43,7 @@ SESSION_STORE_ARGS = {"path": str(Path(__file__).parents[2] / "data")}
 
 This will specify the creation of the `SQLiteStore` under the `/data` subfolder, using the `SQLiteStore` setup from your installed Kedro-Viz plugin.
 
-Please ensure that your installed version of Kedro-Viz is at least version 4.1.1 onwards. This step is crucial to enable experiment tracking features on Kedro-Viz, as it is the database used to serve all run data to the Kedro-Viz front-end. Once this step is complete, you can either proceed to [set up the tracking datasets](#set-up-tracking-datasets) or [set up your nodes and pipelines to log metrics](#set-up-your-nodes-and-pipelines-to-log-metrics); these two activities are interchangeable, but both should be completed to get a working experiment tracking setup. 
+Please ensure that your installed version of Kedro-Viz is at least version 4.1.1 onwards. This step is crucial to enable experiment tracking features on Kedro-Viz, as it is the database used to serve all run data to the Kedro-Viz front-end. Once this step is complete, you can either proceed to [set up the tracking datasets](#set-up-tracking-datasets) or [set up your nodes and pipelines to log metrics](#set-up-your-nodes-and-pipelines-to-log-metrics); these two activities are interchangeable, but both should be completed to get a working experiment tracking setup.
 
 ## Set up tracking datasets
 

--- a/kedro/io/__init__.py
+++ b/kedro/io/__init__.py
@@ -31,3 +31,6 @@ __all__ = [
     "PartitionedDataSet",
     "Version",
 ]
+
+
+

--- a/kedro/io/__init__.py
+++ b/kedro/io/__init__.py
@@ -31,6 +31,3 @@ __all__ = [
     "PartitionedDataSet",
     "Version",
 ]
-
-
-

--- a/setup.py
+++ b/setup.py
@@ -107,7 +107,7 @@ extras_require = {
     "docs": [
         "docutils==0.16",
         "sphinx~=3.4.3",
-        "sphinx_rtd_theme==0.4.1",
+        "sphinx_rtd_theme==1.1.1",
         "nbsphinx==0.8.1",
         "nbstripout~=0.4",
         "sphinx-autodoc-typehints==1.11.1",


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
There is a bug that causes the Table of Content does not stick with the current navigation page. See Jo's SO post here.
https://stackoverflow.com/questions/74391444/sphinx-docs-table-of-contents-skips-to-top-when-new-page-is-below-the-fold

Demo: https://www.youtube.com/watch?v=orW1_vmOxNY

The issues appear to be the `sphinx-rtd-theme`
In 0.17.1 , we use `0.4.1` , but in `0.17.0` we use `0.4.3`. Bumping it to `1.1.1` solves the issue.

## Context
It creates a build issue in the past and thus we downgrade and pin to the `0.4.1` version instead.
https://github.com/quantumblacklabs/private-kedro/pull/963

Change Log for `sphinx-rtd-theme`
https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html


## Development notes
<!-- What have you changed, and how has this been tested? -->
It states clearly that `0.4.3` solve this issue.

0.4.3[](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#release-0-4-3)
```
Date
Feb 12, 2019

New Features[](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#id18)
Fixes[](https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#id19)
Fix scrolling to active item in sidebar on load (#214)
```

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2018"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
