### PR TITLE
Safe guard KedroSession for Runner argument

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -131,7 +131,7 @@ class KedroCLI(CommandCollection):
         # subcommand, arguments and options. click doesn't store this information anywhere
         # so we have to re-do it.
         args = sys.argv[1:] if args is None else list(args)
-        self._cli_hook_manager.hook.before_command_run(  # pylint: disable=no-member
+        self._cli_hook_manager.hook.before_command_run(
             project_metadata=self._metadata, command_args=args
         )
 
@@ -146,7 +146,7 @@ class KedroCLI(CommandCollection):
         # click.core.main() method exits by default, we capture this and then
         # exit as originally intended
         except SystemExit as exc:
-            self._cli_hook_manager.hook.after_command_run(  # pylint: disable=no-member
+            self._cli_hook_manager.hook.after_command_run(
                 project_metadata=self._metadata, command_args=args, exit_code=exc.code
             )
             sys.exit(exc.code)

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -417,6 +417,10 @@ class KedroSession:
         # Run the runner
         hook_manager = self._hook_manager
         runner = runner or SequentialRunner()
+        if not isinstance(runner, AbstractRunner):
+            raise KedroSessionError(
+                "KedroSession expect an instance of Runner, make sure you are passing an instance instead of a class."
+            )
         hook_manager.hook.before_pipeline_run(  # pylint: disable=no-member
             run_params=record_data, pipeline=filtered_pipeline, catalog=catalog
         )

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -406,7 +406,7 @@ class KedroSession:
             "runner": getattr(runner, "__name__", str(runner)),
         }
 
-        catalog = context._get_catalog(
+        catalog = context._get_catalog(  # pylint: disable=protected-access
             save_version=save_version,
             load_versions=load_versions,
         )
@@ -416,7 +416,8 @@ class KedroSession:
         runner = runner or SequentialRunner()
         if not isinstance(runner, AbstractRunner):
             raise KedroSessionError(
-                "KedroSession expect an instance of Runner instead of a class. Have you forgotten the `()` at the end of the statement?"
+                "KedroSession expect an instance of Runner instead of a class."
+                "Have you forgotten the `()` at the end of the statement?"
             )
         hook_manager.hook.before_pipeline_run(
             run_params=record_data, pipeline=filtered_pipeline, catalog=catalog

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -272,9 +272,7 @@ class KedroSession:
             extra_params=extra_params,
             hook_manager=self._hook_manager,
         )
-        self._hook_manager.hook.after_context_created(  # pylint: disable=no-member
-            context=context
-        )
+        self._hook_manager.hook.after_context_created(context=context)
 
         return context
 
@@ -354,7 +352,6 @@ class KedroSession:
             These are returned in a dictionary, where the keys are defined
             by the node outputs.
         """
-        # pylint: disable=protected-access,no-member
         # Report project name
         self._logger.info("Kedro project %s", self._project_path.name)
 
@@ -419,9 +416,9 @@ class KedroSession:
         runner = runner or SequentialRunner()
         if not isinstance(runner, AbstractRunner):
             raise KedroSessionError(
-                "KedroSession expect an instance of Runner, make sure you are passing an instance instead of a class."
+                "KedroSession expect an instance of Runner instead of a class. Have you forgotten the `()` at the end of the statement?"
             )
-        hook_manager.hook.before_pipeline_run(  # pylint: disable=no-member
+        hook_manager.hook.before_pipeline_run(
             run_params=record_data, pipeline=filtered_pipeline, catalog=catalog
         )
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -22,8 +22,10 @@ from kedro.framework.project import (
     _ProjectSettings,
 )
 from kedro.framework.session import KedroSession
+from kedro.framework.session.session import KedroSessionError
 from kedro.framework.session.shelvestore import ShelveStore
 from kedro.framework.session.store import BaseSessionStore
+from kedro.runner import SequentialRunner
 
 _FAKE_PROJECT_NAME = "fake_project"
 _FAKE_PIPELINE_NAME = "fake_pipeline"
@@ -880,6 +882,28 @@ class TestKedroSession:
             pipeline=mock_pipeline,
             catalog=mock_catalog,
         )
+
+    @pytest.mark.usefixtures("mock_settings_context_class")
+    def test_session_raise_error_with_invalid_runner_instance(  # pylint: disable=too-many-locals
+        self,
+        fake_project,
+        mock_package_name,
+        mocker,
+    ):
+        mock_pipelines = mocker.patch(
+            "kedro.framework.session.session.pipelines",
+            return_value={
+                "__default__": mocker.Mock(),
+            },
+        )
+
+        session = KedroSession.create(mock_package_name, fake_project)
+        with pytest.raises(
+            KedroSessionError,
+            match="KedroSession expect an instance of Runner, make sure you are passing an instance instead of a class.",
+        ):
+            # Execute run with SequentialRunner class instead of SequentialRunner()
+            session.run(runner=SequentialRunner)
 
 
 @pytest.fixture

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -900,9 +900,7 @@ class TestKedroSession:
                 "__default__": mocker.Mock(),
             },
         )
-        mock_runner_class = mocker.patch(
-            "kedro.runner.SequentialRunner", auto_spec=True
-        )
+        mock_runner_class = mocker.patch("kedro.runner.SequentialRunner")
 
         session = KedroSession.create(mock_package_name, fake_project)
         with pytest.raises(

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -25,7 +25,6 @@ from kedro.framework.session import KedroSession
 from kedro.framework.session.session import KedroSessionError
 from kedro.framework.session.shelvestore import ShelveStore
 from kedro.framework.session.store import BaseSessionStore
-from kedro.runner import SequentialRunner
 
 _FAKE_PROJECT_NAME = "fake_project"
 _FAKE_PIPELINE_NAME = "fake_pipeline"
@@ -41,6 +40,16 @@ class BadConfigLoader:  # pylint: disable=too-few-public-methods
     """
     ConfigLoader class that doesn't subclass `AbstractConfigLoader`, for testing only.
     """
+
+
+@pytest.fixture
+def mock_runner(mocker):
+    mock_runner = mocker.patch(
+        "kedro.runner.sequential_runner.SequentialRunner",
+        autospec=True,
+    )
+    mock_runner.__name__ = "MockRunner"
+    return mock_runner
 
 
 @pytest.fixture
@@ -590,6 +599,7 @@ class TestKedroSession:
         fake_pipeline_name,
         mock_context_class,
         mock_package_name,
+        mock_runner,
         mocker,
     ):
         """Test running the project via the session"""
@@ -606,10 +616,6 @@ class TestKedroSession:
         )
         mock_context = mock_context_class.return_value
         mock_catalog = mock_context._get_catalog.return_value
-        mock_runner = mocker.patch(
-            "kedro.runner.sequential_runner.SequentialRunner",
-            autospec=True,
-        )
         mock_runner.__name__ = "SequentialRunner"
         mock_pipeline = mock_pipelines.__getitem__.return_value.filter.return_value
 
@@ -656,6 +662,7 @@ class TestKedroSession:
         fake_pipeline_name,
         mock_context_class,
         mock_package_name,
+        mock_runner,
         mocker,
     ):
         """Test running the project more than once via the session"""
@@ -672,8 +679,6 @@ class TestKedroSession:
         )
         mock_context = mock_context_class.return_value
         mock_catalog = mock_context._get_catalog.return_value
-        mock_runner = mocker.Mock()
-        mock_runner.__name__ = "SequentialRunner"
         mock_pipeline = mock_pipelines.__getitem__.return_value.filter.return_value
 
         message = (
@@ -720,12 +725,9 @@ class TestKedroSession:
         )
 
     @pytest.mark.usefixtures("mock_settings_context_class")
-    def test_run_non_existent_pipeline(self, fake_project, mock_package_name, mocker):
-        mock_runner = mocker.patch(
-            "kedro.runner.sequential_runner.SequentialRunner",
-            autospec=True,
-        )
-        mock_runner.__name__ = "SequentialRunner"
+    def test_run_non_existent_pipeline(
+        self, fake_project, mock_package_name, mock_runner
+    ):
 
         pattern = (
             "Failed to find the pipeline named 'doesnotexist'. "
@@ -745,6 +747,7 @@ class TestKedroSession:
         fake_pipeline_name,
         mock_context_class,
         mock_package_name,
+        mock_runner,
         mocker,
     ):
         """Test exception being raised during the run"""
@@ -761,11 +764,6 @@ class TestKedroSession:
         mock_context = mock_context_class.return_value
         mock_catalog = mock_context._get_catalog.return_value
         error = FakeException("You shall not pass!")
-        mock_runner = mocker.patch(
-            "kedro.runner.sequential_runner.SequentialRunner",
-            autospec=True,
-        )
-        mock_runner.__name__ = "SequentialRunner"
         mock_runner.run.side_effect = error  # runner.run() raises an error
         mock_pipeline = mock_pipelines.__getitem__.return_value.filter.return_value
 
@@ -815,6 +813,7 @@ class TestKedroSession:
         fake_pipeline_name,
         mock_context_class,
         mock_package_name,
+        mock_runner,
         mocker,
     ):
         """Test exception being raised during the first run and
@@ -831,13 +830,17 @@ class TestKedroSession:
         )
         mock_context = mock_context_class.return_value
         mock_catalog = mock_context._get_catalog.return_value
+        session = KedroSession.create(mock_package_name, fake_project)
+
+        broken_runner = mocker.patch(
+            "kedro.runner.SequentialRunner",
+            autospec=True,
+        )
+        broken_runner.__name__ = "BrokenRunner"
         error = FakeException("You shall not pass!")
-        broken_runner = mocker.Mock()
-        broken_runner.__name__ = "SequentialRunner"
         broken_runner.run.side_effect = error  # runner.run() raises an error
         mock_pipeline = mock_pipelines.__getitem__.return_value.filter.return_value
 
-        session = KedroSession.create(mock_package_name, fake_project)
         with pytest.raises(FakeException):
             # Execute run with broken runner
             session.run(runner=broken_runner, pipeline_name=fake_pipeline_name)
@@ -869,13 +872,14 @@ class TestKedroSession:
         mock_hook.after_pipeline_run.assert_not_called()
 
         # Execute run another time with fixed runner
-        fixed_runner = mocker.Mock()
-        fixed_runner.__name__ = "SequentialRunner"
+        fixed_runner = mock_runner
         session.run(runner=fixed_runner, pipeline_name=fake_pipeline_name)
 
         fixed_runner.run.assert_called_once_with(
             mock_pipeline, mock_catalog, session._hook_manager, fake_session_id
         )
+
+        record_data["runner"] = "MockRunner"
         mock_hook.after_pipeline_run.assert_called_once_with(
             run_params=record_data,
             run_result=fixed_runner.run.return_value,
@@ -884,26 +888,29 @@ class TestKedroSession:
         )
 
     @pytest.mark.usefixtures("mock_settings_context_class")
-    def test_session_raise_error_with_invalid_runner_instance(  # pylint: disable=too-many-locals
+    def test_session_raise_error_with_invalid_runner_instance(
         self,
         fake_project,
         mock_package_name,
         mocker,
     ):
-        mock_pipelines = mocker.patch(
+        mocker.patch(
             "kedro.framework.session.session.pipelines",
             return_value={
                 "__default__": mocker.Mock(),
             },
         )
+        mock_runner_class = mocker.patch(
+            "kedro.runner.SequentialRunner", auto_spec=True
+        )
 
         session = KedroSession.create(mock_package_name, fake_project)
         with pytest.raises(
             KedroSessionError,
-            match="KedroSession expect an instance of Runner, make sure you are passing an instance instead of a class.",
+            match="KedroSession expect an instance of Runner instead of a class.",
         ):
             # Execute run with SequentialRunner class instead of SequentialRunner()
-            session.run(runner=SequentialRunner)
+            session.run(runner=mock_runner_class)
 
 
 @pytest.fixture


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
This is created as a quick attempt to fix thing as it was asked in Slack today.

Currently when user passed a Runner class instead of Runner(), Kedro gives a very subtle error which is not helpful. We can add a simple checks here to make sure user don't fall into the trap.

This is the error you get if you pass `session.run(runner=SequentialRunner)` instead of `session.run(runner=SequentialRunner())`
```
     54 """Run the ``Pipeline`` using the datasets provided by ``catalog``
     55 and save results back to the same objects.
     56 
   (...)
     70 
     71 """
     73 hook_manager = hook_manager or _NullPluginManager()
---> 74 catalog = catalog.shallow_copy()
     76 unsatisfied = pipeline.inputs() - set(catalog.list())
     77 if unsatisfied:

AttributeError: 'PluginManager' object has no attribute 'shallow_copy'
```

Same goes for Hook when we expect a instance `Hook()` instead of `Hook`, this confuse user sometimes.
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
