### PR TITLE
Fix OmegaConfigLoader when file is empty

### DIFF
--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -195,7 +195,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         if not config:
             raise MissingConfigException(
                 f"No files of YAML or JSON format found in {base_path} or {env_path} matching"
-                f" the glob pattern(s): {[*self.config_patterns[key]]}"
+                f" the glob pattern(s): {[*self.config_patterns[key]]}, or the files are empty."
             )
         return config
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Currently, if you have an empty configuration file with `OmegaConfigLoader`, you will get this error which isn't very accurate. 

This draft PR is just a starting point, it's expected to be picked up by someone and worked on it further.
```
            raise MissingConfigException(
                f"No files of YAML or JSON format found in {base_path} or {env_path} matching"
                f" the glob pattern(s): {[*self.config_patterns[key]]}"
            )
```



## Possible Alternative
* Refactor the code and eliminate the need of handling it with a special condition. The code below shows that we cannot differentiate between missing and empty configs.
* If this is necessary, we should at least provide a better message (Which I think it shouldn't be, as we don't need this for the other ConfigLoader).

> Lines 276-277 don't actually cause a bug I think, so if removing them makes some tests fail and it seems related to #2556 then let's leave those here for now and try to remove them in that PR.

https://github.com/kedro-org/kedro/blob/807c4e64fb68d224a1debeafd17de6b91175a735/kedro/config/omegaconf_config.py#L274-L275

We should also take this as an opportunity to revisit the logic and see if we can simplify it
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
