### PR TITLE
Add 404 page

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,6 +52,7 @@ extensions = [
     "sphinx_copybutton",
     "sphinxcontrib.mermaid",
     "myst_parser",
+    "notfound.extension",
 ]
 
 # enable autosummary plugin (table of contents for modules/classes/class

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -105,7 +105,7 @@ A job queue is the bridge between the submitted jobs and the compute environment
 
 ### Configure the credentials
 
-Ensure you have the necessary AWS credentials in place before moving on, so that your pipeline can access and interact with the AWS services. Check out [the AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config) for instructions on how to set this up.
+Ensure you have the necessary AWS credentials in place before moving on, so that your pipeline can access and interact with the AWS services. Check out [the AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) for instructions on how to set this up.
 
 ```{note}
 You should configure the default region to match the region where you've created the Batch resources.

--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,7 @@ extras_require = {
         # that creates some problematic docstrings
         "sphinx-autodoc-typehints==1.20.2",
         "sphinx_copybutton==0.3.1",
+        "sphinx-notfound-page",
         "ipykernel>=5.3, <7.0",
         "sphinxcontrib-mermaid~=0.7.1",
         "myst-parser~=1.0.0",


### PR DESCRIPTION
## Description
Attempt to fix gh-2464. Let's see if this easy change does it.

## Development notes
Locally the 404.html page gets created, but it has no effect, because using it is a Read the Docs feature https://docs.readthedocs.io/en/stable/reference/404-not-found.html

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
