### PR TITLE
Update puppeteer-config.json for mermaid-cli headless warning

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -551,6 +551,7 @@ myst_heading_anchors = 5
 # https://github.com/kedro-org/kedro/issues/1772
 mermaid_output_format = "png"
 # https://github.com/mermaidjs/mermaid.cli#linux-sandbox-issue
+# https://github.com/mermaid-js/mermaid-cli/issues/544
 mermaid_params = ["-p", here / "puppeteer-config.json", "-s", "2"]
 # https://github.com/kedro-org/kedro/issues/2451
 mermaid_version = mermaid_init_js = ""

--- a/docs/source/puppeteer-config.json
+++ b/docs/source/puppeteer-config.json
@@ -1,3 +1,4 @@
 {
-  "args": ["--no-sandbox"]
+  "args": ["--no-sandbox"],
+  "headless": "old"
 }


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

I have this issue when I try to fix  https://github.com/kedro-org/kedro/pull/2688#issuecomment-1607919555 GitPod to run `make build-docs`
> > Warning, treated as error:
> mermaid code 'flowchart TD\n  A[Start] --> B{Do you prefer developing your projects in notebooks?}\n  B -->|Yes| C[Use a Databricks workspace to develop a Kedro project]\n  B -->|No| D{Are you a beginner with Kedro?}\n  D -->|Yes| E[Use an IDE, dbx and Databricks Repos to develop a Kedro project]\n  D -->|No| F{Do you have advanced project requirements<br>e.g. CI/CD, scheduling, production-ready, complex pipelines, etc.?}\n  F -->|Yes| G{Is rapid development needed for your project needs?}\n  F -->|No| H[Use an IDE, dbx and Databricks Repos to develop a Kedro project]\n  G -->|Yes| I[Use an IDE, dbx and Databricks Repos to develop a Kedro project]\n  G -->|No| J[Use a Databricks job to deploy a Kedro project]': Mermaid exited with error:
> [stderr]
> b'\x1b[1m\x1b[43m\x1b[30m\n  Puppeteer old Headless deprecation warning:\x1b[0m\x1b[33m\n    In the near feature `headless: true` will default to the new Headless mode\n    for Chrome instead of the old Headless implementation. For more\n    information, please see https://developer.chrome.com/articles/new-headless/.\n    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`\n    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.\x1b[0m\n\n\nError: Failed to launch the browser process!\n/home/gitpod/.cache/puppeteer/chrome/linux-1108766/chrome-linux/chrome: error while loading shared libraries: libatk-1.0.so.0: cannot open shared object file: No such file or directory\n\n\nTROUBLESHOOTING: https://pptr.dev/troubleshooting\n\n    at Interface.onClose (file:///home/gitpod/.nvm/versions/node/v18.16.0/lib/node_modules/@mermaid-js/mermaid-cli/node_modules/@puppeteer/browsers/lib/esm/launch.js:253:24)\n    at Interface.emit (node:events:525:35)\n    at Interface.close (node:internal/readline/interface:533:10)\n    at Socket.onend (node:internal/readline/interface:259:10)\n    at Socket.emit (node:events:525:35)\n    at endReadableNT (node:internal/streams/readable:1359:12)\n    at process.processTicksAndRejections (node:internal/process/task_queues:82:21)\n\n'
> [stdout]
> b''


 https://github.com/mermaid-js/mermaid-cli/issues/544#issuecomment-1602955907
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
