### PR TITLE
kedro_tutorial has been renamed to spaceflights

### DIFF
--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -124,7 +124,7 @@ pip install <path-to-wheel-file>
 An executable, `kedro-tutorial`, is placed in the `bin` subfolder of the Python install folder, so the project can be run as follows:
 
 ```bash
-python -m kedro_tutorial
+python -m spaceflights
 ```
 
 ```{note}
@@ -134,7 +134,7 @@ The recipient will need to add a `conf` subfolder. They also need to add `data` 
 Once your project is installed, to run your pipelines from any Python code, simply import it:
 
 ```python
-from kedro_tutorial.__main__ import main
+from spaceflights.__main__ import main
 
 main(
     ["--pipeline", "__default__"]


### PR DESCRIPTION
When following the tutorial I cam across this fault in the documentation

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
