### PR TITLE
Update specs in pipeline hooks docstrings

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,6 +19,12 @@
 
 ## Breaking changes to the API
 * `kedro package` does not produce `.egg` files anymore, and now relies exclusively on `.whl` files.
+
+## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
+
+* [tomasvanpottelbergh](https://github.com/tomasvanpottelbergh)
+
 ## Upcoming deprecations for Kedro 0.19.0
 
 

--- a/kedro/framework/hooks/specs.py
+++ b/kedro/framework/hooks/specs.py
@@ -155,8 +155,10 @@ class PipelineSpecs:
                      "from_inputs": Optional[List[str]],
                      "to_outputs": Optional[List[str]],
                      "load_versions": Optional[List[str]],
-                     "pipeline_name": str,
                      "extra_params": Optional[Dict[str, Any]]
+                     "pipeline_name": str,
+                     "namespace": Optional[str],
+                     "runner": str,
                    }
 
             pipeline: The ``Pipeline`` that will be run.
@@ -190,8 +192,10 @@ class PipelineSpecs:
                      "from_inputs": Optional[List[str]],
                      "to_outputs": Optional[List[str]],
                      "load_versions": Optional[List[str]],
-                     "pipeline_name": str,
                      "extra_params": Optional[Dict[str, Any]]
+                     "pipeline_name": str,
+                     "namespace": Optional[str],
+                     "runner": str,
                    }
 
             run_result: The output of ``Pipeline`` run.
@@ -229,9 +233,12 @@ class PipelineSpecs:
                      "from_inputs": Optional[List[str]],
                      "to_outputs": Optional[List[str]],
                      "load_versions": Optional[List[str]],
-                     "pipeline_name": str,
                      "extra_params": Optional[Dict[str, Any]]
+                     "pipeline_name": str,
+                     "namespace": Optional[str],
+                     "runner": str,
                    }
+
             pipeline: The ``Pipeline`` that will was run.
             catalog: The ``DataCatalog`` used during the run.
         """


### PR DESCRIPTION
## Description

The specification of `run_params` in the docstrings of the pipeline hooks does not reflect what is actually passed [here](https://github.com/kedro-org/kedro/blob/main/kedro/framework/session/session.py#L394-L410).

## Development notes

Updated the docstrings to reflect the implementation [here](https://github.com/kedro-org/kedro/blob/main/kedro/framework/session/session.py#L394-L410).

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
