### PR TITLE
Use `fsspec` in `OmegaConfLoader` to support reading config from tar/zip files

### DIFF
--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -364,7 +364,7 @@ def activate_nbstripout(
 )
 @click.option(
     "--conf-source",
-    type=click.Path(exists=True, file_okay=False, resolve_path=True),
+    type=click.Path(exists=True, file_okay=True, resolve_path=True),
     help=CONF_SOURCE_HELP,
 )
 @click.option(

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -783,7 +783,7 @@ class TestRunCommand:
         )
         assert result.exit_code, result.output
         expected_output = (
-            "Error: Invalid value for '--conf-source': Directory 'nonexistent_dir'"
+            "Error: Invalid value for '--conf-source': Path 'nonexistent_dir'"
             " does not exist."
         )
         assert expected_output in result.output


### PR DESCRIPTION
Signed-off-by: Ankita Katiyar <ankitakatiyar2401@gmail.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Resolves #2146.
This is a fresh PR for the issue. Previous approach - #2268 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2298"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

