### PR TITLE
Replace misspelt `TemplateConfigLoader` references

### DIFF
--- a/docs/source/kedro_project_setup/configuration.md
+++ b/docs/source/kedro_project_setup/configuration.md
@@ -255,7 +255,7 @@ Under the hood, `TemplatedConfigLoader` uses [`JMESPath` syntax](https://github.
 
 ### Jinja2 support
 
-From version 0.17.0, `TemplateConfigLoader` also supports the [Jinja2](https://palletsprojects.com/p/jinja/) template engine alongside the original template syntax. Below is an example of a `catalog.yml` file that uses both features:
+From version 0.17.0, `TemplatedConfigLoader` also supports the [Jinja2](https://palletsprojects.com/p/jinja/) template engine alongside the original template syntax. Below is an example of a `catalog.yml` file that uses both features:
 
 ```
 {% for speed in ['fast', 'slow'] %}
@@ -271,11 +271,11 @@ From version 0.17.0, `TemplateConfigLoader` also supports the [Jinja2](https://p
 {% endfor %}
 ```
 
-When parsing this configuration file, `TemplateConfigLoader` will:
+When parsing this configuration file, `TemplatedConfigLoader` will:
 
 1. Read the `catalog.yml` and compile it using Jinja2
 2. Use a YAML parser to parse the compiled config into a Python dictionary
-3. Expand `${bucket_name}` in `filepath` using the `globals_pattern` and `globals_dict` arguments for the `TemplateConfigLoader` instance, as in the previous examples
+3. Expand `${bucket_name}` in `filepath` using the `globals_pattern` and `globals_dict` arguments for the `TemplatedConfigLoader` instance, as in the previous examples
 
 The output Python dictionary will look as follows:
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
