### PR TITLE
Render Mermaid diagrams from Sphinx

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,11 +7,13 @@ version: 2
 
 # .readthedocs.yml hook to copy kedro-datasets to kedro.datasets before building the docs
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
     python: "3.7"
+    nodejs: "19"
   jobs:
     post_create_environment:
+      - npm install -g @mermaid-js/mermaid-cli
       - ./docs/kedro-datasets-docs.sh
 
 # Build documentation in the docs/ directory with Sphinx

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,6 +11,8 @@ build:
   tools:
     python: "3.7"
     nodejs: "19"
+  apt_packages:
+    - libasound2
   jobs:
     post_create_environment:
       - npm install -g @mermaid-js/mermaid-cli

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,16 +20,11 @@ import sys
 from distutils.dir_util import copy_tree
 from inspect import getmembers, isclass, isfunction
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Tuple
 
 from click import secho, style
-from docutils import nodes
-from sphinx.application import Sphinx
-from sphinxcontrib.mermaid import mermaid
 
 from kedro import __version__ as release
-
-MERMAID_JS_URL = "https://unpkg.com/mermaid@9.4.0/dist/mermaid.min.js"
 
 # -- Project information -----------------------------------------------------
 
@@ -538,29 +533,6 @@ def _add_jinja_filters(app):
         app.builder.templates.environment.filters["env_override"] = env_override
 
 
-def remove_unused_mermaid_script_file(
-    app: Sphinx,
-    pagename: str,
-    templatename: str,
-    context: Dict,
-    doctree: Optional[nodes.document],
-) -> None:
-    # The `doctree` arg is `None` when not created from a reST document.
-    if not doctree:
-        return
-
-    # Remove the Mermaid JavaScript from pages without Mermaid diagrams.
-    if not doctree.next_node(mermaid):
-        # Create a copy of `context["script_files"]`; modifying the list
-        # in place affects all pages, because they all use the same ref.
-        context["script_files"] = [
-            x for x in context["script_files"] if x != MERMAID_JS_URL
-        ]
-
-    # Remove "None" entries added when `mermaid_version` is set to `""`.
-    context["script_files"] = [x for x in context["script_files"] if x != "None"]
-
-
 def setup(app):
     app.connect("config-inited", _prepare_build_dir)
     app.connect("builder-inited", _add_jinja_filters)
@@ -569,8 +541,6 @@ def setup(app):
     # fix a bug with table wraps in Read the Docs Sphinx theme:
     # https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html
     app.add_css_file("css/theme-overrides.css")
-    app.add_js_file(MERMAID_JS_URL)
-    app.connect("html-page-context", remove_unused_mermaid_script_file)
 
 
 # (regex, restructuredText link replacement, object) list
@@ -599,4 +569,5 @@ user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99
 
 myst_heading_anchors = 5
 
-mermaid_version = ""  # We add a minified Mermaid script file ourselves.
+# https://github.com/kedro-org/kedro/issues/1772
+mermaid_output_format = "svg"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -570,6 +570,6 @@ user_agent = "Mozilla/5.0 (X11; Linux x86_64; rv:99.0) Gecko/20100101 Firefox/99
 myst_heading_anchors = 5
 
 # https://github.com/kedro-org/kedro/issues/1772
-mermaid_output_format = "svg"
+mermaid_output_format = "png"
 # https://github.com/mermaidjs/mermaid.cli#linux-sandbox-issue
-mermaid_params = ["-p", here / "puppeteer-config.json"]
+mermaid_params = ["-p", here / "puppeteer-config.json", "-s", "2"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -571,3 +571,5 @@ myst_heading_anchors = 5
 
 # https://github.com/kedro-org/kedro/issues/1772
 mermaid_output_format = "svg"
+# https://github.com/mermaidjs/mermaid.cli#linux-sandbox-issue
+mermaid_params = ["-p", here / "puppeteer-config.json"]

--- a/docs/puppeteer-config.json
+++ b/docs/puppeteer-config.json
@@ -1,0 +1,3 @@
+{
+  "args": ["--no-sandbox"]
+}


### PR DESCRIPTION
## Description
To fix gh-1772. See previous discussion in gh-2362 and gh-2351.

## Development notes
No JavaScript is used to render the Mermaid diagrams anymore - instead, the SVG is generated from the Sphinx process using the server-side Mermaid CLI. I tested this locally and it works.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
