### PR TITLE
Release notes changes for 18.4 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -48,7 +48,7 @@
 * Moved some pages that covered advanced materials into more appropriate sections
 * Moved visualisation into its own section
 * Fixed a bug that degraded user experience: the table of contents is now sticky when you navigate between pages
-* Added redirects where needed on ReadTheDocs for legacy links and bookmarks 
+* Added redirects where needed on ReadTheDocs for legacy links and bookmarks
 
 ## Contributions from the Kedroid community
 We are grateful to the following for submitting PRs that contributed to this release: [jstammers](https://github.com/jstammers), [FlorianGD](https://github.com/FlorianGD), [yash6318](https://github.com/yash6318), [carlaprv](https://github.com/carlaprv), [dinotuku](https://github.com/dinotuku), [williamcaicedo](https://github.com/williamcaicedo), [avan-sh](https://github.com/avan-sh), [Kastakin](https://github.com/Kastakin), [amaralbf](https://github.com/amaralbf), [BSGalvan](https://github.com/BSGalvan), [levimjoseph](https://github.com/levimjoseph), [daniel-falk](https://github.com/daniel-falk), [clotildeguinard](https://github.com/clotildeguinard), [avsolatorio](https://github.com/avsolatorio), and [picklejuicedev](https://github.com/picklejuicedev) for comments and input to documentation changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,22 +51,7 @@
 * Added redirects where needed on ReadTheDocs for legacy links and bookmarks 
 
 ## Contributions from the Kedroid community
-We are grateful to the following for submitting PRs that contributed to this release:
-
-* [jstammers](https://github.com/jstammers)
-* [FlorianGD](https://github.com/FlorianGD)
-* [yash6318](https://github.com/yash6318)
-* [carlaprv](https://github.com/carlaprv)
-* [dinotuku](https://github.com/dinotuku)
-*  [williamcaicedo](https://github.com/williamcaicedo)
-* [avan-sh](https://github.com/avan-sh)
-* [Kastakin](https://github.com/Kastakin)
-* [amaralbf](https://github.com/amaralbf)
-* [BSGalvan](https://github.com/BSGalvan)
-* [levimjoseph](https://github.com/levimjoseph)
-* [daniel-falk](https://github.com/daniel-falk)
-* [clotildeguinard](https://github.com/clotildeguinard)
-* [picklejuicedev](https://github.com/picklejuicedev) for comments and input to documentation changes
+We are grateful to the following for submitting PRs that contributed to this release: [jstammers](https://github.com/jstammers), [FlorianGD](https://github.com/FlorianGD), [yash6318](https://github.com/yash6318), [carlaprv](https://github.com/carlaprv), [dinotuku](https://github.com/dinotuku), [williamcaicedo](https://github.com/williamcaicedo), [avan-sh](https://github.com/avan-sh), [Kastakin](https://github.com/Kastakin), [amaralbf](https://github.com/amaralbf), [BSGalvan](https://github.com/BSGalvan), [levimjoseph](https://github.com/levimjoseph), [daniel-falk](https://github.com/daniel-falk), [clotildeguinard](https://github.com/clotildeguinard), [avsolatorio](https://github.com/avsolatorio), and [picklejuicedev](https://github.com/picklejuicedev) for comments and input to documentation changes
 
 # Release 0.18.3
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -49,6 +49,24 @@
 * Fixed a bug that degraded user experience: the table of contents is now sticky when you navigate between pages
 * Added redirects where needed on ReadTheDocs for legacy links and bookmarks 
 
+## Contributions from the Kedroid community
+We are grateful to the following for submitting PRs that contributed to this release:
+
+* [jstammers](https://github.com/jstammers)
+* [FlorianGD](https://github.com/FlorianGD)
+* [yash6318](https://github.com/yash6318)
+* [carlaprv](https://github.com/carlaprv)
+* [dinotuku](https://github.com/dinotuku)
+*  [williamcaicedo](https://github.com/williamcaicedo)
+* [avan-sh](https://github.com/avan-sh)
+* [Kastakin](https://github.com/Kastakin)
+* [amaralbf](https://github.com/amaralbf)
+* [BSGalvan](https://github.com/BSGalvan)
+* [levimjoseph](https://github.com/levimjoseph)
+* [daniel-falk](https://github.com/daniel-falk)
+* [clotildeguinard](https://github.com/clotildeguinard)
+* [picklejuicedev](https://github.com/picklejuicedev) for comments and input to documentation changes
+
 # Release 0.18.3
 
 ## Major features and improvements

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,6 +46,7 @@
 * Updated the spaceflights tutorial to simplify the later stages and clarify what the reader needed to do in each phase
 * Moved some pages that covered advanced materials into more appropriate sections
 * Moved visualisation into its own section
+* Fixed a bug that degraded user experience: the table of contents is now sticky when you navigate between pages
 * Added redirects where needed on ReadTheDocs for legacy links and bookmarks 
 
 # Release 0.18.3

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -40,6 +40,13 @@
 ## Upcoming deprecations for Kedro 0.19.0
 * `kedro test` and `kedro lint` will be deprecated.
 
+## Documentation
+* Revised the Introduction to shorten it
+* Revised the Get Started section to remove unnecessary information and clarify the learning path
+* Updated the spaceflights tutorial to simplify the later stages and clarify what the reader needed to do in each phase
+* Moved some pages that covered advanced materials into more appropriate sections
+* Moved visualisation into its own section
+* Added redirects where needed on ReadTheDocs for legacy links and bookmarks 
 
 # Release 0.18.3
 


### PR DESCRIPTION
This PR adds a section to describe docs changes for the 18.4 release to RELEASE.md.

We could use the open PR and branch for other changes as we make them for the release, but equally happy just to get this signed off and merged so it's ready for liftoff 🚀 

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2064"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

