### PR TITLE
update dependencies, new version of pandas-gbq/tensorflow break CI

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -6,7 +6,6 @@ import shutil
 import tempfile
 import venv
 from pathlib import Path
-from typing import Set
 
 from features.steps.sh_run import run
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 import venv
 from pathlib import Path
+from typing import Set
 
 from features.steps.sh_run import run
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -6,7 +6,7 @@ import shutil
 import tempfile
 import venv
 from pathlib import Path
-from typing import Set
+from typing import Set  # noqa
 
 from features.steps.sh_run import run
 

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -11,7 +11,7 @@ from itertools import chain
 from multiprocessing.managers import BaseProxy, SyncManager  # type: ignore
 from multiprocessing.reduction import ForkingPickler
 from pickle import PicklingError
-from typing import Any, Dict, Iterable, Set
+from typing import Any, Dict, Iterable
 
 from pluggy import PluginManager
 

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -11,7 +11,7 @@ from itertools import chain
 from multiprocessing.managers import BaseProxy, SyncManager  # type: ignore
 from multiprocessing.reduction import ForkingPickler
 from pickle import PicklingError
-from typing import Any, Dict, Iterable, Set
+from typing import Any, Dict, Iterable, Set  # noqa
 
 from pluggy import PluginManager
 

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -11,7 +11,7 @@ from itertools import chain
 from multiprocessing.managers import BaseProxy, SyncManager  # type: ignore
 from multiprocessing.reduction import ForkingPickler
 from pickle import PicklingError
-from typing import Any, Dict, Iterable
+from typing import Any, Dict, Iterable, Set
 
 from pluggy import PluginManager
 

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -6,13 +6,13 @@ import warnings
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from itertools import chain
-from typing import Set
+from typing import Set  # noqa
 
 from pluggy import PluginManager
 
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node
+from kedro.pipeline.node import Node  # noqaß
 from kedro.runner.runner import AbstractRunner, run_node
 
 

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -12,7 +12,7 @@ from pluggy import PluginManager
 
 from kedro.io import DataCatalog, MemoryDataSet
 from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node  # noqaß
+from kedro.pipeline.node import Node  # noqa
 from kedro.runner.runner import AbstractRunner, run_node
 
 

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -6,6 +6,7 @@ import warnings
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from itertools import chain
+from typing import Set
 
 from pluggy import PluginManager
 

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -6,7 +6,6 @@ import warnings
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from itertools import chain
-from typing import Set
 
 from pluggy import PluginManager
 

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,8 @@ pandas_require = {
     "pandas.CSVDataSet": [PANDAS],
     "pandas.ExcelDataSet": [PANDAS, "openpyxl>=3.0.6, <4.0"],
     "pandas.FeatherDataSet": [PANDAS],
-    "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
-    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <1.0"],
+    "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
+    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0],
     "pandas.HDFDataSet": [
         PANDAS,
         "tables~=3.6.0; platform_system == 'Windows'",
@@ -99,7 +99,7 @@ tensorflow_required = {
     "tensorflow.TensorflowModelDataset": [
         # currently only TensorFlow V2 supported for saving and loading.
         # V1 requires HDF5 and serialises differently
-        "tensorflow>=2.0, <2.11.0"  # 2.11.0 is not compatible
+        "tensorflow~=2.0"
     ]
 }
 yaml_require = {"yaml.YAMLDataSet": [PANDAS, "PyYAML>=4.2, <7.0"]}

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ pandas_require = {
     "pandas.ExcelDataSet": [PANDAS, "openpyxl>=3.0.6, <4.0"],
     "pandas.FeatherDataSet": [PANDAS],
     "pandas.GBQTableDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
-    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0],
+    "pandas.GBQQueryDataSet": [PANDAS, "pandas-gbq>=0.12.0, <0.18.0"],
     "pandas.HDFDataSet": [
         PANDAS,
         "tables~=3.6.0; platform_system == 'Windows'",

--- a/setup.py
+++ b/setup.py
@@ -99,7 +99,7 @@ tensorflow_required = {
     "tensorflow.TensorflowModelDataset": [
         # currently only TensorFlow V2 supported for saving and loading.
         # V1 requires HDF5 and serialises differently
-        "tensorflow~=2.0"
+        "tensorflow>=2.0, <2.11.0"  # 2.11.0 is not compatible
     ]
 }
 yaml_require = {"yaml.YAMLDataSet": [PANDAS, "PyYAML>=4.2, <7.0"]}

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -55,6 +55,6 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow~=2.0
+tensorflow>=2.0, <2.11.0  # 2.11.0 is not compatible
 trufflehog~=2.1
 xlsxwriter~=1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -32,7 +32,7 @@ moto==3.0.4; python_version == '3.10'
 networkx~=2.4
 opencv-python~=4.5.5.64
 openpyxl>=3.0.3, <4.0
-pandas-gbq>=0.12.0, <1.0
+pandas-gbq>=0.12.0, <0.18.0
 pandas~=1.3  # 1.3 for read_xml/to_xml
 Pillow~=9.0
 plotly>=4.8.0, <6.0
@@ -55,7 +55,7 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-# tensorflow>=2.0, <2.11.0  # 2.11.0 is not compatible
-tensorflow==2.10.0
+tensorflow~=2.0 # 2.11.0 is not compatible
+# tensorflow==2.10.0
 trufflehog~=2.1
 xlsxwriter~=1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -55,6 +55,7 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow>=2.0, <2.11.0  # 2.11.0 is not compatible
+# tensorflow>=2.0, <2.11.0  # 2.11.0 is not compatible
+tensorflow==2.10.0
 trufflehog~=2.1
 xlsxwriter~=1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -55,7 +55,6 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow~=2.0 # 2.11.0 is not compatible
-# tensorflow==2.10.0
+tensorflow~=2.0
 trufflehog~=2.1
 xlsxwriter~=1.0


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
The current CI is failing as the package resolver is struggling. After some investigation I found out it was because `tensorflow` and `pandas-gbq` both requires `protobuf` and they have some conflicting dependencies.

The temporary solution is pin the `pandas-gbq` to an older version.


## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


## GitPod
https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2068