### PR TITLE
Fix the level heading for collaborative experiment tracking in docs so it shows in sidebar

### DIFF
--- a/docs/source/experiment_tracking/index.md
+++ b/docs/source/experiment_tracking/index.md
@@ -95,7 +95,7 @@ This specifies the creation of the `SQLiteStore` under the `data` subfolder, usi
 This step is crucial to enable experiment tracking features on Kedro-Viz, as it is the database used to serve all run data to the Kedro-Viz front-end. Once this step is complete, you can either proceed to [set up the tracking datasets](#set-up-experiment-tracking-datasets) or [set up your nodes and pipelines to log metrics](#modify-your-nodes-and-pipelines-to-log-metrics); these two activities are interchangeable, but both should be completed to get a working experiment tracking setup.
 
 
-### Collaborative experiment tracking
+## Collaborative experiment tracking
 
 ```{note}
 To use collaborative experiment tracking, ensure that your installed version of Kedro-Viz is `>=6.2.0`.


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
I noticed in the middle of a user interview that collaborative experiment tracking is not shown in the sidebar 🤦‍♀️

## Development notes
Upgraded to second level header (from third), rebuilt.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
