### PR TITLE
Fix Failing CI tests caused by setuptools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	pre-commit clean || true
 
 install-pip-setuptools:
-	pip install -U "pip>=21.2" "setuptools>=65.5.1" wheel
+	pip install -U "pip>=21.2" "setuptools>=65.5.1, 67.0.0" wheel
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)

--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -17,6 +17,6 @@ pluggy~=1.0.0
 PyYAML>=4.2, <7.0
 rich~=13.2
 rope~=1.7.0  # subject to LGPLv3 license
-setuptools>=65.5.1
+setuptools>=65.5.1, <67.0.0
 toml~=0.10
 toposort~=1.9  # Needs to be at least 1.5 to be able to raise CircularDependencyError

--- a/features/environment.py
+++ b/features/environment.py
@@ -105,7 +105,7 @@ def _setup_minimal_env(context):
             "install",
             "-U",
             "pip>=21.2",
-            "setuptools>=65.5.1",
+            "setuptools>=65.5.1, <67.0.0",
             "wheel",
         ],
         env=context.env,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # PEP-518 https://peps.python.org/pep-0518/
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=65.5.1", "wheel"]  # PEP 518 specifications.
+requires = ["setuptools>=65.5.1, <67.0.0", "wheel"]  # PEP 518 specifications.
 
 [tool.black]
 exclude = "/templates/|^features/steps/test_starter"

--- a/tools/circleci/requirements.txt
+++ b/tools/circleci/requirements.txt
@@ -1,3 +1,3 @@
 pip>=21.2
-setuptools>=65.5.1
+setuptools>=65.5.1, <67.0.0
 twine~=3.0


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
