### PR TITLE
Add archive link on docs home page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -43,6 +43,10 @@ Welcome to Kedro's documentation!
     :target: https://slack.kedro.org
     :alt: Kedro's Slack organisation
 
+.. image:: https://img.shields.io/badge/slack-archive-blue.svg?label=Kedro%20Slack%20
+    :target: https://www.linen.dev/s/kedro
+    :alt: Kedro's Slack archive
+
 .. image:: https://img.shields.io/badge/code%20style-black-black.svg
     :target: https://github.com/psf/black
     :alt: Code style is Black


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
Created to address https://github.com/kedro-org/kedro-devrel/issues/84 by adding extra link to linen archive on the homepage of the docs.

## Development notes
Rebuilt locally

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
