### PR TITLE
Enable variable interpolation for the catalog with `OmegaConfigLoader`

### DIFF
--- a/docs/source/configuration/advanced_configuration.md
+++ b/docs/source/configuration/advanced_configuration.md
@@ -236,9 +236,26 @@ data:
 
 Since both of the file names (`parameters.yml` and `parameters_globals.yml`) match the config pattern for parameters, the `OmegaConfigLoader` will load the files and resolve the placeholders correctly.
 
-```{note}
-Templating currently only works for parameter files, but not for catalog files.
+From Kedro `0.18.10` templating also works for catalog files. To enable templating in the catalog you need to ensure that the template values are within the catalog files or the name of the file that contains the template values follows the same config pattern specified for catalogs.
+By default, the config pattern for catalogs is: `["catalog*", "catalog*/**", "**/catalog*"]`.
+
+Additionally, any template values in the catalog need to start with an underscore `_`. This is because of how catalog entries are validated.
+
+Suppose you have one catalog file called `catalog.yml` containing entries with `omegaconf` placeholders like this:
+
+```yaml
+companies:
+  type: ${_pandas.type}
+  filepath: data/01_raw/companies.csv
 ```
+
+and a file containing the template values called `catalog_globals.yml`:
+```yaml
+_pandas:
+  type: pandas.CSVDataSet
+```
+
+Since both of the file names (`catalog.yml` and `catalog_globals.yml`) match the config pattern for catalogs, the `OmegaConfigLoader` will load the files and resolve the placeholders correctly.
 
 ### How to use custom resolvers in the `OmegaConfigLoader`
 `Omegaconf` provides functionality to [register custom resolvers](https://omegaconf.readthedocs.io/en/2.3_branch/usage.html#resolvers) for templated values. You can use these custom resolves within Kedro by extending the [`OmegaConfigLoader`](/kedro.config.OmegaConfigLoader) class.

--- a/docs/source/configuration/configuration_basics.md
+++ b/docs/source/configuration/configuration_basics.md
@@ -45,7 +45,8 @@ Kedro merges configuration information and returns a configuration dictionary ac
 * If any two configuration files located inside the **same** environment path (such as `conf/base/`) contain the same top-level key, the configuration loader raises a `ValueError` indicating that duplicates are not allowed.
 * If two configuration files contain the same top-level key but are in **different** environment paths (for example, one in `conf/base/`, another in `conf/local/`) then the last loaded path (`conf/local/`) takes precedence as the key value. `ConfigLoader.get` does not raise any errors but a `DEBUG` level log message is emitted with information on the overridden keys.
 
-When using the default `ConfigLoader` or the `TemplatedConfigLoader`, any top-level keys that start with `_` are considered hidden (or reserved) and are ignored. Those keys will neither trigger a key duplication error nor appear in the resulting configuration dictionary. However, you can still use such keys, for example, as [YAML anchors and aliases](https://www.educative.io/blog/advanced-yaml-syntax-cheatsheet#anchors).
+When using any of the configuration loaders, any top-level keys that start with `_` are considered hidden (or reserved) and are ignored. Those keys will neither trigger a key duplication error nor appear in the resulting configuration dictionary. However, you can still use such keys, for example, as [YAML anchors and aliases](https://www.educative.io/blog/advanced-yaml-syntax-cheatsheet#anchors)
+or [to enable templating in the catalog when using the `OmegaConfigLoader`](advanced_configuration.md#how-to-do-templating-with-the-omegaconfigloader).
 
 ### Configuration file names
 Configuration files will be matched according to file name and type rules. Suppose the config loader needs to fetch the catalog configuration, it will search according to the following rules:

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -286,7 +286,15 @@ class OmegaConfigLoader(AbstractConfigLoader):
             return OmegaConf.to_container(
                 OmegaConf.merge(*aggregate_config, self.runtime_params), resolve=True
             )
-        return OmegaConf.to_container(OmegaConf.merge(*aggregate_config), resolve=True)
+        # return OmegaConf.to_container(OmegaConf.merge(*aggregate_config), resolve=True)
+
+        return {
+            k: v
+            for k, v in OmegaConf.to_container(
+                OmegaConf.merge(*aggregate_config), resolve=True
+            ).items()
+            if not k.startswith("_")
+        }
 
     def _is_valid_config_path(self, path):
         """Check if given path is a file path and file type is yaml or json."""
@@ -307,7 +315,11 @@ class OmegaConfigLoader(AbstractConfigLoader):
             for filepath2 in filepaths[i:]:
                 config2 = seen_files_to_keys[filepath2]
 
-                overlapping_keys = config1 & config2
+                combined_keys = config1 & config2
+                overlapping_keys = set()
+                for key in combined_keys:
+                    if not key.startswith("_"):
+                        overlapping_keys.add(key)
 
                 if overlapping_keys:
                     sorted_keys = ", ".join(sorted(overlapping_keys))

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -609,6 +609,10 @@ class TestOmegaConfigLoader:
         assert catalog.keys() == {"k1", "k3"}
 
         _write_yaml(tmp_path / _BASE_ENV / "catalog3.yml", {"k1": "dup", "_k2": "v5"})
-        pattern = r"Duplicate keys found in .*catalog1\.yml and .*catalog3\.yml\: k1"
+        pattern = (
+            r"Duplicate keys found in "
+            r"(.*catalog1\.yml and .*catalog3\.yml|.*catalog3\.yml and .*catalog1\.yml)"
+            r"\: k1"
+        )
         with pytest.raises(ValueError, match=pattern):
             conf["catalog"]


### PR DESCRIPTION
## Description
Resolves https://github.com/kedro-org/kedro/issues/2507

## Development notes
This implementation enables variable interpolation for the catalog through a special character: `_`
Kedro users are already familiar with this syntax from using the other config loaders and was the preferred implementation after some discussion on https://github.com/kedro-org/kedro/pull/2516

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
