### PR TITLE
Allow any version of Python (including 3.11) in metadata

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,8 @@
 FROM gitpod/workspace-full:2023-05-08-21-16-55
 
 # Some datasets work on 3.8 only
-RUN pyenv install 3.8.15\
-    && pyenv global 3.8.15
+RUN pyenv install 3.11.1\
+    && pyenv global 3.11.1
 
 # VideoDataSet
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full
+FROM gitpod/workspace-full:2023-05-08-21-16-55
 
 # Some datasets work on 3.8 only
 RUN pyenv install 3.8.15\

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,4 +1,4 @@
-FROM gitpod/workspace-full:2023-05-08-21-16-55
+FROM gitpod/workspace-full
 
 # Some datasets work on 3.8 only
 RUN pyenv install 3.11.1\

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,8 +1,8 @@
 FROM gitpod/workspace-full
 
 # Some datasets work on 3.8 only
-RUN pyenv install 3.11.1\
-    && pyenv global 3.11.1
+RUN pyenv install 3.8.15\
+    && pyenv global 3.8.15
 
 # VideoDataSet
 RUN sudo apt-get update && sudo apt-get install -y --no-install-recommends libgl1

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -8,7 +8,6 @@ import warnings
 
 __version__ = "0.18.11"
 
-print("IMPORT KEDRO!")
 
 class KedroPythonVersionWarning(UserWarning):
     """Custom class for warnings about incompatibilities with Python versions."""
@@ -20,9 +19,10 @@ if not sys.warnoptions:
     warnings.simplefilter("error", KedroPythonVersionWarning)
 
 if sys.version_info >= (3, 11):
