### PR TITLE
Only convert omegaconf DictConfig to primitive type for logging

### DIFF
--- a/docs/source/hooks/examples.md
+++ b/docs/source/hooks/examples.md
@@ -178,7 +178,7 @@ class DataValidationHooks:
 great_expectations checkpoint new raw_companies_dataset_checkpoint
 ```
 
-* Remove `data_connector_query` from the `batch_request` in the checkpoint config file: 
+* Remove `data_connector_query` from the `batch_request` in the checkpoint config file:
 
 ```python
 yaml_config = f"""
@@ -249,7 +249,7 @@ class DataValidationHooks:
                     },
                     "batch_identifiers": {
                         "runtime_batch_identifier_name": dataset_name
-                    }
+                    },
                 },
                 run_name=session_id,
             )

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -231,11 +231,11 @@ class OmegaConfLoader(AbstractConfigLoader):
         aggregate_config = config_per_file.values()
         self._check_duplicates(seen_file_to_keys)
 
-        if aggregate_config:
-            if len(aggregate_config) > 1:
-                return dict(OmegaConf.merge(*aggregate_config))
+        if not aggregate_config:
+            return {}
+        if len(aggregate_config) == 1:
             return list(aggregate_config)[0]
-        return {}
+        return dict(OmegaConf.merge(*aggregate_config))
 
     @staticmethod
     def _is_valid_config_path(path):

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -233,9 +233,8 @@ class OmegaConfLoader(AbstractConfigLoader):
 
         if aggregate_config:
             if len(aggregate_config) > 1:
-                merged_config = OmegaConf.merge(*aggregate_config)
-                return OmegaConf.to_container(merged_config)
-            return OmegaConf.to_container(list(aggregate_config)[0])
+                return dict(OmegaConf.merge(*aggregate_config))
+            return list(aggregate_config)[0]
         return {}
 
     @staticmethod

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
 
 import click
+from omegaconf import OmegaConf
 
 from kedro import __version__ as kedro_version
 from kedro.config import ConfigLoader, MissingConfigException
@@ -191,7 +192,7 @@ class KedroSession:
         return session
 
     def _get_logging_config(self) -> Dict[str, Any]:
-        logging_config = self._get_config_loader()["logging"]
+        logging_config = OmegaConf.to_container(self._get_config_loader()["logging"])
         # turn relative paths in logging config into absolute path
         # before initialising loggers
         logging_config = _convert_paths_to_absolute_posix(

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Union
 
 import click
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, omegaconf
 
 from kedro import __version__ as kedro_version
 from kedro.config import ConfigLoader, MissingConfigException
@@ -192,7 +192,9 @@ class KedroSession:
         return session
 
     def _get_logging_config(self) -> Dict[str, Any]:
-        logging_config = OmegaConf.to_container(self._get_config_loader()["logging"])
+        logging_config = self._get_config_loader()["logging"]
+        if isinstance(logging_config, omegaconf.DictConfig):
+            logging_config = OmegaConf.to_container(logging_config)
         # turn relative paths in logging config into absolute path
         # before initialising loggers
         logging_config = _convert_paths_to_absolute_posix(


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
After merging https://github.com/kedro-org/kedro/pull/2174 where I made `OmegaConfLoader` return the primitive dict type I realised that in order to leverage other `omegaconf` functionality such as variable interpolation (https://omegaconf.readthedocs.io/en/2.3_branch/usage.html#variable-interpolation) it's necessary to have it return the `omegaconf.dictconfig.DictConfig` type. 

## Development notes
The problems I discovered with logging were related to this line 
[`LOGGING.configure(logging_config)`](https://github.com/kedro-org/kedro/blob/main/kedro/framework/project/__init__.py#L258)

and so I decided to revert my previous change and only convert the `omegaconf.dictconfig.DictConfig` type to the primitive dict for the logging files. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2176"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

