### PR TITLE
Remove mentions to `.egg` and stop producing them from `kedro package`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 ## Bug fixes and other changes
 ## Breaking changes to the API
+* `kedro package` does not produce `.egg` files anymore, and now relies exclusively on `.whl` files.
 ## Upcoming deprecations for Kedro 0.19.0
 
 

--- a/dependency/requirements.txt
+++ b/dependency/requirements.txt
@@ -1,5 +1,6 @@
 anyconfig~=0.10.0
 attrs>=21.3
+build
 cachetools~=5.3
 click<9.0
 cookiecutter>=2.1.1, <3.0

--- a/docs/source/deployment/single_machine.md
+++ b/docs/source/deployment/single_machine.md
@@ -47,22 +47,16 @@ Run the following in your project’s root directory:
 kedro package
 ```
 
-Kedro builds the package into the `dist/` folder of your project, and creates one `.egg` file and one `.whl` file, which are [Python packaging formats for binary distribution](https://packaging.python.org/overview/).
+Kedro builds the package into the `dist/` folder of your project, and creates a `.whl` file, which is [a Python packaging format for binary distribution](https://packaging.python.org/overview/).
 
-The resulting `.egg` and `.whl` packages only contain the Python source code of your Kedro pipeline, not any of the `conf/` and `data/` subfolders nor the `pyproject.toml` file.
+The resulting `.whl` package only contains the Python source code of your Kedro pipeline, not any of the `conf/` and `data/` subfolders nor the `pyproject.toml` file.
 The project configuration is packaged separately in a `tar.gz` file. This compressed version of the config files excludes any files inside your `local` directory.
 This means that you can distribute the project to run elsewhere, such as on a separate computer with different configuration, data and logging. When distributed, the packaged project must be run from within a directory that contains the `pyproject.toml` file and `conf/` subfolder (and `data/` if your pipeline loads/saves local data). This means that you will have to create these directories on the remote servers manually.
 
-Recipients of the `.egg` and `.whl` files need to have Python and `pip` set up on their machines, but do not need to have Kedro installed. The project is installed to the root of a folder with the relevant `conf/` and `data/` subfolders, by navigating to the root and calling:
+Recipients of the `.whl` file need to have Python and `pip` set up on their machines, but do not need to have Kedro installed. The project is installed to the root of a folder with the relevant `conf/` and `data/` subfolders, by navigating to the root and calling:
 
 ```console
 pip install <path-to-wheel-file>
-```
-
-Or when using the .egg file:
-
-```console
-easy_install <path-to-egg-file>
 ```
 
 After having installed your project on the remote server, run the Kedro project as follows from the root of the project:

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -357,7 +357,7 @@ A parameterised run is best used for dynamic parameters, i.e. running the same p
 
 ### Deploy the project
 
-The following packages your application as one `.egg` file  and one `.whl` file within the `dist/` folder of your project. It packages the project configuration separately in a `tar.gz` file:
+The following packages your application as one `.whl` file within the `dist/` folder of your project. It packages the project configuration separately in a `tar.gz` file:
 
 ```bash
 kedro package

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -749,9 +749,7 @@ def _generate_sdist_file(
             raise KedroCliError(f"{cls.__module__}.{cls.__qualname__}: {exc}") from exc
 
         _generate_manifest_file(temp_dir_path)
-        setup_file = _generate_setup_file(
-            package_name, version, install_requires, temp_dir_path
-        )
+        _generate_setup_file(package_name, version, install_requires, temp_dir_path)
 
         package_file = destination / _get_sdist_name(name=package_name, version=version)
 
@@ -760,14 +758,14 @@ def _generate_sdist_file(
                 f"Package file {package_file} will be overwritten!", fg="yellow"
             )
 
-        # python setup.py sdist --formats=gztar --dist-dir <destination>
+        # python -m build --sdist --outdir <destination>
         call(
             [
                 sys.executable,
-                str(setup_file.resolve()),
-                "sdist",
-                "--formats=gztar",
-                "--dist-dir",
+                "-m",
+                "build",
+                "--sdist",
+                "--outdir",
                 str(destination),
             ],
             cwd=temp_dir,

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -749,7 +749,9 @@ def _generate_sdist_file(
             raise KedroCliError(f"{cls.__module__}.{cls.__qualname__}: {exc}") from exc
 
         _generate_manifest_file(temp_dir_path)
-        _generate_setup_file(package_name, version, install_requires, temp_dir_path)
+        setup_file = _generate_setup_file(
+            package_name, version, install_requires, temp_dir_path
+        )
 
         package_file = destination / _get_sdist_name(name=package_name, version=version)
 
@@ -758,14 +760,14 @@ def _generate_sdist_file(
                 f"Package file {package_file} will be overwritten!", fg="yellow"
             )
 
-        # python -m build --sdist --outdir <destination>
+        # python setup.py sdist --formats=gztar --dist-dir <destination>
         call(
             [
                 sys.executable,
-                "-m",
-                "build",
-                "--sdist",
-                "--outdir",
+                str(setup_file.resolve()),
+                "sdist",
+                "--formats=gztar",
+                "--dist-dir",
                 str(destination),
             ],
             cwd=temp_dir,

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -148,28 +148,15 @@ def ipython(
 @project_group.command()
 @click.pass_obj  # this will pass the metadata as first argument
 def package(metadata: ProjectMetadata):
-    """Package the project as a Python egg and wheel."""
+    """Package the project as a Python wheel."""
     source_path = metadata.source_dir
     call(
         [
             sys.executable,
-            "setup.py",
-            "clean",
-            "--all",
-            "bdist_egg",
-            "--dist-dir",
-            "../dist",
-        ],
-        cwd=str(source_path),
-    )
-    call(
-        [
-            sys.executable,
-            "setup.py",
-            "clean",
-            "--all",
-            "bdist_wheel",
-            "--dist-dir",
+            "-m",
+            "build",
+            "--wheel",
+            "--outdir",
             "../dist",
         ],
         cwd=str(source_path),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -17,7 +17,7 @@ gcsfs>=2023.1, <2023.3; python_version >= '3.8'
 geopandas>=0.6.0, <1.0
 hdfs>=2.5.8, <3.0
 holoviews~=1.13.0
-import-linter[toml]==1.2.6
+import-linter[toml]==1.8.0
 ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 isort~=5.0

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -296,23 +296,10 @@ class TestPackageCommand:
                 mocker.call(
                     [
                         sys.executable,
-                        "setup.py",
-                        "clean",
-                        "--all",
-                        "bdist_egg",
-                        "--dist-dir",
-                        "../dist",
-                    ],
-                    cwd=str(fake_repo_path / "src"),
-                ),
-                mocker.call(
-                    [
-                        sys.executable,
-                        "setup.py",
-                        "clean",
-                        "--all",
-                        "bdist_wheel",
-                        "--dist-dir",
+                        "-m",
+                        "build",
+                        "--wheel",
+                        "--outdir",
                         "../dist",
                     ],
                     cwd=str(fake_repo_path / "src"),


### PR DESCRIPTION
## Description
Fix gh-2273.

~~In addition, I fixed some low-hanging fruit for gh-2414, but found some complex issues along the way (gh-2542, gh-2567) so I didn't go any further. On the other hand, the `micropkg` workflow is somewhat self-contained and is not affected by how starters look, so it can be refactored separately.~~ Reverted, see below.

## Development notes
Added https://pypi.org/project/build/ as runtime dependency.

Even though _in principle_ we should be ready to move forward with gh-2350, just to avoid any issues I think it will be better to wait until https://github.com/kedro-org/kedro/milestone/36 is complete.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
