### PR TITLE
`OmegaConfigLoader` should not show `MissingConfigException` when the file is empty

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 
 ## Bug fixes and other changes
 * `OmegaConfigLoader` will return a `dict` instead of `DictConfig`.
+* `OmegaConfigLoader` does not show a `MissingConfigError` when the config files exist but are empty.
 
 ## Breaking changes to the API
 * `kedro package` does not produce `.egg` files anymore, and now relies exclusively on `.whl` files.

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -278,6 +278,9 @@ class OmegaConfigLoader(AbstractConfigLoader):
         aggregate_config = config_per_file.values()
         self._check_duplicates(seen_file_to_keys)
 
+        if not aggregate_config:
+            return {}
+
         if key == "parameters":
             # Merge with runtime parameters only for "parameters"
             return OmegaConf.to_container(

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -278,9 +278,6 @@ class OmegaConfigLoader(AbstractConfigLoader):
         aggregate_config = config_per_file.values()
         self._check_duplicates(seen_file_to_keys)
 
-        if not aggregate_config:
-            return {}
-
         if key == "parameters":
             # Merge with runtime parameters only for "parameters"
             return OmegaConf.to_container(

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -335,6 +335,15 @@ class TestOmegaConfigLoader:
         with pytest.raises(MissingConfigException, match=pattern):
             OmegaConfigLoader(str(tmp_path))["credentials"]
 
+    def test_empty_catalog_file(self, tmp_path):
+        """Check that empty catalog file is read and returns an empty dict"""
+        _write_yaml(tmp_path / _BASE_ENV / "catalog_empty.yml", {})
+        catalog_patterns = {"catalog": ["catalog*", "catalog*/**", "**/catalog*"]}
+        catalog = OmegaConfigLoader(
+            conf_source=tmp_path, env="base", config_patterns=catalog_patterns
+        )["catalog"]
+        assert catalog == {}
+
     def test_overlapping_patterns(self, tmp_path, mocker):
         """Check that same configuration file is not loaded more than once."""
         _write_yaml(


### PR DESCRIPTION
<!-- Why was this PR created? -->
Resolves #2566 

## Development notes
<!-- What have you changed, and how has this been tested? -->
When config files exist but are empty, OmegaConfigLoader should not throw `MissingConfigException` but pass on an empty dict. 
Solved this in a similar way to how it's handled in `ConfigLoader` -> throw `MissingConfigException` when `processed_files` which is a set of files read for a given type of config is empty. In cases where the file exists but is empty, empty dict `{}` is returned without an error. 

As opposed to `ConfigLoader` where the config for base and runtime envs is loaded in the same function call (`ConfigLoader.get()`-> `_get_config_from_patterns()`), `OmegaConfigLoader` calls `load_and_merge_dir_config()` twice for base and runtime env, I've declared `processed_files` outside and passed it as a parameter to `load_and_merge_dir_config` and kept the logic where we raise the exception outside of the function. 

Also added a unit test to `test_omega_config.py`

NOTE : 
I checked the merging logic in `load_and_merge_dir_config()` and we still need the following lines because it handles the case when no relevant config files exist for a given pattern + env. `aggregate_config` is `dict_values([])` which `OmegaConf` complains about while merging.
https://github.com/kedro-org/kedro/blob/16d8a7559573f331680fef13ad27e484e51764f6/kedro/config/omegaconf_config.py#L278-L279
## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
