### PR TITLE
Fix `load_ipython_extension` not registering the `%reload_kedro` line magic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,7 @@
 
 ## Bug fixes and other changes
 * Fix bug where `micropkg` manifest section in `pyproject.toml` isn't recognised as allowed configuration.
+* Fix bug causing `load_ipython_extension` not to register the `%reload_kedro` line magic when called in a directory that does not contain a Kedro project.
 
 ## Breaking changes to the API
 

--- a/kedro/ipython/__init__.py
+++ b/kedro/ipython/__init__.py
@@ -29,6 +29,8 @@ def load_ipython_extension(ipython):
     IPython will look for this function specifically.
     See https://ipython.readthedocs.io/en/stable/config/extensions/index.html
     """
+    ipython.register_magic_function(magic_reload_kedro, magic_name="reload_kedro")
+
     if _find_kedro_project(Path.cwd()) is None:
         logger.warning(
             "Kedro extension was registered but couldn't find a Kedro project. "
@@ -36,7 +38,6 @@ def load_ipython_extension(ipython):
         )
         return
 
-    ipython.register_magic_function(magic_reload_kedro, magic_name="reload_kedro")
     reload_kedro()
 
 


### PR DESCRIPTION
## Description
Resolves [#2060](https://github.com/kedro-org/kedro/issues/2060)

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
