### PR TITLE
Add `kedro catalog factory list` CLI command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 * Added dataset factories feature which uses pattern matching to reduce the number of catalog entries.
 * Activated all built-in resolvers by default for `OmegaConfigLoader` except for `oc.env`.
+* Added `kedro catalog factories` CLI command.
 
 ## Bug fixes and other changes
 * Updated `kedro catalog list` to work with dataset factories.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,7 +13,7 @@
 ## Major features and improvements
 * Added dataset factories feature which uses pattern matching to reduce the number of catalog entries.
 * Activated all built-in resolvers by default for `OmegaConfigLoader` except for `oc.env`.
-* Added `kedro catalog factories` CLI command.
+* Added `kedro catalog factory list` CLI command.
 
 ## Bug fixes and other changes
 * Updated `kedro catalog list` to work with dataset factories.

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -179,7 +179,7 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
         click.echo("All datasets are already configured.")
 
 
-@catalog.command("factories")
+@catalog.command("factory list")
 @env_option
 @click.pass_obj
 def list_patterns(metadata: ProjectMetadata, env):

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -193,7 +193,10 @@ def list_factories(metadata: ProjectMetadata, env):
     context = session.load_context()
 
     catalog_factories = context.catalog._dataset_patterns
-    click.echo(yaml.dump(list(catalog_factories.keys())))
+    if catalog_factories:
+        click.echo(yaml.dump(list(catalog_factories.keys())))
+    else:
+        click.echo("There are no dataset factories in the catalog.")
 
 
 def _add_missing_datasets_to_catalog(missing_ds, catalog_path):

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -179,7 +179,11 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
         click.echo("All datasets are already configured.")
 
 
-@catalog.command("factory list")
+@catalog.group()
+def factory():
+    """Command for working with catalog factories"""
+
+@factory.command("list")
 @env_option
 @click.pass_obj
 def list_patterns(metadata: ProjectMetadata, env):

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -179,6 +179,18 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
         click.echo("All datasets are already configured.")
 
 
+@catalog.command("factories")
+@env_option
+@click.pass_obj
+def list_patterns(metadata: ProjectMetadata, env):
+    "Show all factory patterns in catalog, ranked by priority by which they are matched"
+    session = _create_session(metadata.package_name, env=env)
+    context = session.load_context()
+
+    catalog_factories = context.catalog._dataset_patterns
+    click.echo(yaml.dump(list(catalog_factories.keys())))
+
+
 def _add_missing_datasets_to_catalog(missing_ds, catalog_path):
     if catalog_path.is_file():
         catalog_config = yaml.safe_load(catalog_path.read_text()) or {}

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -181,13 +181,14 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
 
 @catalog.group()
 def factory():
-    """Command for working with catalog factories"""
+    """Commands for working with catalog dataset factories"""
+
 
 @factory.command("list")
 @env_option
 @click.pass_obj
-def list_patterns(metadata: ProjectMetadata, env):
-    "Show all factory patterns in the catalog, ranked by priority by which they are matched."
+def list_factories(metadata: ProjectMetadata, env):
+    """Show all dataset factories in the catalog, ranked by priority by which they are matched."""
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -183,7 +183,7 @@ def create_catalog(metadata: ProjectMetadata, pipeline_name, env):
 @env_option
 @click.pass_obj
 def list_patterns(metadata: ProjectMetadata, env):
