### PR TITLE
Correct release for dataset factories to 0.18.12

### DIFF
--- a/docs/source/data/data_catalog.md
+++ b/docs/source/data/data_catalog.md
@@ -462,7 +462,7 @@ airplanes:
 In this example, the default `csv` configuration is inserted into `airplanes` and then the `load_args` block is overridden. Normally, that would replace the whole dictionary. In order to extend `load_args`, the defaults for that block are then re-inserted.
 
 ## Load multiple datasets with similar configuration using dataset factories
-For catalog entries that share configuration details, you can also use the dataset factories introduced in Kedro 0.18.11. This syntax allows you to generalise the configuration and
+For catalog entries that share configuration details, you can also use the dataset factories introduced in Kedro 0.18.12. This syntax allows you to generalise the configuration and
 reduce the number of similar catalog entries by matching datasets used in your project's pipelines to dataset factory patterns.
 
 ### Example 1: Generalise datasets with similar names and types into one dataset factory


### PR DESCRIPTION
## Description
Dataset factories weren't released in `0.18.11`, so changing that to be `0.18.12`

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
