### PR TITLE
Fix/tensorflow macos test

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,6 +29,7 @@
 * Improvements to documentation about configuration.
 * Improvements to Jupyter E2E tests.
 * Improvements to documentation on visualising Kedro projects on Databricks.
+* Fixed test dependencies for MacOS.
 
 ## Breaking changes to the API
 

--- a/setup.py
+++ b/setup.py
@@ -80,7 +80,8 @@ tensorflow_required = {
     "tensorflow.TensorflowModelDataset": [
         # currently only TensorFlow V2 supported for saving and loading.
         # V1 requires HDF5 and serialises differently
-        "tensorflow~=2.0"
+        "tensorflow~=2.0; platform_system != 'Darwin' or platform_machine != 'arm64'"
+        "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'",
     ]
 }
 yaml_require = {"yaml.YAMLDataSet": [PANDAS, "PyYAML>=4.2, <7.0"]}

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -59,7 +59,8 @@ scipy~=1.7.3
 SQLAlchemy~=1.2
 tables~=3.6.0; platform_system == "Windows" and python_version<'3.9'
 tables~=3.6; platform_system != "Windows"
-tensorflow~=2.0
+tensorflow-macos~=2.0; platform_system == "Darwin" and platform_machine == 'arm64'
+tensorflow~=2.0; platform_system != "Darwin" or platform_machine != 'arm64'
 triad>=0.6.7, <1.0
 trufflehog~=2.1
 xlsxwriter~=1.0


### PR DESCRIPTION
On Macs there is "tensorflow-macos" instead of "tensorflow" for installing Tensorflow. I added the dependency in setup.py and test-requirements since it was missing there

## Development notes
There are no tests required since it is just a dependency issue
