### PR TITLE
Unpin setuptools and fix test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ clean:
 	pre-commit clean || true
 
 install-pip-setuptools:
-	pip install -U "pip>=21.2" "setuptools>=65.5.1, <67.0.0" wheel
+	pip install -U "pip>=21.2" "setuptools>=65.5.1" wheel
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,7 +29,6 @@
 * Fixed bug causing the `after_dataset_saved` hook only to be called for one output dataset when multiple are saved in a single node and async saving is in use.
 * Log level for "Credentials not found in your Kedro project config" was changed from `WARNING` to `DEBUG`.
 * Added safe extraction of tar files in `micropkg pull` to fix vulnerability caused by [CVE-2007-4559](https://github.com/advisories/GHSA-gw9q-c7gh-j9vm).
-* Added an upper bound for the `setuptools` dependency to <67.0.0.
 
 ## Breaking changes to the API
 

--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -17,6 +17,6 @@ pluggy~=1.0.0
 PyYAML>=4.2, <7.0
 rich~=13.3
 rope~=1.7.0  # subject to LGPLv3 license
-setuptools>=65.5.1, <67.0.0
+setuptools>=65.5.1
 toml~=0.10
 toposort~=1.9  # Needs to be at least 1.5 to be able to raise CircularDependencyError

--- a/features/environment.py
+++ b/features/environment.py
@@ -105,7 +105,7 @@ def _setup_minimal_env(context):
             "install",
             "-U",
             "pip>=21.2",
-            "setuptools>=65.5.1, <67.0.0",
+            "setuptools>=65.5.1",
             "wheel",
         ],
         env=context.env,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # PEP-518 https://peps.python.org/pep-0518/
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ["setuptools>=65.5.1, <67.0.0", "wheel"]  # PEP 518 specifications.
+requires = ["setuptools>=65.5.1", "wheel"]  # PEP 518 specifications.
 
 [tool.black]
 exclude = "/templates/|^features/steps/test_starter"

--- a/tests/framework/cli/micropkg/test_micropkg_requirements.py
+++ b/tests/framework/cli/micropkg/test_micropkg_requirements.py
@@ -249,7 +249,6 @@ class TestMicropkgRequirements:
     def test_complex_requirements(
         self, requirement, fake_project_cli, fake_metadata, fake_package_path
     ):
-        # pylint: disable=condition-evals-to-constant
         """Options that are valid in requirements.txt but cannot be packaged using
         setup.py."""
         self.call_pipeline_create(fake_project_cli, fake_metadata)
@@ -266,5 +265,6 @@ class TestMicropkgRequirements:
         assert result.exit_code == 1
         assert (
             "InvalidRequirement: Expected package name at the start of dependency specifier"
+            in result.output
             or "InvalidRequirement: Expected end or semicolon" in result.output
         )

--- a/tests/framework/cli/micropkg/test_micropkg_requirements.py
+++ b/tests/framework/cli/micropkg/test_micropkg_requirements.py
@@ -249,6 +249,7 @@ class TestMicropkgRequirements:
     def test_complex_requirements(
         self, requirement, fake_project_cli, fake_metadata, fake_package_path
     ):
+        # pylint: disable=condition-evals-to-constant
         """Options that are valid in requirements.txt but cannot be packaged using
         setup.py."""
         self.call_pipeline_create(fake_project_cli, fake_metadata)
@@ -263,4 +264,7 @@ class TestMicropkgRequirements:
             obj=fake_metadata,
         )
         assert result.exit_code == 1
-        assert "InvalidRequirement: Parse error" in result.output
+        assert (
+            "InvalidRequirement: Expected package name at the start of dependency specifier"
+            or "InvalidRequirement: Expected end or semicolon" in result.output
+        )

--- a/tools/circleci/requirements.txt
+++ b/tools/circleci/requirements.txt
@@ -1,3 +1,3 @@
 pip>=21.2
-setuptools>=65.5.1, <67.0.0
+setuptools>=65.5.1
 twine~=3.0


### PR DESCRIPTION
Signed-off-by: Merel Theisen <merel.theisen@quantumblack.com>

## Description
Solves part of https://github.com/kedro-org/kedro/issues/2276

## Development notes
In the latest `setuptools` release they made breaking changes related to requirements parsing:
https://setuptools.pypa.io/en/stable/history.html#v67-0-0

As a consequence some of the error messages changed. I updated those accordingly in our tests. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
