### PR TITLE
Update modular_pipelines.md  in docs to make it clear that `params:` are namespaced

### DIFF
--- a/docs/source/nodes_and_pipelines/modular_pipelines.md
+++ b/docs/source/nodes_and_pipelines/modular_pipelines.md
@@ -240,10 +240,6 @@ final_pipeline = (
 * Namespaces can also be arbitrarily nested with the `.` character.
 * `kedro run --namespace=<namespace>` could be used to only run nodes with a specific namespace.
 
-```{note}
-Parameter references (`params:` and `parameters`) will not be namespaced.
-```
-
 </details>
 
 ## How to use a modular pipeline with different parameters

--- a/docs/source/nodes_and_pipelines/modular_pipelines.md
+++ b/docs/source/nodes_and_pipelines/modular_pipelines.md
@@ -241,7 +241,7 @@ final_pipeline = (
 * `kedro run --namespace=<namespace>` could be used to only run nodes with a specific namespace.
 
 ```{note}
-Parameter references (`params:`) will also be namespaced except for `parameters`.
+`parameters` references will not be namespaced, but `params:` references will.
 ```
 </details>
 

--- a/docs/source/nodes_and_pipelines/modular_pipelines.md
+++ b/docs/source/nodes_and_pipelines/modular_pipelines.md
@@ -240,6 +240,9 @@ final_pipeline = (
 * Namespaces can also be arbitrarily nested with the `.` character.
 * `kedro run --namespace=<namespace>` could be used to only run nodes with a specific namespace.
 
+```{note}
+Parameter references (`params:`) will also be namespaced except for `parameters`.
+```
 </details>
 
 ## How to use a modular pipeline with different parameters


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
https://github.com/kedro-org/kedro/issues/971 Suggest that `params:` will be prefixed, which conflict the docs.
## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
