### PR TITLE
Revert aggressive requirements bumps by Dependabot

### DIFF
--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -4,20 +4,19 @@ cachetools~=5.3
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <=2023.1.0; python_version == '3.7'
-fsspec>=2023.1, <2023.5; python_version >= '3.8'
+fsspec>=2021.4, <2024.1
 gitpython~=3.0
 importlib-metadata>=3.6; python_version >= '3.8'
 importlib_metadata>=3.6, <5.0; python_version < '3.8'  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10. Bandit on Python 3.7 relies on a library with `importlib_metadata` < 5.0
 importlib_resources>=1.3  # The `files()` API was introduced in `importlib_resources` 1.3 and Python 3.9.
 jmespath>=0.9.5, <1.0
-more_itertools~=9.1
+more_itertools~=9.0
 omegaconf~=2.3
-pip-tools~=6.12
+pip-tools~=6.5
 pluggy~=1.0.0
 PyYAML>=4.2, <7.0
-rich~=13.3
-rope~=1.7.0  # subject to LGPLv3 license
+rich>=12.0, <14.0
+rope>=0.21, <2.0  # subject to LGPLv3 license
 setuptools>=65.5.1
 toml~=0.10
-toposort~=1.10  # Needs to be at least 1.5 to be able to raise CircularDependencyError
+toposort~=1.5  # Needs to be at least 1.5 to be able to raise CircularDependencyError

--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -4,7 +4,7 @@ cachetools~=5.3
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <2024.1. # Upper bound set arbitrarily, to be reassessed in early 2024
+fsspec>=2021.4, <2024.1  # Upper bound set arbitrarily, to be reassessed in early 2024
 gitpython~=3.0
 importlib-metadata>=3.6; python_version >= '3.8'
 importlib_metadata>=3.6, <5.0; python_version < '3.8'  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10. Bandit on Python 3.7 relies on a library with `importlib_metadata` < 5.0

--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -4,7 +4,7 @@ cachetools~=5.3
 click<9.0
 cookiecutter>=2.1.1, <3.0
 dynaconf>=3.1.2, <4.0
-fsspec>=2021.4, <2024.1
+fsspec>=2021.4, <2024.1. # Upper bound set arbitrarily, to be reassessed in early 2024
 gitpython~=3.0
 importlib-metadata>=3.6; python_version >= '3.8'
 importlib_metadata>=3.6, <5.0; python_version < '3.8'  # The "selectable" entry points were introduced in `importlib_metadata` 3.6 and Python 3.10. Bandit on Python 3.7 relies on a library with `importlib_metadata` < 5.0


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Resolves #2511 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
