### PR TITLE
Add deprecation warning for `--node`, `--tag` and `--load-version` flags

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -35,6 +35,7 @@
 
 ## Upcoming deprecations for Kedro 0.19.0
 * `project_version` will be deprecated in `pyproject.toml` please use `kedro_init_version` instead.
+* Deprecated `kedro run` flags `--node`, `--tag`, and `--load-version` in favour of `--nodes`, `--tags`, and `--load-versions`.
 
 # Release 0.18.4
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -13,6 +13,7 @@ from kedro.framework.cli.utils import (
     KedroCliError,
     _check_module_importable,
     _config_file_callback,
+    _deprecate_options,
     _get_values_as_tuple,
     _reformat_load_versions,
     _split_params,
@@ -339,13 +340,28 @@ def activate_nbstripout(
 @click.option(
     "--to-nodes", type=str, default="", help=TO_NODES_HELP, callback=split_node_names
 )
-@click.option("--node", "-n", "node_names", type=str, multiple=True, help=NODE_ARG_HELP)
+@click.option(
+    "--node",
+    "-n",
+    "node_names",
+    type=str,
+    multiple=True,
+    help=NODE_ARG_HELP,
+    callback=_deprecate_options,
+)
 @click.option(
     "--runner", "-r", type=str, default=None, multiple=False, help=RUNNER_ARG_HELP
 )
 @click.option("--async", "is_async", is_flag=True, multiple=False, help=ASYNC_ARG_HELP)
 @env_option
-@click.option("--tag", "-t", type=str, multiple=True, help=TAG_ARG_HELP)
+@click.option(
+    "--tag",
+    "-t",
+    type=str,
+    multiple=True,
+    help=TAG_ARG_HELP,
+    callback=_deprecate_options,
+)
 @click.option(
     "--load-version",
     "-lv",

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -351,7 +351,6 @@ def activate_nbstripout(
 )
 @click.option("--runner", "-r", type=str, default=None, help=RUNNER_ARG_HELP)
 @click.option("--async", "is_async", is_flag=True, help=ASYNC_ARG_HELP)
-
 @env_option
 @click.option(
     "--tag",

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -483,11 +483,18 @@ def _deprecate_options(ctx, param, value):
         "tag": "--tags",
         "load_version": "--load-versions",
     }
+    shorthand_flag = {
+        "node_names": "-n",
+        "tag": "-t",
+        "load_version": "-lv",
+    }
     if value:
         deprecation_message = (
             f"DeprecationWarning: 'kedro run' flag '{deprecated_flag[param.name]}' is deprecated "
             "and will not be available from Kedro 0.19.0. "
-            f"Use the flag '{new_flag[param.name]}' instead. "
+            f"Use the flag '{new_flag[param.name]}' instead. Shorthand "
+            f"'{shorthand_flag[param.name]}' will be updated to use "
+            f"'{new_flag[param.name]}' in Kedro 0.19.0."
         )
         click.secho(deprecation_message, fg="red")
     return value

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -422,8 +422,8 @@ def _reformat_load_versions(  # pylint: disable=unused-argument
     """Reformat data structure from tuple to dictionary for `load-version`, e.g.:
     ('dataset1:time1', 'dataset2:time2') -> {"dataset1": "time1", "dataset2": "time2"}.
     """
+    _deprecate_options(ctx, param, value)
     load_versions_dict = {}
-
     for load_version in value:
         load_version_list = load_version.split(":", 1)
         if len(load_version_list) != 2:
@@ -470,3 +470,24 @@ def _split_params(ctx, param, value):
 
 def _get_values_as_tuple(values: Iterable[str]) -> Tuple[str, ...]:
     return tuple(chain.from_iterable(value.split(",") for value in values))
+
+
+def _deprecate_options(ctx, param, value):
+    deprecated_flag = {
+        "node_names": "--node",
+        "tag": "--tag",
+        "load_version": "--load-version",
+    }
+    new_flag = {
+        "node_names": "--nodes",
+        "tag": "--tags",
+        "load_version": "--load-versions",
+    }
+    if value:
+        deprecation_message = (
+            f"DeprecationWarning: 'kedro run' flag '{deprecated_flag[param.name]}' is deprecated "
+            "and will not be available from Kedro 0.19.0. "
+            f"Use the flag '{new_flag[param.name]}' instead. "
+        )
+        click.secho(deprecation_message, fg="red")
+    return value


### PR DESCRIPTION
Signed-off-by: Ankita Katiyar <ankitakatiyar2401@gmail.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Resolves #2243 

## Development notes
<!-- What have you changed, and how has this been tested? -->
* Added `_deprecate_options` function in `kedro/framework/cli/utils.py` that displays deprecation warning. It is passed as callback for `--node` and `--tag` options. 
* Since `--load-version` already had a callback function - the method `_deprecate_options` is called within the callback fn `_reformat_load_versions`. (This should not interfere with the changes in #2301 since `--load-versions` will use a different callback function)
## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2303"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

