### PR TITLE
Proposal: modify catalog validation to allow variable interpolation

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -374,9 +374,6 @@ def parse_dataset_definition(
     save_version = save_version or generate_timestamp()
     config = copy.deepcopy(config)
 
-    if "type" not in config:
-        raise DataSetError("'type' is missing from DataSet catalog configuration")
-
     class_obj = config.pop("type")
     if isinstance(class_obj, str):
         if len(class_obj.strip(".")) != len(class_obj):

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -269,14 +269,15 @@ class DataCatalog:
 
         layers = defaultdict(set)  # type: Dict[str, Set[str]]
         for ds_name, ds_config in catalog.items():
-            ds_layer = ds_config.pop("layer", None)
-            if ds_layer is not None:
-                layers[ds_layer].add(ds_name)
+            if "type" in ds_config:
+                ds_layer = ds_config.pop("layer", None)
+                if ds_layer is not None:
+                    layers[ds_layer].add(ds_name)
 
-            ds_config = _resolve_credentials(ds_config, credentials)
-            data_sets[ds_name] = AbstractDataSet.from_config(
-                ds_name, ds_config, load_versions.get(ds_name), save_version
-            )
+                ds_config = _resolve_credentials(ds_config, credentials)
+                data_sets[ds_name] = AbstractDataSet.from_config(
+                    ds_name, ds_config, load_versions.get(ds_name), save_version
+                )
 
         dataset_layers = layers or None
         return cls(data_sets=data_sets, layers=dataset_layers)

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -76,7 +76,8 @@ class AbstractRunner(ABC):
         unsatisfied = pipeline.inputs() - set(catalog.list())
         if unsatisfied:
             raise ValueError(
-                f"Pipeline input(s) {unsatisfied} not found in the DataCatalog"
+                f"Pipeline input(s) {unsatisfied} not found in the DataCatalog. "
+                f"Make sure that any dataset entry contains the 'type' key."
             )
 
         free_outputs = pipeline.outputs() - set(catalog.list())


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/issues/2507

## Development notes
`omegaconf` variable interpolation doesn't work out of the box, because of the catalog validation that happens later down the line. When you have a catalog like this:

```yaml
example_iris_data:
  type: ${data}
  filepath: data/01_raw/iris.csv

data: pandas.CSVDataSet
```
The catalog validation will fail saying that the entry "data" doesn't have the 'type' key which is required for dataset entries. Obviously this entry isn't meant to be read or parsed as a dataset, because it's just the value that needs to be read into the template above.

This solution modifies the catalog validation to check if an entry contains 'type', if it does it will then be parsed as a dataset. Otherwise, it's skipped from that conversion. 

### Pros

- Users can use the standard `omegaconf` syntax for variable interpolation in the catalog, no special hidden character syntax needed.
- Variable interpolation in the catalog works exactly the same as for parameters

### Cons

- Validation is changed so it doesn't try to parse entries without the 'type' key. However, if a dataset is missing the 'type' key but is supposed to be parsed, that is now only detected after the run.

## Alternative solutions
Require template values to be preceded by a special character, e.g. `_` so they're not read as a dataset in the catalog validation. This is how yaml anchors work in the `ConfigLoader` and `TemplatedConfigLoader`.

You could then have a catalog like this:
```yaml
_pandas:
  type: pandas.CSVDataSet

example_iris_data:
  type: ${_pandas.type}
  filepath: data/01_raw/iris.csv
```

### Pros
- No need to change catalog validation.

### Cons
- A concern with this implementation is that it introduces special Kedro syntax to enable core omegaconf functionality. Users would then not be able to just use the `omegaconf` docs to find out how variable interpolation works. 
- Variable interpolation would be different for the catalog and parameters, because for parameters no special character is needed.

**FYI** I didn't change any tests yet. This PR draft is initially meant to facilitate discussion.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
