### PR TITLE
Update kedro-viz version in docs

### DIFF
--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -52,7 +52,7 @@ pytest~=7.2
 kedro~=0.18.7
 kedro-datasets[pandas.CSVDataSet, pandas.ExcelDataSet, pandas.ParquetDataSet]~=1.1
 kedro-telemetry~=0.2.0
-kedro-viz~=5.0 # Visualise pipelines
+kedro-viz~=6.0 # Visualise pipelines
 
 # For modelling in the data science pipeline
 scikit-learn~=1.0

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
@@ -11,7 +11,7 @@ Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get st
 In order to get the best out of the template:
 
 * Don't remove any lines from the `.gitignore` file we provide
-* Make sure your results can be reproduced by following a [data engineering convention](https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention)
+* Make sure your results can be reproduced by following a [data engineering convention](https://docs.kedro.org/en/stable/resources/glossary.html#layers-data-engineering-convention)
 * Don't commit data to your repository
 * Don't commit any credentials or your local configuration to your repository. Keep all your credentials and local configuration in `conf/local/`
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -152,7 +152,8 @@ class DataCatalog:
             feed_dict: A feed dict with data to be added in memory.
             layers: A dictionary of data set layers. It maps a layer name
                 to a set of data set names, according to the
-                data engineering convention.
+                data engineering convention. For more details, see
+                https://docs.kedro.org/en/stable/resources/glossary.html#layers-data-engineering-convention
 
         Example:
         ::

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -152,8 +152,7 @@ class DataCatalog:
             feed_dict: A feed dict with data to be added in memory.
             layers: A dictionary of data set layers. It maps a layer name
                 to a set of data set names, according to the
-                data engineering convention. For more details, see
-                https://kedro.readthedocs.io/en/stable/faq/faq.html#what-is-data-engineering-convention
+                data engineering convention.
 
         Example:
         ::


### PR DESCRIPTION
[kedro-viz 6.0.0 has been released](https://github.com/kedro-org/kedro-viz/pull/1297) but is not actually a breaking release from a kedro user perspective.

We should bump the requirement in our docs so that users get the latest version.

See also https://github.com/kedro-org/kedro-starters/pull/121.

