### PR TITLE
remove misleading example for pandas.ParquetDataSet

### DIFF
--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -57,7 +57,6 @@ class ParquetDataSet(AbstractVersionedDataSet[pd.DataFrame, pd.DataFrame]):
             index: name
           save_args:
             compression: GZIP
-            partition_on: [name]
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\


### PR DESCRIPTION
the name `partition_on` is no longer supported by pandas (should use `partition_cols` instead) and this class explicitly reject the use of this keyword. For partition, we should use `kedro.io.PartitionedDataSet`

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
