### PR TITLE
Revert special logic handling DictConfig

### DIFF
--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -8,7 +8,6 @@ from typing import Any
 from urllib.parse import urlparse
 from warnings import warn
 
-from omegaconf import DictConfig
 from pluggy import PluginManager
 
 from kedro.config import ConfigLoader, MissingConfigException
@@ -93,7 +92,6 @@ def _convert_paths_to_absolute_posix(
     conf_keys_with_filepath = ("filename", "filepath", "path")
 
     for conf_key, conf_value in conf_dictionary.items():
-
         # if the conf_value is another dictionary, absolutify its paths first.
         if isinstance(conf_value, dict):
             conf_dictionary[conf_key] = _convert_paths_to_absolute_posix(
@@ -156,9 +154,7 @@ def _update_nested_dict(old_dict: dict[Any, Any], new_dict: dict[Any, Any]) -> N
         if key not in old_dict:
             old_dict[key] = value
         else:
-            if isinstance(old_dict[key], (dict, DictConfig)) and isinstance(
-                value, (dict, DictConfig)
-            ):
+            if isinstance(old_dict[key], dict) and isinstance(value, dict):
                 _update_nested_dict(old_dict[key], value)
             else:
                 old_dict[key] = value
@@ -326,7 +322,7 @@ class KedroContext:
             """
             key = f"params:{param_name}"
             feed_dict[key] = param_value
-            if isinstance(param_value, (dict, DictConfig)):
+            if isinstance(param_value, dict):
                 for key, val in param_value.items():
                     _add_param_to_feed_dict(f"{param_name}.{key}", val)
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -13,7 +13,6 @@ from pathlib import Path
 from typing import Any, Iterable
 
 import click
-from omegaconf import OmegaConf, omegaconf
 
 from kedro import __version__ as kedro_version
 from kedro.config import ConfigLoader, MissingConfigException

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -200,8 +200,6 @@ class KedroSession:
 
     def _get_logging_config(self) -> dict[str, Any]:
         logging_config = self._get_config_loader()["logging"]
-        if isinstance(logging_config, omegaconf.DictConfig):
-            logging_config = OmegaConf.to_container(logging_config)  # pragma: no cover
         # turn relative paths in logging config into absolute path
         # before initialising loggers
         logging_config = _convert_paths_to_absolute_posix(

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -12,7 +12,6 @@ import pandas as pd
 import pytest
 import toml
 import yaml
-from omegaconf import OmegaConf
 from pandas.util.testing import assert_frame_equal
 
 from kedro import __version__ as kedro_version
@@ -485,11 +484,6 @@ def test_validate_layers_error(layers, conflicting_datasets, mocker):
             {"a": {"a.a": 1, "a.b": 2, "a.c": {"a.c.a": 3}}},
             {"a": {"a.c": {"a.c.b": 4}}},
             {"a": {"a.a": 1, "a.b": 2, "a.c": {"a.c.a": 3, "a.c.b": 4}}},
-        ),
-        (
-            {"a": OmegaConf.create({"b": 1}), "x": 3},
-            {"a": {"c": 2}},
-            {"a": {"b": 1, "c": 2}, "x": 3},
         ),
     ],
 )


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Close #2561 

## Development notes
<!-- What have you changed, and how has this been tested? -->
- 45f34beeac87c899809f628efdbde642a83df3ae - Partially revert #2378, to_container is kept because we need to make sure dict is return. @ankatiyar 
  - some tests are removed because we shouldn't have any OmegaConf.DictConfig return from config
- cbe7813bd26d2f199895168321d761a5045a17e7 -  Partially revert #2176 
## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
