### PR TITLE
Bump Pylint test_requirements.txt

### DIFF
--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -42,7 +42,7 @@ plotly>=4.8.0, <6.0
 pre-commit>=2.9.2, <3.0  # The hook `mypy` requires pre-commit version 2.9.2.
 psutil==5.8.0
 pyarrow>=1.0, <7.0
-pylint>=2.5.2, <3.0
+pylint>=2.17.0, <3.0
 pyproj~=3.0
 pyspark>=2.2, <4.0
 pytest-cov~=3.0


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Often GitPod installed a very old version of Pylint which generate a lot of false positive error. This PR intend to bump the lower bump to minimise the difference.

In Circle CI, the installed version is `2.17.4`,  GitPod version is `2.10.0` which is 2 years old already.

https://app.circleci.com/pipelines/github/kedro-org/kedro/23146/workflows/dcdff4b9-de82-4ec0-9930-988a575ad08e/jobs/266285
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
