### PR TITLE
Remove logs folder from `kedro new` project template

### DIFF
--- a/docs/source/deployment/airflow_astronomer.md
+++ b/docs/source/deployment/airflow_astronomer.md
@@ -51,7 +51,6 @@ To follow this tutorial, ensure you have the following:
     ├── data
     ├── docs
     ├── include
-    ├── logs
     ├── notebooks
     ├── packages.txt
     ├── plugins

--- a/docs/source/deployment/aws_step_functions.md
+++ b/docs/source/deployment/aws_step_functions.md
@@ -173,7 +173,7 @@ ARG FUNCTION_DIR
 ARG RUNTIME_VERSION
 # Create the function directory
 RUN mkdir -p ${FUNCTION_DIR}
-RUN mkdir -p ${FUNCTION_DIR}/{conf,logs}
+RUN mkdir -p ${FUNCTION_DIR}/{conf}
 # Add handler function
 COPY lambda_handler.py ${FUNCTION_DIR}
 # Add conf/ directory

--- a/docs/source/deployment/single_machine.md
+++ b/docs/source/deployment/single_machine.md
@@ -47,11 +47,11 @@ kedro package
 
 Kedro builds the package into the `dist/` folder of your project, and creates one `.egg` file and one `.whl` file, which are [Python packaging formats for binary distribution](https://packaging.python.org/overview/).
 
-The resulting `.egg` and `.whl` packages only contain the Python source code of your Kedro pipeline, not any of the `conf/`, `data/` and `logs/` subfolders nor the `pyproject.toml` file.
+The resulting `.egg` and `.whl` packages only contain the Python source code of your Kedro pipeline, not any of the `conf/` and `data/` subfolders nor the `pyproject.toml` file.
 The project configuration is packaged separately in a `tar.gz` file. This compressed version of the config files excludes any files inside your `local` directory.
-This means that you can distribute the project to run elsewhere, such as on a separate computer with different configuration, data and logging. When distributed, the packaged project must be run from within a directory that contains the `pyproject.toml` file and `conf/` subfolder (and `data/` and `logs/` if your pipeline loads/saves local data or uses logging). This means that you will have to create these directories on the remote servers manually.
+This means that you can distribute the project to run elsewhere, such as on a separate computer with different configuration, data and logging. When distributed, the packaged project must be run from within a directory that contains the `pyproject.toml` file and `conf/` subfolder (and `data/` if your pipeline loads/saves local data). This means that you will have to create these directories on the remote servers manually.
 
-Recipients of the `.egg` and `.whl` files need to have Python and `pip` set up on their machines, but do not need to have Kedro installed. The project is installed to the root of a folder with the relevant `conf/`, `data/` and `logs/` subfolders, by navigating to the root and calling:
+Recipients of the `.egg` and `.whl` files need to have Python and `pip` set up on their machines, but do not need to have Kedro installed. The project is installed to the root of a folder with the relevant `conf/` and `data/` subfolders, by navigating to the root and calling:
 
 ```console
 pip install <path-to-wheel-file>

--- a/docs/source/get_started/kedro_concepts.md
+++ b/docs/source/get_started/kedro_concepts.md
@@ -69,7 +69,6 @@ project-dir         # Parent directory of the template
 ├── conf            # Project configuration files
 ├── data            # Local project data (not committed to version control)
 ├── docs            # Project documentation
-├── logs            # Project output logs (not committed to version control)
 ├── notebooks       # Project-related Jupyter notebooks (can be used for experimental code before moving the code to src)
 ├── pyproject.toml  # Identifies the project root and contains configuration information
 ├── README.md       # Project README

--- a/docs/source/kedro_project_setup/starters.md
+++ b/docs/source/kedro_project_setup/starters.md
@@ -153,7 +153,6 @@ Here is the layout of the project as a Cookiecutter template:
 ├── conf                         # Project configuration files
 ├── data                         # Local project data (not committed to version control)
 ├── docs                         # Project documentation
-├── logs                         # Project output logs (not committed to version control)
 ├── notebooks                    # Project related Jupyter notebooks (can be used for experimental code before moving the code to src)
 ├── README.md                    # Project README
 ├── setup.cfg                    # Configuration options for tools e.g. `pytest` or `flake8`

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -7,7 +7,7 @@ By default, Python only shows logging messages at level `WARNING` and above. Ked
 
 ## Project-side logging configuration
 
-In addition to the `rich` handler defined in Kedro's framework, the [project-side `conf/base/logging.yml`](https://github.com/kedro-org/kedro/blob/main/kedro/templates/project/%7B%7B%20cookiecutter.repo_name%20%7D%7D/conf/base/logging.yml) defines three further logging handlers:
+In addition to the `rich` handler defined in Kedro's framework, the [project-side `conf/base/logging.yml`](https://github.com/kedro-org/kedro/blob/main/kedro/templates/project/%7B%7B%20cookiecutter.repo_name%20%7D%7D/conf/base/logging.yml) defines two further logging handlers:
 * `console`: show logs on standard output (typically your terminal screen) without any rich formatting
 * `info_file_handler`: write logs of level `INFO` and above to `info.log`
 
@@ -19,7 +19,7 @@ We now give some common examples of how you might like to change your project's 
 
 ### Disable file-based logging
 
-You might sometimes need to disable file-based logging, e.g. if you are running Kedro on a read-only file system such as [Databricks Repos](https://docs.databricks.com/repos/index.html). The simplest way to do this is to delete your `conf/base/logging.yml` file. The `logs` directory can then also be safely removed. With no project-side logging configuration specified, Kedro uses the default framework-side logging configuration, which does not include any file-based handlers.
+You might sometimes need to disable file-based logging, e.g. if you are running Kedro on a read-only file system such as [Databricks Repos](https://docs.databricks.com/repos/index.html). The simplest way to do this is to delete your `conf/base/logging.yml` file. With no project-side logging configuration specified, Kedro uses the default framework-side logging configuration, which does not include any file-based handlers.
 
 Alternatively, if you would like to keep other configuration in `conf/base/logging.yml` and just disable file-based logging, then you can remove the file-based handlers from the `root` logger as follows:
 ```diff

--- a/docs/source/logging/logging.md
+++ b/docs/source/logging/logging.md
@@ -9,10 +9,9 @@ By default, Python only shows logging messages at level `WARNING` and above. Ked
 
 In addition to the `rich` handler defined in Kedro's framework, the [project-side `conf/base/logging.yml`](https://github.com/kedro-org/kedro/blob/main/kedro/templates/project/%7B%7B%20cookiecutter.repo_name%20%7D%7D/conf/base/logging.yml) defines three further logging handlers:
 * `console`: show logs on standard output (typically your terminal screen) without any rich formatting
-* `info_file_handler`: write logs of level `INFO` and above to `logs/info.log`
-* `error_file_handler`: write logs of level `ERROR` and above to `logs/error.log`
+* `info_file_handler`: write logs of level `INFO` and above to `info.log`
 
-The logging handlers that are actually used by default are `rich`, `info_file_handler` and `error_file_handler`.
+The logging handlers that are actually used by default are `rich` and `info_file_handler`.
 
 The project-side logging configuration also ensures that [logs emitted from your project's logger](#perform-logging-in-your-project) should be shown if they are `INFO` level or above (as opposed to the Python default of `WARNING`).
 
@@ -25,7 +24,7 @@ You might sometimes need to disable file-based logging, e.g. if you are running 
 Alternatively, if you would like to keep other configuration in `conf/base/logging.yml` and just disable file-based logging, then you can remove the file-based handlers from the `root` logger as follows:
 ```diff
  root:
--  handlers: [console, info_file_handler, error_file_handler]
+-  handlers: [console, info_file_handler]
 +  handlers: [console]
 ```
 
@@ -35,8 +34,8 @@ To use plain rather than rich logging, swap the `rich` handler for the `console`
 
 ```diff
  root:
--  handlers: [rich, info_file_handler, error_file_handler]
-+  handlers: [console, info_file_handler, error_file_handler]
+-  handlers: [rich, info_file_handler]
++  handlers: [console, info_file_handler]
 ```
 
 ### Rich logging in a dumb terminal

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -107,7 +107,7 @@ kedro package
 
 Kedro builds the package into the `dist` folder of the project as a `.whl` file, which is a [Python packaging format for binary distribution](https://packaging.python.org/en/latest/overview/#python-binary-distributions).
 
-The resulting `.whl` packages only contain the Python source code of the Kedro pipeline, not any of the `conf`, `data` and `logs` subfolders. This means that you can distribute the project to run elsewhere, such as on a separate computer with different configuration information, dataset and logging locations.
+The resulting `.whl` packages only contain the Python source code of the Kedro pipeline, not any of the `conf` and `data` subfolders. This means that you can distribute the project to run elsewhere, such as on a separate computer with different configuration information, dataset and logging locations.
 
 The project configuration is provided separately in a `tar.gz` file, also inside the `dist` folder. This compressed version of the config files excludes any files inside the `local` directory.
 
@@ -126,7 +126,6 @@ Once the packaged project is installed, you will need to add:
 
 * a `conf` folder
 * a `data` folder if the pipeline loads/saves local data
-* a `logs` folder if the project uses logging.
 
 Alternatively, you can make use of the ``OmegaConfigLoader`` to run the configuration directly from the compressed .tar.gz configuration file by running
 kedro run --conf-source <path-to-compressed-config>.tar.gz

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -22,12 +22,12 @@ def _is_relative_path(path_string: str) -> bool:
     Example:
     ::
         >>> _is_relative_path("data/01_raw") == True
-        >>> _is_relative_path("logs/info.log") == True
+        >>> _is_relative_path("info.log") == True
         >>> _is_relative_path("/tmp/data/01_raw") == False
-        >>> _is_relative_path(r"C:\\logs\\info.log") == False
-        >>> _is_relative_path(r"\\logs\\'info.log") == False
-        >>> _is_relative_path("c:/logs/info.log") == False
-        >>> _is_relative_path("s3://logs/info.log") == False
+        >>> _is_relative_path(r"C:\\info.log") == False
+        >>> _is_relative_path(r"\\'info.log") == False
+        >>> _is_relative_path("c:/info.log") == False
+        >>> _is_relative_path("s3://info.log") == False
 
     Args:
         path_string: The path string to check.
@@ -67,13 +67,13 @@ def _convert_paths_to_absolute_posix(
         >>>     conf_dictionary={
         >>>         "handlers": {
         >>>             "info_file_handler": {
-        >>>                 "filename": "logs/info.log"
+        >>>                 "filename": "info.log"
         >>>             }
         >>>         }
         >>>     }
         >>> )
         >>> print(conf['handlers']['info_file_handler']['filename'])
-        "/path/to/my/project/logs/info.log"
+        "/path/to/my/project/info.log"
 
     Args:
         project_path: The root directory to prepend to relative path to make absolute path.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/conf/base/logging.yml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/conf/base/logging.yml
@@ -17,17 +17,7 @@ handlers:
     class: logging.handlers.RotatingFileHandler
     level: INFO
     formatter: simple
-    filename: logs/info.log
-    maxBytes: 10485760 # 10MB
-    backupCount: 20
-    encoding: utf8
-    delay: True
-
-  error_file_handler:
-    class: logging.handlers.RotatingFileHandler
-    level: ERROR
-    formatter: simple
-    filename: logs/errors.log
+    filename: info.log
     maxBytes: 10485760 # 10MB
     backupCount: 20
     encoding: utf8
@@ -44,4 +34,4 @@ loggers:
     level: INFO
 
 root:
-  handlers: [rich, info_file_handler, error_file_handler]
+  handlers: [rich, info_file_handler]

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -17,7 +17,7 @@ from kedro.framework.cli.starters import (
     KedroStarterSpec,
 )
 
-FILES_IN_TEMPLATE = 32
+FILES_IN_TEMPLATE = 31
 
 
 @pytest.fixture


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
Part of https://github.com/kedro-org/kedro/issues/2429, Similar to https://github.com/kedro-org/kedro-starters/pull/124

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Removed `logs` folder
- Removed `error_file_handler`
- Changed `info_file_handler` filename from `logs/info.log` to `info.log`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
