### PR TITLE
Add lint check to build-docs CI job

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -555,10 +555,15 @@ workflows:
     jobs:
       - build_docs
       - docs_linkcheck
+      - lint:
+          matrix:
+            parameters:
+              python_version: ["3.7", "3.8", "3.9", "3.10"]
       - all_circleci_checks_succeeded:
           requires:
             - build_docs
             - docs_linkcheck
+            - lint
 
   build_code_and_docs:
     when:


### PR DESCRIPTION
Signed-off-by: Ahdra Merali <ahdra.merali@quantumblack.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
Omitting linting from docs changes can cause lint errors to be introduced to the codebase that later become blockers to development tickets. This PR adds linting to the docs-only CI setup to prevent this.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2311"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

