### PR TITLE
Fix typo in docstring (parameter name)

### DIFF
--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -127,7 +127,7 @@ class SQLTableDataSet(AbstractDataSet[pd.DataFrame, pd.DataFrame]):
 
     .. code-block:: yaml
 
-            >>> db_creds:
+            >>> db_credentials:
             >>>     con: postgresql://scott:tiger@localhost/test
 
     Example using Python API:
@@ -304,7 +304,7 @@ class SQLQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
 
     .. code-block:: yaml
 
-            >>> db_creds:
+            >>> db_credentials:
             >>>     con: postgresql://scott:tiger@localhost/test
 
     Example using Python API:


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
The example docstring didn't work due to using the parameter name `db_credentials` somewhere and `db_creds` somewhere else. Because of that, the example didn't work. This PR implements the same parameter name in the docstring so the example actually works.

## Development notes
A docstring was modified. 

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2077"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

