### PR TITLE
[DRAFT] Dataset factory parsing rules demo

### DIFF
--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -179,7 +179,7 @@ def _add_missing_datasets_to_catalog(missing_ds, catalog_path):
 
 
 def pick_best_match(matches):
-    matches = sorted(matches, key=lambda x: (specificity(x[0]), x[0]))
+    matches = sorted(matches, key=lambda x: (specificity(x[0]), -x[0].count("{"), x[0]))
     return matches[0]
 
 

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -179,9 +179,22 @@ def _add_missing_datasets_to_catalog(missing_ds, catalog_path):
 
 
 def pick_best_match(matches):
-    # according to number of { then alphabetical
-    matches = sorted(matches, key=lambda x: (x[0].count("}"), x[0]))
+    matches = sorted(matches, key=lambda x: (specificity(x[0]), x[0]))
     return matches[0]
+
+
+def specificity(pattern):
+    """This function will check length of exactly matched characters not inside brackets
+    Example -
+    specificity("{namespace}.companies") = 10
+    specificity("{namespace}.{dataset}") = 1
+    specificity("france.companies") = 16
+    """
+    pattern_variables = parse(pattern, pattern).named
+    for k in pattern_variables:
+        pattern_variables[k] = ""
+    specific_characters = pattern.format(**pattern_variables)
+    return -len(specific_characters)
 
 
 @catalog.command("resolve")


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Related to https://github.com/kedro-org/kedro/issues/2508 
This PR is just to demonstrate/experiment with parsing rules - not the actual dataset factory prototype. 

## Development notes
<!-- What have you changed, and how has this been tested? -->
I've added a `kedro catalog resolve` (Similar to what @merelcht did in https://github.com/kedro-org/kedro/pull/2560)
For each named dataset used by the pipelines ->
It loops over all the catalog entries, finds patterns that would be a match and then selects the best match pattern (`pick_best_match` function)

### Problem Statement 
The `matches` list contains all the patterns that match the dataset name - for example for `france.companies`, all the patterns listed below would be a match -
```yaml
# Catalog Entry 1
"{namespace}.{dataset}":
  type: pandas.CSVDataSet
  filepath: path1/{namespace}_{dataset}.csv

# Catalog Entry 2
"{dataset}":
  type: pandas.CSVDataSet
  filepath: path2/{dataset}.csv

# Catalog Entry 3
"{namespace}.{a}":
  type: pandas.CSVDataSet
  filepath: path3/{namespace}_{a}.csv

# Catalog Entry 4
"{namespace}.companies":
  type: pandas.CSVDataSet
  filepath: path4/{namespace}_companies.csv

# Catalog Entry 5
france.companies:
  type: pandas.CSVDataSet
  filepath: path5/france_companies.csv

# Catalog Entry 6
"{dataset}s":
  type: pandas.CSVDataSet
  filepath: path6/{dataset}s.csv

```
We need to decide the ranked order of these entries to find the best match.

### Proposed Solution 
* Sort according to "specificity" (for the lack of a better word?) - The number of characters outside of the brackets that match. The order then would be ->
`#5 -> #4 -> #6/ #3/ #1 -> #2`
*  When "specificity" is the same - 
    * sort them according to the number of brackets? Between  `#6`, `#3` & `#1` - pick the highest number of bracket pairs. Example: `{namespace}.{dataset}` would be chosen over `{dataset}s`. 
    * either after sorting them according to bracket pairs or instead we can also sort them alphabetically. Example: `f{*}` should rank above `{*}s`

## Notes / Challenges

* When the dataset entry is too generic, for example : 
``` yaml
{dataset}:
  type: pandas.CSVDataSet
  filepath: path/path
```
The datasets that are supposed to be default/`MemoryDataSet` and parameters (eg. `params:model_input`) will falsely match against the pattern. This will lead to runtime errors and we will need to document this.

* Catalog entry 1 & 3 are basically the same thing and we could check for duplicating patterns and disallow it.



## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
