### PR TITLE
Add /kedro/datasets/* to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -161,3 +161,6 @@ tests/template/fake_project/
 
 default.profraw
 package-lock.json
+
+# Kedro-Datasets plugin
+kedro/datasets/*

--- a/docs/source/development/set_up_pycharm.md
+++ b/docs/source/development/set_up_pycharm.md
@@ -38,7 +38,7 @@ Finally, in the **Project Explorer** right-click on `src` and then go to **Mark 
 
 ## Set up Run configurations
 
-[PyCharm Run configurations](https://www.jetbrains.com/help/pycharm/creating-and-editing-run-debug-configurations.html) allow you to execute preconfigured scripts rapidly in your IDE with a click of a button. This may be useful for testing, running and packaging your Kedro projects.
+[PyCharm Run configurations](https://www.jetbrains.com/help/pycharm/creating-run-debug-configuration-for-tests.html) allow you to execute preconfigured scripts rapidly in your IDE with a click of a button. This may be useful for testing, running and packaging your Kedro projects.
 
 Here we will walk you through an example of how to setup Run configuration for Kedro CLI `run` command, however it is also applicable to other Kedro commands: `test`, `install`, `package`, `build-docs`.
 


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Related issue: https://github.com/kedro-org/kedro/issues/2111

When we do `make build-docs`, `kedro-datasets` is copied over, ending up with new `__init__.py` files which git tries to add. It can become quite tedious working around this, we can add `kedro/datasets/*` to `.gitignore` as an easy fix.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
