### PR TITLE
Quick fix .gitpod.yml

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -22,6 +22,7 @@ tasks:
       export PIP_USER=no
       cd /workspace
       pip install -e /workspace/kedro --no-deps
+      source ~/.bashrc
       yes project | kedro new -s pandas-iris --checkout main
     command: |
       pip install -e /workspace/kedro --no-deps


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Gitpod is broken when you open a new workspace. I observe at least 2 things are not working
1. Pre-build is not happening - everything get installed when you open a new workspace and take ~5-10minutes before you can do anything
2. the template `project` isn't created because of `kedro` is not found. This is likely linked to 1.


## Development notes
<!-- What have you changed, and how has this been tested? -->
The PR simply add one step to reload `~/.bashrc`, it's unclear why the CLI isn't installed with pip, but this would work.

This PR only fix 2. as a quick hack. The pre-build stop working since GitPod move to "organisation", we create a new organisation and works for a few months but it started to fail again recently.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
