### PR TITLE
Fix `micropkg` manifest section in `pyproject.toml`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Fix bug where `micropkg` manifest section in `pyproject.toml` isn't recognised as allowed configuration.
 
 ## Breaking changes to the API
 

--- a/docs/source/kedro_project_setup/dependencies.md
+++ b/docs/source/kedro_project_setup/dependencies.md
@@ -5,8 +5,8 @@ Both `pip install kedro` and `conda install -c conda-forge kedro` install the co
 When you create a project, you then introduce additional dependencies for the tasks it performs.
 
 ## Project-specific dependencies
-You can specify a project's exact dependencies in the `src/requirements.txt` file to make it easier for you and others to run your project in the future, 
-and to avoid version conflicts downstream. This can be achieved with the help of [`pip-tools`](https://pypi.org/project/pip-tools/). 
+You can specify a project's exact dependencies in the `src/requirements.txt` file to make it easier for you and others to run your project in the future,
+and to avoid version conflicts downstream. This can be achieved with the help of [`pip-tools`](https://pypi.org/project/pip-tools/).
 To install `pip-tools` in your virtual environment, run the following command:
 ```bash
 pip install pip-tools
@@ -18,10 +18,10 @@ To add or remove dependencies to a project, edit the `src/requirements.txt` file
 pip-compile --output-file=<project_root>/src/requirements.txt --input-file=<project_root>/src/requirements.txt
 ```
 
-This will [pip compile](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) the requirements listed in 
-the `src/requirements.txt` file into a `src/requirements.lock` that specifies a list of pinned project dependencies 
-(those with a strict version). You can also use this command with additional CLI arguments such as `--generate-hashes` 
-to use `pip`'s Hash Checking Mode or `--upgrade-package` to update specific packages to the latest or specific versions. 
+This will [pip compile](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) the requirements listed in
+the `src/requirements.txt` file into a `src/requirements.lock` that specifies a list of pinned project dependencies
+(those with a strict version). You can also use this command with additional CLI arguments such as `--generate-hashes`
+to use `pip`'s Hash Checking Mode or `--upgrade-package` to update specific packages to the latest or specific versions.
 [Check out the `pip-tools` documentation](https://pypi.org/project/pip-tools/) for more information.
 
 ```{note}

--- a/docs/source/nodes_and_pipelines/micro_packaging.md
+++ b/docs/source/nodes_and_pipelines/micro_packaging.md
@@ -71,7 +71,7 @@ You can pull a micro-package from a tar file by executing `kedro micropkg pull <
   * To place parameters from a different config environment, run `kedro micropkg pull <micropkg_name> --env <env_name>`
   * Unit tests in `src/tests/<micropkg_name>`
 * Kedro will also parse any requirements packaged with the micro-package and add them to project level `requirements.in`.
-* It is advised to compile an updated list of requirements after pulling a micro-package using [`pip-compile`](https://pypi.org/project/pip-tools/). 
+* It is advised to compile an updated list of requirements after pulling a micro-package using [`pip-compile`](https://pypi.org/project/pip-tools/).
 
 ```{note}
 If a micro-package has embedded requirements and a project `requirements.in` file does not already exist, it will be generated based on the project `requirements.txt` before appending the micro-package requirements.

--- a/features/micropkg.feature
+++ b/features/micropkg.feature
@@ -1,0 +1,19 @@
+Feature: Micro-package target in new project
+
+  Background:
+    Given I have prepared a config file
+    And I have run a non-interactive kedro new with starter "default"
+    And I have installed the project dependencies
+
+  @fresh_venv
+  Scenario: Package a micro-package
+    When I execute the kedro command "micropkg package pipelines.data_science"
+    Then I should get a successful exit code
+    And I should get a message including "'project_dummy.pipelines.data_science' packaged!"
+
+  @fresh_venv
+  Scenario: Package a micro-package from manifest
+    Given I have micro-packaging settings in pyproject.toml
+    When I execute the kedro command "micropkg package --all"
+    Then I should get a successful exit code
+    And I should get a message including "Packaged 'pipelines.data_science' micro-package!"

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -2,6 +2,7 @@
 
 import json
 import shutil
+import textwrap
 from pathlib import Path
 from time import time
 
@@ -621,3 +622,16 @@ def check_cell_conversion(context: behave.runner.Context):
         / "hello_world.py"
     )
     assert "Hello World!" in converted_file.read_text()
+
+
+@given("I have micro-packaging settings in pyproject.toml")
+def add_micropkg_to_pyproject_toml(context: behave.runner.Context):
+    pyproject_toml_path = context.root_project_dir / "pyproject.toml"
+    project_toml_str = textwrap.dedent(
+        """
+                [tool.kedro.micropkg.package]
+                "pipelines.data_science" = {{alias = "ds"}}
+                """
+    )
+    with pyproject_toml_path.open(mode="a") as file:
+        file.write(project_toml_str)

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -629,9 +629,9 @@ def add_micropkg_to_pyproject_toml(context: behave.runner.Context):
     pyproject_toml_path = context.root_project_dir / "pyproject.toml"
     project_toml_str = textwrap.dedent(
         """
-                [tool.kedro.micropkg.package]
-                "pipelines.data_science" = {{alias = "ds"}}
-                """
+        [tool.kedro.micropkg.package]
+        "pipelines.data_science" = {alias = "ds"}
+        """
     )
     with pyproject_toml_path.open(mode="a") as file:
         file.write(project_toml_str)

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -100,7 +100,7 @@ def _get_project_metadata(project_path: Union[str, Path]) -> ProjectMetadata:
     metadata_dict["source_dir"] = source_dir
     metadata_dict["config_file"] = pyproject_toml
     metadata_dict["project_path"] = project_path
-    metadata_dict.pop("pipeline", {})  # don't include micro-packaging specs
+    metadata_dict.pop("micropkg", {})  # don't include micro-packaging specs
 
     try:
         return ProjectMetadata(**metadata_dict)


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
I found a bug, which makes that you can’t use the micropkg specification in the `pyproject.toml`. This line https://github.com/kedro-org/kedro/blob/main/kedro/framework/startup.py#L103 should have been updated to `metadata_dict.pop("micropkg", {})` when we renamed the cli command from `kedro pipeline package` to `kedro micropkg package`.

## Development notes
The existing unit tests didn't catch the bug, because in the setup we don't verify the `pyproject.toml`. I've added e2e tests to check the basic packaging commands. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [X] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2119"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>
