### PR TITLE
Don't request user to add new pipeline to registry

### DIFF
--- a/docs/source/get_started/new_project.md
+++ b/docs/source/get_started/new_project.md
@@ -112,7 +112,7 @@ The nodes are stored in `src/get_started/nodes.py`:
 
 ### Visualise the project
 
-This is a swift introduction to show how to visualise the project with Kedro-Viz. See the [visualisation documentation](../visualisation/kedro-viz_visualisation) for more detail. 
+This is a swift introduction to show how to visualise the project with Kedro-Viz. See the [visualisation documentation](../visualisation/kedro-viz_visualisation) for more detail.
 
 The Kedro-Viz package needs to be installed separately as it is not part of the standard Kedro installation:
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -110,12 +110,6 @@ def create_pipeline(
     _copy_pipeline_configs(result_path, project_conf_path, skip_config, env=env)
     click.secho(f"\nPipeline '{name}' was successfully created.\n", fg="green")
 
-    click.secho(
-        f"To be able to run the pipeline '{name}', you will need to add it "
-        f"""to 'register_pipelines()' in '{package_dir / "pipeline_registry.py"}'.""",
-        fg="yellow",
-    )
-
 
 @command_with_verbosity(pipeline, "delete")
 @click.argument("name", nargs=1, callback=_check_pipeline_name)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -55,7 +55,7 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow~=2.0
+#tensorflow~=2.0
 triad>=0.6.7, <1.0
 trufflehog~=2.1
 xlsxwriter~=1.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -55,7 +55,7 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-#tensorflow~=2.0
+tensorflow~=2.0
 triad>=0.6.7, <1.0
 trufflehog~=2.1
 xlsxwriter~=1.0

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -88,10 +88,6 @@ class TestPipelineCreateCommand:
 
         result = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
         assert result.exit_code == 0
-        assert (
-            f"To be able to run the pipeline '{PIPELINE_NAME}', you will need "
-            f"to add it to 'register_pipelines()'" in result.output
-        )
         assert f"Creating the pipeline '{PIPELINE_NAME}': OK" in result.output
         assert f"Pipeline '{PIPELINE_NAME}' was successfully created." in result.output
 

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -58,10 +58,6 @@ class TestPipelineCreateCommand:
         result = CliRunner().invoke(fake_project_cli, cmd, obj=fake_metadata)
 
         assert result.exit_code == 0
-        assert (
-            f"To be able to run the pipeline '{PIPELINE_NAME}', you will need "
-            f"to add it to 'register_pipelines()'" in result.output
-        )
 
         # pipeline
         assert f"Creating the pipeline '{PIPELINE_NAME}': OK" in result.output


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

Adding a new pipeline to the registry is no longer necessary (by default) with pipeline auto-discovery.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
