### PR TITLE
Check for the whole protocol including delimited (<scheme>://) when j…

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Compare for protocol and delimiter in `PartitionedDataSet` to be able to pass the protocol to partitions which paths starts with the same characters as the protocol (e.g. `s3://s3-my-bucket`).
 
 ## Breaking changes to the API
 

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -263,10 +263,11 @@ class PartitionedDataset(AbstractDataSet):
         ]
 
     def _join_protocol(self, path: str) -> str:
-        if self._path.startswith(self._protocol) and not path.startswith(
-            self._protocol
+        protocol_prefix = f"{self._protocol}://"
+        if self._path.startswith(protocol_prefix) and not path.startswith(
+            protocol_prefix
         ):
-            return f"{self._protocol}://{path}"
+            return f"{protocol_prefix}{path}"
         return path
 
     def _partition_to_path(self, path: str):

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -401,7 +401,7 @@ class TestPartitionedDatasetLocal:
         assert pds._credentials == global_creds
 
 
-BUCKET_NAME = "fake_bucket_name"
+BUCKET_NAME = "s3_fake_bucket_name"
 S3_DATASET_DEFINITION = [
     "pandas.CSVDataSet",
     "kedro.extras.datasets.pandas.CSVDataSet",


### PR DESCRIPTION
Check for the whole protocol including delimited (<scheme>://) when joining path for partitions in partitioned data set

## Description
The PartitionedDataSet does not join the protocol properly to delegate it to its partitions. It does not work if the name of the path starts with the same letters as the protocol as it is only a startsWith comparison.

If a path starts with the prefix as same as the protocol (e.g. s3-kedro-pipeline-filesystem for a bucket) the protocol is not delegated to the partitions of the PartitionedDataSet

## Development notes
Changed from only scheme comparison to scheme plus delimited comparison.
Changed the test to use s3 as prefix for the bucket name.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
