### PR TITLE
Update docs with alternative to `kedro build-reqs`

### DIFF
--- a/docs/source/kedro_project_setup/dependencies.md
+++ b/docs/source/kedro_project_setup/dependencies.md
@@ -5,21 +5,29 @@ Both `pip install kedro` and `conda install -c conda-forge kedro` install the co
 When you create a project, you then introduce additional dependencies for the tasks it performs.
 
 ## Project-specific dependencies
-You can use Kedro to specify a project's exact dependencies to make it easier for you and others to run your project in the future, and to avoid version conflicts downstream.
+You can specify a project's exact dependencies in the `src/requirements.txt` file to make it easier for you and others to run your project in the future, 
+and to avoid version conflicts downstream. This can be achieved with the help of [`pip-tools`](https://pypi.org/project/pip-tools/). 
+To install `pip-tools` in your virtual environment, run the following command:
+```bash
+pip install pip-tools
+```
 
 To add or remove dependencies to a project, edit the `src/requirements.txt` file, then run the following:
 
 ```bash
-kedro build-reqs
+pip-compile --output-file=<project_root>/src/requirements.txt --input-file=<project_root>/src/requirements.txt
 ```
 
-The `build-reqs` command will [pip compile](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) the requirements listed in the `src/requirements.txt` file into a `src/requirements.lock` that specifies a list of pinned project dependencies (those with a strict version).
+This will [pip compile](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) the requirements listed in 
+the `src/requirements.txt` file into a `src/requirements.lock` that specifies a list of pinned project dependencies 
+(those with a strict version). You can also use this command with additional CLI arguments such as `--generate-hashes`. 
+[Check out the `pip-tools` documentation](https://pypi.org/project/pip-tools/) for more information.
 
 ```{note}
 The `src/requirements.txt` file contains "source" requirements, while `src/requirements.lock` contains the compiled version of those and requires no manual updates.
 ```
 
-To further update the project requirements, modify the `src/requirements.txt` file (not `src/requirements.lock`) and re-run `kedro build-reqs`.
+To further update the project requirements, modify the `src/requirements.txt` file (not `src/requirements.lock`) and re-run the `pip-compile` command above.
 
 
 ## Install project-specific dependencies

--- a/docs/source/nodes_and_pipelines/micro_packaging.md
+++ b/docs/source/nodes_and_pipelines/micro_packaging.md
@@ -71,7 +71,7 @@ You can pull a micro-package from a tar file by executing `kedro micropkg pull <
   * To place parameters from a different config environment, run `kedro micropkg pull <micropkg_name> --env <env_name>`
   * Unit tests in `src/tests/<micropkg_name>`
 * Kedro will also parse any requirements packaged with the micro-package and add them to project level `requirements.in`.
-* It is advised to do `kedro build-reqs` to compile the updated list of requirements after pulling a micro-package.
+* It is advised to compile an updated list of requirements after pulling a micro-package using [`pip-compile`](https://pypi.org/project/pip-tools/). 
 
 ```{note}
 If a micro-package has embedded requirements and a project `requirements.in` file does not already exist, it will be generated based on the project `requirements.txt` before appending the micro-package requirements.


### PR DESCRIPTION
Signed-off-by: Ankita Katiyar <ankitakatiyar2401@gmail.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Resolves #2071 
`kedro build-reqs` will be deprecated in Kedro 0.19.0. 
Updating the documentation to replace mentions of `kedro build-reqs` with alternative `pip-compile` command.
## Development notes
<!-- What have you changed, and how has this been tested? -->
- Updated `docs/source/kedro_project_setup/dependencies.md`
- Updated `docs/source/nodes_and_pipelines/micro_packaging.md`



## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