-    "Show all factory patterns in catalog, ranked by priority by which they are matched"
+    "Show all factory patterns in the catalog, ranked by priority by which they are matched."
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -419,3 +419,28 @@ def test_list_catalog_factories(
 
     assert yaml_dump_mock.call_count == 1
     assert yaml_dump_mock.call_args[0][0] == expected_patterns_sorted
+
+
+@pytest.mark.usefixtures(
+    "chdir_to_dummy_project",
+    "fake_load_context",
+)
+def test_list_factories_with_no_factories(
+    fake_project_cli, fake_metadata, fake_load_context
+):
+    mocked_context = fake_load_context.return_value
+
+    catalog_data_sets = {
+        "iris_data": CSVDataSet("test.csv"),
+        "intermediate": MemoryDataset(),
+        "not_used": CSVDataSet("test2.csv"),
+    }
+    mocked_context.catalog = DataCatalog(data_sets=catalog_data_sets)
+
+    result = CliRunner().invoke(
+        fake_project_cli, ["catalog", "factory", "list"], obj=fake_metadata
+    )
+
+    assert not result.exit_code
+    expected_output = "There are no dataset factories in the catalog."
+    assert expected_output in result.output

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -406,7 +406,7 @@ def test_list_catalog_factories(
     )
 
     result = CliRunner().invoke(
-        fake_project_cli, ["catalog", "factory list"], obj=fake_metadata
+        fake_project_cli, ["catalog", "factory", "list"], obj=fake_metadata
     )
     assert not result.exit_code
 

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -397,7 +397,9 @@ def test_list_catalog_factories(
 ):
     yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
     mocked_context = fake_load_context.return_value
-    mocked_context.catalog = DataCatalog.from_config(fake_catalog_with_overlapping_factories)
+    mocked_context.catalog = DataCatalog.from_config(
+        fake_catalog_with_overlapping_factories
+    )
 
     result = CliRunner().invoke(
         fake_project_cli, ["catalog", "factories"], obj=fake_metadata

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -45,6 +45,10 @@ def fake_catalog_config():
 @pytest.fixture
 def fake_catalog_with_overlapping_factories():
     config = {
+        "an_example_dataset": {
+            "type": "pandas.CSVDataSet",
+            "filepath": "dummy_filepath",
+        },
         "an_example_{placeholder}": {
             "type": "dummy_type",
             "filepath": "dummy_filepath",

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -45,10 +45,10 @@ def fake_catalog_config():
 @pytest.fixture
 def fake_catalog_with_factories():
     config = {
-        "some_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "a_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "b_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "other_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
+        "an_example_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
+        "an_example_{place}_{holder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
+        "on_{example_placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
+        "an_{example_placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
     }
     return config
 
@@ -393,10 +393,10 @@ def test_list_catalog_factories(
     assert not result.exit_code
 
     expected_patterns_sorted = [
-        "other_{placeholder}",
-        "some_{placeholder}",
-        "a_{placeholder}",
-        "b_{placeholder}",
+        "an_example_{place}_{holder}",
+        "an_example_{placeholder}",
+        "an_{example_placeholder}",
+        "on_{example_placeholder}",
     ]
 
     assert yaml_dump_mock.call_count == 1

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -402,7 +402,7 @@ def test_list_catalog_factories(
     )
 
     result = CliRunner().invoke(
-        fake_project_cli, ["catalog", "factories"], obj=fake_metadata
+        fake_project_cli, ["catalog", "factory list"], obj=fake_metadata
     )
     assert not result.exit_code
 

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -43,7 +43,7 @@ def fake_catalog_config():
 
 
 @pytest.fixture
-def fake_catalog_with_factories():
+def fake_catalog_with_overlapping_factories():
     config = {
         "an_example_{placeholder}": {
             "type": "dummy_type",
@@ -393,11 +393,11 @@ def test_list_catalog_factories(
     fake_metadata,
     mocker,
     fake_load_context,
-    fake_catalog_with_factories,
+    fake_catalog_with_overlapping_factories,
 ):
     yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
     mocked_context = fake_load_context.return_value
-    mocked_context.catalog = DataCatalog.from_config(fake_catalog_with_factories)
+    mocked_context.catalog = DataCatalog.from_config(fake_catalog_with_overlapping_factories)
 
     result = CliRunner().invoke(
         fake_project_cli, ["catalog", "factories"], obj=fake_metadata

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -45,10 +45,22 @@ def fake_catalog_config():
 @pytest.fixture
 def fake_catalog_with_factories():
     config = {
-        "an_example_{placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "an_example_{place}_{holder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "on_{example_placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
-        "an_{example_placeholder}": {"type": "dummy_type", "filepath": "dummy_filepath"},
+        "an_example_{placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "an_example_{place}_{holder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "on_{example_placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "an_{example_placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
     }
     return config
 

--- a/tests/tools/test_cli.py
+++ b/tests/tools/test_cli.py
@@ -139,18 +139,18 @@ class TestCLITools:
         assert isinstance(help_cli_structure, dict)
         assert isinstance(help_cli_structure["kedro"], dict)
 
-        self.recursive_cli_structure_test(help_cli_structure["kedro"])
+        self.recursively_check_cli_structure(help_cli_structure["kedro"])
 
         assert sorted(list(help_cli_structure["kedro"])) == sorted(
             DEFAULT_KEDRO_COMMANDS
         )
 
-    def recursive_cli_structure_test(self, structure):
+    def recursively_check_cli_structure(self, structure):
         for k, v in structure.items():
             assert isinstance(k, str)
             if isinstance(v, str):
                 assert v.startswith("Usage:  [OPTIONS]")
             elif isinstance(v, dict):
-                self.recursive_cli_structure_test(v)
+                self.recursively_check_cli_structure(v)
             else:  # Should never be reached
                 pytest.fail()

--- a/tests/tools/test_cli.py
+++ b/tests/tools/test_cli.py
@@ -139,14 +139,14 @@ class TestCLITools:
         assert isinstance(help_cli_structure, dict)
         assert isinstance(help_cli_structure["kedro"], dict)
 
-        for k, v in help_cli_structure["kedro"].items():
+        cli_commands = list(help_cli_structure["kedro"].items())
+
+        while cli_commands:
+            k, v = cli_commands[0]
+            cli_commands.pop(0)
             assert isinstance(k, str)
             if isinstance(v, dict):
-                for sub_key in v:
-                    assert isinstance(help_cli_structure["kedro"][k][sub_key], str)
-                    assert help_cli_structure["kedro"][k][sub_key].startswith(
-                        "Usage:  [OPTIONS]"
-                    )
+                cli_commands = cli_commands + list(v.items())
             elif isinstance(v, str):
                 assert v.startswith("Usage:  [OPTIONS]")
 

--- a/tests/tools/test_cli.py
+++ b/tests/tools/test_cli.py
@@ -139,17 +139,18 @@ class TestCLITools:
         assert isinstance(help_cli_structure, dict)
         assert isinstance(help_cli_structure["kedro"], dict)
 
-        cli_commands = list(help_cli_structure["kedro"].items())
-
-        while cli_commands:
-            k, v = cli_commands[0]
-            cli_commands.pop(0)
-            assert isinstance(k, str)
-            if isinstance(v, dict):
-                cli_commands = cli_commands + list(v.items())
-            elif isinstance(v, str):
-                assert v.startswith("Usage:  [OPTIONS]")
+        self.recursive_cli_structure_test(help_cli_structure["kedro"])
 
         assert sorted(list(help_cli_structure["kedro"])) == sorted(
             DEFAULT_KEDRO_COMMANDS
         )
+
+    def recursive_cli_structure_test(self, structure):
+        for k, v in structure.items():
+            assert isinstance(k, str)
+            if isinstance(v, str):
+                assert v.startswith("Usage:  [OPTIONS]")
+            elif isinstance(v, dict):
+                self.recursive_cli_structure_test(v)
+            else:  # Should never be reached
+                pytest.fail()


### PR DESCRIPTION
Ignore the target branch for now, #2793 to be merged first.

## Description
This PR introduces the command `kedro catalog factory list \<edited\> which lists out all dataset factories in the catalog config in order of how they are matched (i.e. if an explicitly named dataset could match several of the factories in the catalog, it would be resolved with the first on the list.)

The priority is determined as such:
1. Decreasing specificity (number of characters outside the curly brackets)
2. Decreasing number of placeholders (number of curly bracket pairs)
3. Alphabetically

### Question for reviewers
An alternative suggestion for the name of the command was `kedro catalog patterns`. I went with factories to attempt to streamline the terminology used in the docs and other communications, but am otherwise impartial. Any thoughts on this?

#### Added note on streamlining the terminology
It looks like `dataset factory` is equiv to `factory pattern`, `catalog factory`, `dataset pattern`, `dataset factory pattern` and others that have been used interchangeably. As per #2670 any mentions of a catalog entry that makes use of placeholders will be referred to as a `dataset factory`. `Catalog factories` refer to all dataset factories within a specific catalog.

## What this means in practice / Why this is useful
As seen in the test case, a catalog is created with the following patterns:

1. `an_example_{place}_{holder}`,
2.  `an_example_{placeholder}`,
3.  `an_{example_placeholder}`,
5.  `on_{example_placeholder}`,

The explicitly declared `an_example_data_set` could match any of patterns 1, 2, or 3: `an_example_{data}_{set}`, `an_example_{data_set}`, `an_{example_data_set}`. Priority matching means that it will be resolved with the first pattern.
`kedro catalog factories` allows users to confirm the order in which factory patterns are considered for matching.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