-    warnings.warn(KedroPythonVersionWarning(
+    warnings.warn(
         """Kedro is not yet fully compatible with this Python version.
 To proceed at your own risk and ignore this warning,
 run Kedro with `python -W "default:Kedro is not yet fully compatible" -m kedro ...`
-or set the PYTHONWARNINGS environment variable accordingly.""")
-        )
+or set the PYTHONWARNINGS environment variable accordingly.""",
+        KedroPythonVersionWarning,
+    )

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -8,6 +8,7 @@ import warnings
 
 __version__ = "0.18.11"
 
+print("IMPORT KEDRO!")
 
 class KedroPythonVersionWarning(UserWarning):
     """Custom class for warnings about incompatibilities with Python versions."""
@@ -19,10 +20,9 @@ if not sys.warnoptions:
     warnings.simplefilter("error", KedroPythonVersionWarning)
 
 if sys.version_info >= (3, 11):
-    warnings.warn(
+    warnings.warn(KedroPythonVersionWarning(
         """Kedro is not yet fully compatible with this Python version.
 To proceed at your own risk and ignore this warning,
 run Kedro with `python -W "default:Kedro is not yet fully compatible" -m kedro ...`
-or set the PYTHONWARNINGS environment variable accordingly.""",
-        KedroPythonVersionWarning,
-    )
+or set the PYTHONWARNINGS environment variable accordingly.""")
+        )

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -3,4 +3,26 @@ data pipelines by providing uniform project templates, data abstraction,
 configuration and pipeline assembly.
 """
 
+import sys
+import warnings
+
 __version__ = "0.18.11"
+
+
+class KedroPythonVersionWarning(UserWarning):
+    """Custom class for warnings about incompatibilities with Python versions."""
+
+    pass
+
+
+if not sys.warnoptions:
+    warnings.simplefilter("error", KedroPythonVersionWarning)
+
+if sys.version_info >= (3, 11):
+    warnings.warn(
+        """Kedro is not yet fully compatible with this Python version.
+To proceed at your own risk and ignore this warning,
+run Kedro with `python -W "default:Kedro is not yet fully compatible" -m kedro ...`
+or set the PYTHONWARNINGS environment variable accordingly.""",
+        KedroPythonVersionWarning,
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Kedro"}
 ]
 description = "Kedro helps you build production-ready data and analytics pipelines"
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.7"
 keywords = [
     "pipelines",
     "machine learning",

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,11 +1,32 @@
 import importlib
 import warnings
 import pytest
-from unittest.mock import patch
 
 def test_import_kedro_with_no_official_support_raise_error(mocker, monkeypatch):
     """Test importing kedro should fails with python>=3.11 should fails"""
     import kedro
+    with mocker.patch("kedro.sys"):
+        kedro.__loader__.exec_module(kedro)
+
+@pytest.mark.filterwarnings("default:Kedro")
+def test_import_kedro_success(mocker):
+    """Test importing kedro should fails with python>=3.11 should fails"""
+    import kedro
+    with mocker.patch("kedro.sys"):
+        kedro.__loader__.exec_module(kedro)
+
+def test_import_kedro_success_with_env_variable(mocker, monkeypatch):
+    """Test importing kedro should fails with python>=3.11 should fails"""
+    import kedro
+    monkeypatch.setenv("PYTHONWARNINGS", "default:Kedro")
+    with mocker.patch("kedro.sys"):
+        kedro.__loader__.exec_module(kedro)
+
+def test_import_kedro_success_with_env_variable(mocker, monkeypatch):
+    """Test importing kedro should fails with python>=3.11 should fails"""
+    import kedro
+    with mocker.patch("kedro.sys"):
+        kedro.__loader__.exec_module(kedro)
     
 @pytest.mark.filterwarnings("default:Kedro")
 def test_import_kedro_slient_warning(mocker, monkeypatch):

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,13 @@
+import importlib
+import warnings
+import pytest
+from unittest.mock import patch
+
+def test_import_kedro_with_no_official_support_raise_error(mocker, monkeypatch):
+    """Test importing kedro should fails with python>=3.11 should fails"""
+    import kedro
+    
+@pytest.mark.filterwarnings("default:Kedro")
+def test_import_kedro_slient_warning(mocker, monkeypatch):
+    """Test importing kedro when warning is silent"""
+    import kedro

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,34 +1,27 @@
-import importlib
-import warnings
 import pytest
 
-def test_import_kedro_with_no_official_support_raise_error(mocker, monkeypatch):
-    """Test importing kedro should fails with python>=3.11 should fails"""
-    import kedro
-    with mocker.patch("kedro.sys"):
+import kedro
+
+
+def test_import_kedro_with_no_official_support_raise_error(mocker):
+    """Test importing kedro with python>=3.11 should fail"""
+    mocker.patch("kedro.sys.version_info", (3, 11))
+
+    # We use the parent class to avoid issues with `exec_module`
+    with pytest.raises(UserWarning) as excinfo:
         kedro.__loader__.exec_module(kedro)
 
-@pytest.mark.filterwarnings("default:Kedro")
-def test_import_kedro_success(mocker):
-    """Test importing kedro should fails with python>=3.11 should fails"""
-    import kedro
-    with mocker.patch("kedro.sys"):
+    assert "Kedro is not yet fully compatible" in str(excinfo.value)
+
+
+def test_import_kedro_with_no_official_support_emits_warning(mocker):
+    """Test importing kedro python>=3.11 and controlled warnings should work"""
+    mocker.patch("kedro.sys.version_info", (3, 11))
+    mocker.patch("kedro.sys.warnoptions", ["default:Kedro is not yet fully compatible"])
+
+    # We use the parent class to avoid issues with `exec_module`
+    with pytest.warns(UserWarning) as record:
         kedro.__loader__.exec_module(kedro)
 
-def test_import_kedro_success_with_env_variable(mocker, monkeypatch):
-    """Test importing kedro should fails with python>=3.11 should fails"""
-    import kedro
-    monkeypatch.setenv("PYTHONWARNINGS", "default:Kedro")
-    with mocker.patch("kedro.sys"):
-        kedro.__loader__.exec_module(kedro)
-
-def test_import_kedro_success_with_env_variable(mocker, monkeypatch):
-    """Test importing kedro should fails with python>=3.11 should fails"""
-    import kedro
-    with mocker.patch("kedro.sys"):
-        kedro.__loader__.exec_module(kedro)
-    
-@pytest.mark.filterwarnings("default:Kedro")
-def test_import_kedro_slient_warning(mocker, monkeypatch):
-    """Test importing kedro when warning is silent"""
-    import kedro
+    assert len(record) == 1
+    assert "Kedro is not yet fully compatible" in record[0].message.args[0]


### PR DESCRIPTION
See https://iscinumpy.dev/post/bound-version-constraints/#pinning-the-python-version-is-special, and discussion in https://discuss.python.org/t/requires-python-upper-limits/12663?u=astrojuanlu, as well as practical problems with leaving the version cap on in https://github.com/kedro-org/kedro/issues/2270#issuecomment-1611641812.

Deliberately _not_ adding anything to the changelog, and not touching our CI systems either.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
