### PR TITLE
Fix mermaid diagrams in documentation

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -24,10 +24,6 @@ sphinx:
 # mkdocs:
 # configuration: mkdocs.yml
 
-# Optionally build your docs in additional formats such as PDF and ePub
-formats:
-  - pdf
-
 # Optionally set the version of Python and requirements required to build your docs
 python:
   install:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,7 @@ from sphinxcontrib.mermaid import mermaid
 
 from kedro import __version__ as release
 
-MERMAID_JS_URL = "https://unpkg.com/mermaid/dist/mermaid.min.js"
+MERMAID_JS_URL = "https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
## Description
gh-2351

## Development notes
Fixed the Mermaid JS URL.

Also, I removed the PDF documentation, because it's making build longers at the cost of producing a 730-page document that I bet almost nobody is reading... but I could be wrong here, happy to rollback.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
