### PR TITLE
Add warning for catch-all patterns [dataset factories]

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -386,6 +386,13 @@ class DataCatalog:
                 self._load_versions.get(data_set_name),
                 self._save_version,
             )
+            if self._specificity(matched_pattern) == 0:
+                self._logger.warning(
+                    "The dataset '%s' is using the catch-all pattern '%s'",
+                    data_set_name,
+                    matched_pattern,
+                )
+
             self.add(data_set_name, data_set)
         if data_set_name not in self._data_sets:
             error_msg = f"Dataset '{data_set_name}' not found in the catalog"

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -388,9 +388,10 @@ class DataCatalog:
             )
             if self._specificity(matched_pattern) == 0:
                 self._logger.warning(
-                    "The dataset '%s' is using the catch-all pattern '%s'",
-                    data_set_name,
+                    "Config from the dataset factory pattern '%s' in the catalog will be used to "
+                    "override the default MemoryDataset creation for the dataset '%s'",
                     matched_pattern,
+                    data_set_name,
                 )
 
             self.add(data_set_name, data_set)

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -826,8 +826,9 @@ class TestDataCatalogDatasetFactories:
         log_record = caplog.records[0]
         assert log_record.levelname == "WARNING"
         assert (
-            "The dataset 'jet@planes' is using the catch-all pattern '{default_dataset}'"
-            in log_record.message
+            "Config from the dataset factory pattern '{default_dataset}' "
+            "in the catalog will be used to override the default "
+            "MemoryDataset creation for the dataset 'jet@planes'" in log_record.message
         )
         assert isinstance(jet_dataset, CSVDataSet)
 

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -818,11 +818,17 @@ class TestDataCatalogDatasetFactories:
         ]
         assert list(catalog._dataset_patterns.keys()) == sorted_keys_expected
 
-    def test_default_dataset(self, config_with_dataset_factories_with_default):
+    def test_default_dataset(self, config_with_dataset_factories_with_default, caplog):
         """Check that default dataset is used when no other pattern matches"""
         catalog = DataCatalog.from_config(**config_with_dataset_factories_with_default)
         assert "jet@planes" not in catalog._data_sets
         jet_dataset = catalog._get_dataset("jet@planes")
+        log_record = caplog.records[0]
+        assert log_record.levelname == "WARNING"
+        assert (
+            "The dataset 'jet@planes' is using the catch-all pattern '{default_dataset}'"
+            in log_record.message
+        )
         assert isinstance(jet_dataset, CSVDataSet)
 
     def test_unmatched_key_error_when_parsing_config(


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Fix #2760

## Development notes
<!-- What have you changed, and how has this been tested? -->
Since this is a small change, I thought I'll add it to the main Dataset Factories PR #2635.

Throw a warning at the first instance that the dataset is used (and added to the catalog) 
## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
