### PR TITLE
Update docs to prevent future warning to show

### DIFF
--- a/docs/source/visualisation/visualise_charts_with_plotly.md
+++ b/docs/source/visualisation/visualise_charts_with_plotly.md
@@ -91,13 +91,21 @@ import pandas as pd
 
 # This function uses plotly.express
 def compare_passenger_capacity_exp(preprocessed_shuttles: pd.DataFrame):
-    return preprocessed_shuttles.groupby(["shuttle_type"]).mean().reset_index()
+    return (
+        preprocessed_shuttles.groupby(["shuttle_type"])
+        .mean(numeric_only=True)
+        .reset_index()
+    )
 
 
 # This function uses plotly.graph_objects
 def compare_passenger_capacity_go(preprocessed_shuttles: pd.DataFrame):
 
-    data_frame = preprocessed_shuttles.groupby(["shuttle_type"]).mean().reset_index()
+    data_frame = (
+        preprocessed_shuttles.groupby(["shuttle_type"])
+        .mean(numeric_only=True)
+        .reset_index()
+    )
     fig = go.Figure(
         [
             go.Bar(


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Resolve part of https://github.com/kedro-org/kedro/issues/2202

## Development notes
When following the visualisation part of the tutorial some extra `FutureWarnings` will appear:

```
 WARNING  /Users/merel_theisen/Projects/Testing/deprecations-spaceflights/src/deprecations_spaceflights/pipelines/reporting/nodes.py:13: FutureWarning:                                                     warnings.py:109

 The default value of numeric_only in DataFrameGroupBy.mean is deprecated. In a future version, numeric_only will default to False. Either specify numeric_only or select only columns which
 should be valid for the function.
```

Adding `numeric_only=True` inside `mean()` removes those warnings. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
