### PR TITLE
Minor modification to titles of deployment docs to replace "deprecated" with "legacy"

### DIFF
--- a/docs/source/deployment/airflow_astronomer.md
+++ b/docs/source/deployment/airflow_astronomer.md
@@ -30,7 +30,7 @@ The general strategy to deploy a Kedro pipeline on Apache Airflow is to run ever
 
 To follow this tutorial, ensure you have the following:
 
-* An Airflow cluster: you can follow [Astronomer's quickstart guide](https://docs.astronomer.io/astro/category/install-astro) to set one up.
+* An Airflow cluster: you can follow [Astronomer's quickstart guide](https://docs.astronomer.io/astro/create-deployment) to set one up.
 * The [Astro CLI installed](https://docs.astronomer.io/astro/install-cli)
 * `kedro>=0.17` installed
 

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,7 +1,7 @@
 # Argo Workflows (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 
 <div style="color:gray">This page explains how to convert your Kedro pipeline to use <a href="https://github.com/argoproj/argo-workflows">Argo Workflows</a>, an open-source container-native workflow engine for orchestrating parallel jobs on <a href="https://kubernetes.io/">Kubernetes</a>.

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,4 +1,4 @@
-# Argo Workflows (neglected documentation that needs an update)
+# Argo Workflows (outdated documentation that needs review)
 
 ``` {important}
 This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,7 +1,7 @@
 # Argo Workflows (neglected documentation that needs an update)
 
 ``` {important}
-This page contains legacy documentation that has not been tested against recent Kedro releases.
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 
 <div style="color:gray">This page explains how to convert your Kedro pipeline to use <a href="https://github.com/argoproj/argo-workflows">Argo Workflows</a>, an open-source container-native workflow engine for orchestrating parallel jobs on <a href="https://kubernetes.io/">Kubernetes</a>.

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,4 +1,4 @@
-# Argo Workflows (deprecated)
+# Argo Workflows (legacy)
 
 ``` {important}
 This page contains legacy documentation that has not been tested against recent Kedro releases.

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,7 +1,7 @@
 # Argo Workflows (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 
 <div style="color:gray">This page explains how to convert your Kedro pipeline to use <a href="https://github.com/argoproj/argo-workflows">Argo Workflows</a>, an open-source container-native workflow engine for orchestrating parallel jobs on <a href="https://kubernetes.io/">Kubernetes</a>.

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,4 +1,4 @@
-# Argo Workflows (legacy)
+# Argo Workflows (neglected documentation that needs an update)
 
 ``` {important}
 This page contains legacy documentation that has not been tested against recent Kedro releases.

--- a/docs/source/deployment/argo.md
+++ b/docs/source/deployment/argo.md
@@ -1,7 +1,7 @@
 # Argo Workflows (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 
 <div style="color:gray">This page explains how to convert your Kedro pipeline to use <a href="https://github.com/argoproj/argo-workflows">Argo Workflows</a>, an open-source container-native workflow engine for orchestrating parallel jobs on <a href="https://kubernetes.io/">Kubernetes</a>.

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,4 +1,4 @@
-# AWS Batch (neglected documentation that needs an update)
+# AWS Batch (outdated documentation that needs review)
 
 ``` {important}
 This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,7 +1,7 @@
 # AWS Batch (neglected documentation that needs an update)
 
 ``` {important}
-This page contains legacy documentation that has not been tested against recent Kedro releases.
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 <div style="color:gray">
 

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,7 +1,7 @@
 # AWS Batch (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 <div style="color:gray">
 

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,7 +1,7 @@
 # AWS Batch (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use this content with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 <div style="color:gray">
 

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,7 +1,7 @@
 # AWS Batch (outdated documentation that needs review)
 
 ``` {important}
-This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](kedro-org.slack.com) or [GitHub](https://github.com/kedro-org/kedro/issues).
+This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 ```
 <div style="color:gray">
 

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,4 +1,4 @@
-# AWS Batch (deprecated)
+# AWS Batch (legacy documentation)
 
 ``` {important}
 This page contains legacy documentation that has not been tested against recent Kedro releases.

--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -1,4 +1,4 @@
-# AWS Batch (legacy documentation)
+# AWS Batch (neglected documentation that needs an update)
 
 ``` {important}
 This page contains legacy documentation that has not been tested against recent Kedro releases.


### PR DESCRIPTION
[We received a comment](https://kedro-org.slack.com/archives/C03RKPCLYGY/p1684846615548879) that using the phrase "Deprecated" on the deployment docs for AWS Batch and Argo suggested that we didn't support those deployment approaches. In fact, it's just that the docs have not received attention of late and we can no longer guarantee them (nor can we offer to maintain them in future). That doesn't necessarily mean that we don't support those platforms, so to avoid any confusion, I've changed the page titles.