### PR TITLE
Replace use of deprecated `_package_name` variable

### DIFF
--- a/docs/source/integrations/pyspark_integration.md
+++ b/docs/source/integrations/pyspark_integration.md
@@ -40,7 +40,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._package_name)
+            SparkSession.builder.appName(context._project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )

--- a/docs/source/integrations/pyspark_integration.md
+++ b/docs/source/integrations/pyspark_integration.md
@@ -40,7 +40,7 @@ class SparkHooks:
 
         # Initialise the spark session
         spark_session_conf = (
-            SparkSession.builder.appName(context._project_path.name)
+            SparkSession.builder.appName(context.project_path.name)
             .enableHiveSupport()
             .config(conf=spark_conf)
         )


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
kedro-org/kedro-starters#123

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
