### PR TITLE
Draft - Resolves configuration earlier & separate runtimes_params and meta_params

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,11 +12,15 @@
 # Upcoming Release 0.18.8
 
 ## Major features and improvements
+* Added support for overiding global parameters via `kedro run --params`
+*
 
 ## Bug fixes and other changes
 * Improvements to documentation about configuration.
 * Improvements to Jupyter E2E tests.
 * Improvements to documentation on visualising Kedro projects on Databricks.
+* Push OmegaConfigLoader variable interpolation earlier in the resolving process,
+  OmegaConfigLoader["parameters"] now return a `Dict` instead of `DictConfig`.
 
 ## Breaking changes to the API
 

--- a/kedro/config/abstract_config.py
+++ b/kedro/config/abstract_config.py
@@ -17,12 +17,12 @@ class AbstractConfigLoader(UserDict):
         conf_source: str,
         env: str = None,
         runtime_params: Dict[str, Any] = None,
-        **kwargs
+        **kwargs,
     ):
         super().__init__()
         self.conf_source = conf_source
         self.env = env
-        self.runtime_params = runtime_params
+        self.runtime_params = runtime_params or {}
 
 
 class BadConfigException(Exception):

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -314,7 +314,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
             raise ValueError(f"{dup_str}")
 
     @staticmethod
-    def _resolve_environment_variables(config: DictConfig]) -> None:
+    def _resolve_environment_variables(config: DictConfig) -> None:
         """Use the ``oc.env`` resolver to read environment variables and replace
         them in-place, clearing the resolver after the operation is complete if
         it was not registered beforehand.

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -254,6 +254,8 @@ class OmegaConfigLoader(AbstractConfigLoader):
                     # this is a workaround to read it as a binary file and decode it back to utf8.
                     tmp_fo = io.StringIO(open_config.read().decode("utf8"))
                     config = OmegaConf.load(tmp_fo)
+                    if not OmegaConf.is_dict(config):
+                        raise TypeError("Only DictConfig is supported")
                 if read_environment_variables:
                     self._resolve_environment_variables(config)
                 config_per_file[config_filepath] = config
@@ -277,6 +279,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
             return {}
         # if len(aggregate_config) == 1:
         #     return list(aggregate_config)[0]
+        print("DEBUG", OmegaConf.merge(*aggregate_config, self.runtime_params))
         return OmegaConf.to_container(
             OmegaConf.merge(*aggregate_config, self.runtime_params), resolve=True)
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -430,6 +430,13 @@ def activate_nbstripout(
     help=PARAMS_ARG_HELP,
     callback=_split_params,
 )
+@click.option(
+    "--meta-params",
+    type=click.UNPROCESSED,
+    default="",
+    help=PARAMS_ARG_HELP,
+    callback=_split_params,
+)
 # pylint: disable=too-many-arguments,unused-argument,too-many-locals
 def run(
     tag,
@@ -450,6 +457,7 @@ def run(
     conf_source,
     params,
     namespace,
+    meta_params,
 ):
     """Run the pipeline."""
 
@@ -467,7 +475,10 @@ def run(
     load_version = {**load_version, **load_versions}
 
     with KedroSession.create(
-        env=env, conf_source=conf_source, extra_params=params
+        env=env,
+        conf_source=conf_source,
+        extra_params=params,
+        meta_params=meta_params,
     ) as session:
         session.run(
             tags=tag,

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -130,6 +130,7 @@ class KedroSession:
         save_on_close: bool = True,
         env: str = None,
         extra_params: Dict[str, Any] = None,
+        meta_params: Dict[str, Any] = None,
         conf_source: Optional[str] = None,
     ) -> "KedroSession":
         """Create a new instance of ``KedroSession`` with the session data.
@@ -178,7 +179,8 @@ class KedroSession:
 
         if extra_params:
             session_data["extra_params"] = extra_params
-
+        if meta_params:
+            session_data["meta_params"] = meta_params
         try:
             session_data["username"] = getpass.getuser()
         except Exception as exc:  # pylint: disable=broad-except
@@ -282,12 +284,22 @@ class KedroSession:
         """An instance of the config loader."""
         env = self.store.get("env")
         extra_params = self.store.get("extra_params")
+        meta_params = self.store.get("meta_params")
 
         config_loader_class = settings.CONFIG_LOADER_CLASS
+        if not meta_params:
+            return config_loader_class(
+                conf_source=self._conf_source,
+                env=env,
+                runtime_params=extra_params,
+                **settings.CONFIG_LOADER_ARGS,
+            )
+
         return config_loader_class(
             conf_source=self._conf_source,
             env=env,
             runtime_params=extra_params,
+            meta_params=meta_params,
             **settings.CONFIG_LOADER_ARGS,
         )
 


### PR DESCRIPTION
Signed-off-by: Nok Chan <nok.lam.chan@quantumblack.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

1. Resolve `runtime_params` earlier
2. Fix problem when len(aggregate_config) == 1

```python
ds_name='example_iris_data' ds_config={'type': 'pandas.CSVDataSet', 'filepath': '/Users/Nok_Lam_Chan/dev/test/omega-nest-param/data/01_raw/iris.csv'}

│ /Users/Nok_Lam_Chan/GitHub/kedro/kedro/io/data_catalog.py:272 in from_config                     │
│                                                                                                  │
│   269 │   │                                                                                      │
│   270 │   │   layers = defaultdict(set)  # type: Dict[str, Set[str]]                             │
│   271 │   │   for ds_name, ds_config in catalog.items():                                         │
│ ❱ 272 │   │   │   ds_layer = ds_config.pop("layer", None)                                        │
│   273 │   │   │   if ds_layer is not None:                                                       │
│   274 │   │   │   │   layers[ds_layer].add(ds_name)  

```
4. Separate runtime_params & meta_params
5. Bonus: It may also simplify the syntax - since `meta_params` will not be pass to `catalog` and avoid the validation problem.


## Development notes
<!-- What have you changed, and how has this been tested? -->

Challenge 1 - Parameters resolved too late
Once we merge parameters in ConfigLoader, all `runtime_params` are merged. This is fine for `parameters`, but when it's done for `catalog` - 

Challenge 2 - Works for parameters but not for other configs
We get invalid entries and we don't really want it. Same goes for logging. This wasn't an issue in https://github.com/kedro-org/kedro/pull/2467 because of an accident.

Currently this PR takes a simple solution - it is only enable for `parameters` and nothing else. This is actually the same problem 
 of #2175, but was hidden because of the above logic. 

https://github.com/kedro-org/kedro/blob/7dcb60c7309739dc41731b5d84daeb23ab50c956/kedro/config/omegaconf_config.py#L276-L278


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
