### PR TITLE
Remove broken & unnecessary iframe from docs

### DIFF
--- a/docs/source/nodes_and_pipelines/modular_pipelines.md
+++ b/docs/source/nodes_and_pipelines/modular_pipelines.md
@@ -27,13 +27,8 @@ In this section, you will learn about how to take advantage of modular pipelines
 3. **The `kedro.pipeline.modular_pipeline.pipeline` wrapper method unlocks the real power of modular pipelines**
 
    * Applying [namespaces](https://en.wikipedia.org/wiki/Namespace) allows you to simplify your mental model and isolate 'within pipeline' processing steps.
-   * ``Kedro-Viz`` is able to accelerate development by rendering namespaced pipelines as collapsible 'super nodes'.
+   * [Kedro-Viz](https://demo.kedro.org) accelerates development by rendering namespaced pipelines as collapsible 'super nodes'.
 
-<iframe
-    src="https://demo.kedro.org"
-    width="850",
-    height="600"
-></iframe>
 
 ## How do I create a modular pipeline?
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
@ankatiyar spotted that the `iframe` was broken that showed the Kedro-Viz demo. It wasn't adding much, if anything, so I removed it and grepped to make sure we weren't using any others.

## Development notes
Rebuilt and tested.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
