### PR TITLE
Re-title and modify introduction to databricks testing guide in contribution section

### DIFF
--- a/docs/source/contribution/development_for_databricks.md
+++ b/docs/source/contribution/development_for_databricks.md
@@ -1,13 +1,11 @@
-# How to deploy a development version of Kedro to Databricks
+# Contribute changes to Kedro that are tested on Databricks
 
-[Databricks](https://www.databricks.com/) is a cloud-based platform for data engineering and data science that many Kedro users deploy their Kedro projects to. Extending and improving the Kedro experience on Databricks is important to a large part of Kedro's user base.
+Many Kedro users deploy their projects to [Databricks](https://www.databricks.com/), a cloud-based platform for data engineering and data science. We encourage contributions to extend and improve the experience for Kedro users on Databricks; this guide explains how to efficiently test your locally modified version of Kedro on Databricks as part of a build-and-test development cycle.
 
-## Introduction
-
-This guide describes how to efficiently develop features and fixes for Kedro on Databricks. Using this guide, you will be able to quickly test your locally modified version of Kedro on Databricks as part of a build-and-test development cycle.
+## How to deploy a development version of Kedro to Databricks
 
 ```{note}
-This page is for people developing changes to Kedro that need to test them on Databricks. If you are working on a Kedro project and need more information about workflows, consult the [documentation for developing a Kedro project on Databricks](../integrations/databricks_workspace.md).
+This page is for **contributors** developing changes to Kedro that need to test them on Databricks. If you are a Kedro user working on an individual or team project and need more information about workflows, consult the [documentation for developing a Kedro project on Databricks](../integrations/databricks_workspace.md).
 ```
 
 ## Prerequisites


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
It occurred to me that the databricks guide in the contributors section looks out of place. I understand the point of it, and it does explain the purpose, but the first sight is a bit jarring. I have given it a new (suggested) title and rephrased the text a little, just to improve the flow when you scan through the contribution section docs.

## Development notes
Changed title text, replaced subheading and reworked introduction. Rebuilt, linted and inspected.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
