### PR TITLE
Fix docs header and secret scan warnings

### DIFF
--- a/docs/source/nodes_and_pipelines/nodes.md
+++ b/docs/source/nodes_and_pipelines/nodes.md
@@ -188,7 +188,7 @@ You can also call a node as a regular Python function: `adder_node(dict(a=2, b=3
 
 The following code uses a `pandas chunksize` generator to process large datasets within the [`pandas-iris` starter](../kedro_project_setup/starters.md). First set up a project by following the [get started guide](../get_started/new_project.md#create-the-example-project) to create a Kedro project with the `pandas-iris` starter example code.
 
-Create a [custom dataset](../extend_kedro/custom_datasets.md) called `ChunkWiseCSVDataSet` in `src/YOUR_PROJECT_NAME/extras/datasets/chunkwise_dataset.py` for your `pandas-iris` project. This dataset is a simplified version of the `pandas.CSVDataSet` where the main change is to the `_save` method which should save the data in append-or-create mode, `a+`. 
+Create a [custom dataset](../extend_kedro/custom_datasets.md) called `ChunkWiseCSVDataSet` in `src/YOUR_PROJECT_NAME/extras/datasets/chunkwise_dataset.py` for your `pandas-iris` project. This dataset is a simplified version of the `pandas.CSVDataSet` where the main change is to the `_save` method which should save the data in append-or-create mode, `a+`.
 
 <details>
 <summary><b>Click to expand</b></summary>
@@ -304,8 +304,10 @@ def split_data(
         Split data.
     """
     # Loop through data in chunks building up the training and test sets
-    for chunk in data: # Iterate over the chunks from data
-        full_data = pd.concat([chunk]) # Converts the TextFileReader object into list of DataFrames
+    for chunk in data:  # Iterate over the chunks from data
+        full_data = pd.concat(
+            [chunk]
+        )  # Converts the TextFileReader object into list of DataFrames
         data_train = full_data.sample(
             frac=parameters["train_fraction"], random_state=parameters["random_state"]
         )
@@ -315,7 +317,7 @@ def split_data(
         X_test = data_test.drop(columns=parameters["target_column"])
         y_train = data_train[parameters["target_column"]]
         y_test = data_test[parameters["target_column"]]
-        yield X_train, X_test, y_train, y_test # Use yield instead of return to get the generator object
+        yield X_train, X_test, y_train, y_test  # Use yield instead of return to get the generator object
 ```
 
 We can now `kedro run` in the terminal. The output shows `X_train`, `X_test`, `y_train`, `y_test` saved in chunks:

--- a/docs/source/visualisation/experiment_tracking.md
+++ b/docs/source/visualisation/experiment_tracking.md
@@ -11,7 +11,7 @@ The metadata you store may include:
 * Model weights
 * Plots and other visualisations
 
-### Experiment tracking demonstration using Kedro-Viz
+## Experiment tracking demonstration using Kedro-Viz
 
 We have made an [experiment tracking demo](https://demo.kedro.org/experiment-tracking) to enable you to explore the capabilities of Kedro-Viz further.
 

--- a/trufflehog-ignore.txt
+++ b/trufflehog-ignore.txt
@@ -1,6 +1,7 @@
 docs/package.json
 docs/package-lock.json
 docs/source/meta/images/KedroArchitecture.drawio
+docs/source/nodes_and_pipelines/nodes.md
 static/img/kedro_gitflow.svg
 .idea/
 .git/


### PR DESCRIPTION
Signed-off-by: SajidAlamQB <90610031+SajidAlamQB@users.noreply.github.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Fix header Warning appearing on RTD console, causing `latest` docs to not build, due to `Non-consecutive header level increase; H1 to H3` on `experiment_tracking.md`.

Fix secret scan warning on `nodes.md`, false positive so added `nodes.md` to `trufflehog-ignore.txt`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2308"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

