### PR TITLE
Fix issue in documentation (parameter name)

### DIFF
--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -127,7 +127,7 @@ class SQLTableDataSet(AbstractDataSet[pd.DataFrame, pd.DataFrame]):
 
     .. code-block:: yaml
 
-            >>> db_creds:
+            >>> db_credentials:
             >>>     con: postgresql://scott:tiger@localhost/test
 
     Example using Python API:
@@ -304,7 +304,7 @@ class SQLQueryDataSet(AbstractDataSet[None, pd.DataFrame]):
 
     .. code-block:: yaml
 
-            >>> db_creds:
+            >>> db_credentials:
             >>>     con: postgresql://scott:tiger@localhost/test
 
     Example using Python API:


### PR DESCRIPTION
Signed-off-by: Nicolas Oulianov <nicolas.oulianov@gmail.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
The example in the docstring didn't work because of multiple parameters names. This PR sets the parameter name to be the same everywhere so the example works. 

(This PR was already posted, but I had an issue with DCO. This new PR attemps to fix it.)

## Development notes
A docstring was modified. 

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2082"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

