### PR TITLE
Remove docs style guide 

### DIFF
--- a/docs/source/contribution/documentation_contributor_guidelines.md
+++ b/docs/source/contribution/documentation_contributor_guidelines.md
@@ -4,7 +4,7 @@ You are welcome to contribute to the Kedro documentation if you find something i
 
 You can tell us what we should change or make a PR to change it yourself.
 
-Before you contribute any documentation changes, please read this page so you are familiar with the [Kedro documentation style guidelines](#kedro-documentation-style-guide).
+Before you contribute any documentation changes, please read the [Kedro documentation style guidelines](https://github.com/kedro-org/kedro/wiki/Kedro-documentation-style-guide) on the GitHub wiki.
 
 ## How do I rebuild the documentation after I make changes to it?
 
@@ -59,97 +59,4 @@ Ask for help over on [GitHub discussions](https://github.com/kedro-org/kedro/dis
 
 ## Kedro documentation style guide
 
-This is the style guide we have used to create [documentation about Kedro](../index).
-
-When you are writing documentation for your own project, you may find it useful to follow these rules. We also ask anyone kind enough to contribute to the Kedro documentation to follow our preferred style to maintain consistency and simplicity.
-
-We prefer to think of the following list as guidelines rather than rules because have made them lightweight to encourage you to contribute.
-
-Where it's not obvious what the style should be, it's worth consulting the [Microsoft style guide](https://docs.microsoft.com/en-gb/style-guide/welcome/). We also use the [INCITS Inclusive Terminology Guidelines](https://standards.incits.org/apps/group_public/download.php/131246/eb-2021-00288-001-INCITS-Inclusive-Terminology-Guidelines.pdf).
-
-```{note}
-If you are unsure of our preferred style, just do what you can in your documentation contribution, and note any queries. We can always iterate the submission with you when you create a pull request.
-```
-
-### Language
-* Use UK English
-
-### Formatting
-* Use Markdown formatting
-* Mark code blocks with the appropriate language to enable syntax highlighting
-* We use a `bash` lexer for all codeblocks that represent the terminal, and we don't include the prompt
-* We use the format `kedro <command> --<flag>=<value1>,<value2>` for command examples and suggestions
-
-### Links
-* Make hyperlink descriptions as descriptive as you can. This is a good description:
-
-```text
-Learn how to [update the project pipeline](../tutorial/create_pipelines.html#update-the-project-pipeline)
-```
-
-This is less helpful:
-
-```text
-Learn how to update the [project pipeline](../tutorial/create_pipelines.html#update-the-project-pipeline)
-```
-
-Don't write this:
-
-```text
-To learn how to update the project pipeline, see [here](../tutorial/create_pipelines.html#update-the-project-pipeline)
-```
-
-### Capitalisation
-* Only capitalise proper nouns e.g. names of technology products, other tools and services. See the [Kedro lexicon section](#kedro-lexicon) below for additional guidance.
-* Don't capitalise cloud, internet, machine learning, advanced analytics etc. as per the [Microsoft style guide](https://docs.microsoft.com/en-us/style-guide/a-z-word-list-term-collections/term-collections/accessibility-terms).
-* Follow sentence case, which capitalises only the first word of a title/subtitle. We prefer this:
-
-```text
-## An introduction to pipelines
-```
-
-Don't write this:
-
-```text
-## An Introduction to Pipelines
-```
-
-### Bullets
-* Capitalise the first word.
-* Don't put a period at the end unless it's a full sentence. Aim for consistency within a block of bullets if you have some bullets with full sentences and others without, you'll need to put a period at the end of each of them. Like in this set.
-* Don't use numbered bullets except for a sequence of activities or where you have to refer back to one of them in the text (or a diagram).
-
-### Notes
-We use directives to bring attention to key points. For example:
-
-```{note}
-Do not pass "Go", do not collect £200.
-```
-
-* You will need to use restructured text formatting within the box. Aim to keep the formatting of the callout text plain, although you can include bold, italic, code and links.
-* Keep the amount of text (and the number of callouts used) to a minimum.
-* Prefer to use `note`, `warning` and `important` only, rather than a larger range of callout.
-
-    * Use `note` for notable information
-    * Use `warning` to indicate a potential `gotcha`
-    * Use `important` when highlighting a key point that cannot be ignored
-
-### Kedro lexicon
-* Name of our product: Kedro and Kedro-Viz (note capitalisation).
-* Use pipeline as this isn't a proper noun. Tend to lower case except if there is a precedent (see next bullet).
-* Use Hooks (not hooks, except where it's a necessary part of your code example). We are taking our lead from React here, so capitalising despite it not seeming consistent with other rules.
-* Use dataset (not data set, or data-set) for a generic dataset.
- * Use capitalised DataSet when talking about a specific Kedro dataset class e.g. CSVDataSet.
-* Use data catalog for a generic data catalog.
- * Use Data Catalog to talk about the [Kedro Data Catalog](../data/data_catalog.md).
-
-### Style
-* Keep your sentences short and easy to read.
-* Do not plagiarise other authors. Link to their text and credit them.
-* Avoid colloquialisms that may not translate to other regions/languages.
-* Avoid technical terminology, particularly acronyms, that do not pass the "Google test", which means it is not possible to find their meaning from a simple Google search.
-* Use imperatives to make instructions, or second person.
-  * For example "Complete the configuration steps" or "You should complete the configuration steps". Don't use the passive "The configuration steps should be completed" (see next bullet).
-* Avoid passive tense. What is passive tense? If you can add "by zombies" to the end of any sentence, it is passive.
-  * For example: "The configuration steps should be completed." can also be read as: "The configuration should be completed BY ZOMBIES".
-  * Instead, you'd write this: "You should complete the configuration steps" or better still, "Complete the configuration steps".
+There is a lightweight [documentation style guide](https://github.com/kedro-org/kedro/wiki/Kedro-documentation-style-guide) on Kedro's GitHub wiki.


### PR DESCRIPTION
I have removed the content of the docs style guide from the contributor guide and added to the wiki instead.

I'll be following up with some tone of voice guidance on the wiki and wanted to put everything in the same location, and make it easier for contributors to (a) find and (b) contribute to as they have questions/ideas.