### PR TITLE
Fix PartitionedDataset tests

### DIFF
--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -401,7 +401,7 @@ class TestPartitionedDatasetLocal:
         assert pds._credentials == global_creds
 
 
-BUCKET_NAME = "s3_fake_bucket_name"
+BUCKET_NAME = "fake_bucket_name"
 S3_DATASET_DEFINITION = [
     "pandas.CSVDataSet",
     "kedro.extras.datasets.pandas.CSVDataSet",
@@ -470,6 +470,19 @@ class TestPartitionedDatasetS3:
             for partition_id in loaded_partitions
         ]
         mocked_ds.assert_has_calls(expected, any_order=True)
+
+    @pytest.mark.parametrize(
+        "partition_path", ["s3_bucket/dummy.csv", "fake_bucket/dummy.csv"]
+    )
+    def test_join_protocol_with_bucket_name_startswith_protocol(
+        self, mocked_csvs_in_s3, partition_path
+    ):
+        """Make sure protocol is joined correctly for the edge case when
+        bucket name starts with the protocol name, i.e. `s3://s3_bucket/dummy_.txt`
+        """
+
+        pds = PartitionedDataset(mocked_csvs_in_s3, "pandas.CSVDataSet")
+        assert pds._join_protocol(partition_path) == f"s3://{partition_path}"
 
     @pytest.mark.parametrize("dataset", S3_DATASET_DEFINITION)
     def test_save(self, dataset, mocked_csvs_in_s3):


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Follow up of #2715
## Development notes
<!-- What have you changed, and how has this been tested? -->
- Revert the bucket name to `fake_bucket_name`
- Add one specific test to make sure protocol is joined correctly.  If we don't have the change of #2715, this new test will fail.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
