### PR TITLE
Fix broken link to apache 2.0 licence

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -227,6 +227,7 @@ linkcheck_ignore = [
     "https://docs.delta.io/latest/delta-update.html#language-python",
     "https://github.com/kedro-org/kedro/blob/main/kedro/framework/project/default_logging.yml",
     "https://kedro.readthedocs.io/en/stable/data/kedro_io.html#partitioned-dataset-lazy-saving",  # Until 0.18.4
+    "https://opensource.org/license/apache2-0-php/",
 ]
 
 # retry before render a link broken (fix for "too many requests")

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,7 +20,7 @@ Welcome to Kedro's documentation!
     :alt: CircleCI - Develop Branch
 
 .. image:: https://img.shields.io/badge/license-Apache%202.0-blue.svg
-    :target: https://opensource.org/licenses/Apache-2.0
+    :target: https://opensource.org/license/apache2-0-php/
     :alt: License is Apache 2.0
 
 .. image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10-blue.svg


### PR DESCRIPTION
Signed-off-by: Jo Stichbury <jo_stichbury@mckinsey.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes


<a href="https://gitpod.io/#https://github.com/kedro-org/kedro/pull/2313"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

