### PR TITLE
Make sure any failure with git won't crash Kedro - update logging

### DIFF
--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -159,8 +159,6 @@ class KedroSession:
             save_on_close=save_on_close,
             conf_source=conf_source,
         )
-        # we need a ConfigLoader registered in order to be able to set up logging
-        session._setup_logging()
 
         # have to explicitly type session_data otherwise mypy will complain
         # possibly related to this: https://github.com/python/mypy/issues/1430
@@ -168,7 +166,6 @@ class KedroSession:
             "package_name": session._package_name,
             "project_path": session._project_path,
             "session_id": session.session_id,
-            **_describe_git(session._project_path),
         }
 
         ctx = click.get_current_context(silent=True)
@@ -189,6 +186,11 @@ class KedroSession:
                 "Unable to get username. Full exception: %s", exc
             )
 
+        session._store.update(session_data)
+
+        # We need ConfigLoader and env to setup logging correctly
+        session._setup_logging()
+        session_data.update(**_describe_git(session._project_path))
         session._store.update(session_data)
 
         return session

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -46,7 +46,7 @@ def _describe_git(project_path: Path) -> Dict[str, Dict[str, Any]]:
         git_data["dirty"] = bool(git_status_res.decode().strip())
 
     # `subprocess.check_output()` raises `NotADirectoryError` on Windows
-    except Exception:
+    except Exception:  # pylint: disable=broad-except
         logger = logging.getLogger(__name__)
         logger.debug("Unable to git describe %s", project_path)
         logger.debug(traceback.format_exc())

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -531,13 +531,13 @@ class TestKedroSession:
         session = KedroSession.create(mock_package_name, fake_project)
         assert "git" not in session.store
 
-        expected_log_messages = [f"Unable to git describe {fake_project}"]
+        expected_log_message = f"Unable to git describe {fake_project}"
         actual_log_messages = [
             rec.getMessage()
             for rec in caplog.records
             if rec.name == SESSION_LOGGER_NAME and rec.levelno == logging.DEBUG
         ]
-        assert actual_log_messages == expected_log_messages
+        assert expected_log_message in actual_log_messages
 
     def test_get_username_error(self, fake_project, mock_package_name, mocker, caplog):
         """Test that username information is not added to the session store


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Fix #1826
## Development notes
<!-- What have you changed, and how has this been tested? -->
* Move `_setup_logging` immediately after session is created, otherwise you can't really see `DEBUG` message because there is no way to configure it. @AntonyMilneQB 
* Catching the generic exception - additionally logging the traceback. Catching the generic Exception here does feel a bit anti-pattern. But the origin Error we are catching aren't better.


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
