### PR TITLE
Fix whitespace in docstrings

### DIFF
--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -28,6 +28,7 @@ class JSONDataSet(AbstractVersionedDataSet[Any, Any]):
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+
     .. code-block:: yaml
 
         cars:

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -25,7 +25,7 @@ class SparkHiveDataSet(AbstractDataSet[DataFrame, DataFrame]):
     This DataSet has some key assumptions:
 
     - Schemas do not change during the pipeline run (defined PKs must be present for the
-    duration of the pipeline)
+      duration of the pipeline)
     - Tables are not being externally modified during upserts. The upsert method is NOT ATOMIC
 
     to external changes to the target table while executing.


### PR DESCRIPTION
Closes gh-2226.

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

Some small whitespace issues in a couple of docstrings were causing Read the Docs to fail.

## Development notes
<!-- What have you changed, and how has this been tested? -->

I tested this locally by doing what RtD does:

```
(.venv37) $ pip install --upgrade --upgrade-strategy eager --no-cache-dir -e ..[docs]
(.venv37) $ pip install -r ../test_requirements.txt
(.venv37) $ python -m sphinx -T -E -W --keep-going -b html -d _build/doctrees -D language=en . _build/html
```

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2228"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

