### PR TITLE
Move pytest options from Makefile to pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,13 +14,13 @@ lint:
 	pre-commit run -a --hook-stage manual $(hook)
 
 test:
-	pytest tests --cov-config pyproject.toml --numprocesses 4 --dist loadfile
+	pytest --numprocesses 4 --dist loadfile
 
 test-no-spark:
-	pytest tests --no-cov --ignore tests/extras/datasets/spark --numprocesses 4 --dist loadfile
+	pytest --no-cov --ignore tests/extras/datasets/spark --numprocesses 4 --dist loadfile
 
 test-no-datasets:
-	pytest tests --no-cov --ignore tests/extras/datasets/ --numprocesses 4 --dist loadfile
+	pytest --no-cov --ignore tests/extras/datasets/ --numprocesses 4 --dist loadfile
 
 e2e-tests:
 	behave

--- a/docs/source/hooks/examples.md
+++ b/docs/source/hooks/examples.md
@@ -178,7 +178,7 @@ class DataValidationHooks:
 great_expectations checkpoint new raw_companies_dataset_checkpoint
 ```
 
-* Remove `data_connector_query` from the `batch_request` in the checkpoint config file: 
+* Remove `data_connector_query` from the `batch_request` in the checkpoint config file:
 
 ```python
 yaml_config = f"""
@@ -249,7 +249,7 @@ class DataValidationHooks:
                     },
                     "batch_identifiers": {
                         "runtime_batch_identifier_name": dataset_name
-                    }
+                    },
                 },
                 run_name=session_id,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,19 +41,34 @@ min-public-methods = 1
 [tool.coverage.report]
 fail_under = 100
 show_missing = true
-omit = ["kedro/templates/*", "kedro/extras/logging/color_logger.py", "kedro/extras/extensions/ipython.py", "kedro/framework/cli/hooks/specs.py", "kedro/framework/hooks/specs.py", "kedro/extras/datasets/tensorflow/*", "kedro/extras/datasets/holoviews/*", "tests/*"]
+omit = [
+    "kedro/templates/*",
+    "kedro/extras/logging/color_logger.py",
+    "kedro/extras/extensions/ipython.py",
+    "kedro/framework/cli/hooks/specs.py",
+    "kedro/framework/hooks/specs.py",
+    "kedro/extras/datasets/tensorflow/*",
+    "kedro/extras/datasets/holoviews/*",
+    "tests/*"
+]
 exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
 
 [tool.pytest.ini_options]
 addopts="""
+--cov-config pyproject.toml \
 --cov-report xml:coverage.xml \
 --cov-report term-missing \
 --cov kedro \
 --cov tests \
 --ignore tests/template/fake_repo \
+--ignore features \
+--ignore kedro/templates \
 --no-cov-on-fail \
 -ra \
 -W ignore"""
+testpaths = [
+  "tests"
+]
 
 [tool.importlinter]
 root_package = "kedro"


### PR DESCRIPTION
### Description and motivation

Having more of our `pytest` config in `pyproject.toml` will allow us to run tests by simply calling `pytest` in the root folder of our project. This will enable easier setup of tests in different IDEs.

<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2179"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

