### PR TITLE
Add `kedro catalog rank` command

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 ## Major features and improvements
 * Added dataset factories feature which uses pattern matching to reduce the number of catalog entries.
 * Activated all built-in resolvers by default for `OmegaConfigLoader` except for `oc.env`.
+* Added `kedro catalog rank` CLI command.
 
 ## Bug fixes and other changes
 * Consolidated dependencies and optional dependencies in `pyproject.toml`.

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -62,6 +62,7 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro build-docs`](#build-the-project-documentation) (deprecated from version 0.19.0)
   * [`kedro build-reqs`](#build-the-projects-dependency-tree) (deprecated from version 0.19.0)
   * [`kedro catalog list`](#list-datasets-per-pipeline-per-type)
+  * [`kedro catalog rank`](#rank-dataset-factories-in-the-catalog)
   * [`kedro catalog create`](#create-a-data-catalog-yaml-configuration-file)
   * [`kedro ipython`](#notebooks)
   * [`kedro jupyter convert`](#copy-tagged-cells) (deprecated from version 0.19.0)
@@ -490,6 +491,14 @@ The command also accepts an optional `--pipeline` argument that allows you to sp
 ```bash
 kedro catalog list --pipeline=ds,de
 ```
+
+##### Rank dataset factories in the catalog
+
+```bash
+kedro catalog rank
+```
+
+The output includes a list of any [dataset factories](../data/data_catalog.md#load-multiple-datasets-with-similar-configuration-using-dataset-factories) in the catalog, ranked by the priority on which they are matched against.
 
 #### Data Catalog
 

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -174,3 +174,18 @@ def _add_missing_datasets_to_catalog(missing_ds, catalog_path):
     catalog_path.parent.mkdir(exist_ok=True)
     with catalog_path.open(mode="w") as catalog_file:
         yaml.safe_dump(catalog_config, catalog_file, default_flow_style=False)
+
+
+@catalog.command("rank")
+@env_option
+@click.pass_obj
+def rank_catalog_factories(metadata: ProjectMetadata, env):
+    """List all dataset factories in the catalog, ranked by priority by which they are matched."""
+    session = _create_session(metadata.package_name, env=env)
+    context = session.load_context()
+
+    catalog_factories = context.catalog._dataset_patterns
+    if catalog_factories:
+        click.echo(yaml.dump(list(catalog_factories.keys())))
+    else:
+        click.echo("There are no dataset factories in the catalog.")

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -363,3 +363,27 @@ def test_rank_catalog_factories(
 
     assert yaml_dump_mock.call_count == 1
     assert yaml_dump_mock.call_args[0][0] == expected_patterns_sorted
+
+@pytest.mark.usefixtures(
+    "chdir_to_dummy_project",
+    "fake_load_context",
+)
+def test_rank_catalog_factories_with_no_factories(
+    fake_project_cli, fake_metadata, fake_load_context
+):
+    mocked_context = fake_load_context.return_value
+
+    catalog_data_sets = {
+        "iris_data": CSVDataSet("test.csv"),
+        "intermediate": MemoryDataset(),
+        "not_used": CSVDataSet("test2.csv"),
+    }
+    mocked_context.catalog = DataCatalog(data_sets=catalog_data_sets)
+
+    result = CliRunner().invoke(
+        fake_project_cli, ["catalog", "rank"], obj=fake_metadata
+    )
+
+    assert not result.exit_code
+    expected_output = "There are no dataset factories in the catalog."
+    assert expected_output in result.output

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -29,6 +29,31 @@ def mock_pipelines(mocker):
     }
     return mocker.patch("kedro.framework.cli.catalog.pipelines", dummy_pipelines)
 
+@pytest.fixture
+def fake_catalog_with_overlapping_factories():
+    config = {
+        "an_example_dataset": {
+            "type": "pandas.CSVDataSet",
+            "filepath": "dummy_filepath",
+        },
+        "an_example_{placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "an_example_{place}_{holder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "on_{example_placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+        "an_{example_placeholder}": {
+            "type": "dummy_type",
+            "filepath": "dummy_filepath",
+        },
+    }
+    return config
 
 @pytest.mark.usefixtures(
     "chdir_to_dummy_project", "fake_load_context", "mock_pipelines"
@@ -307,3 +332,34 @@ class TestCatalogCreateCommand:
 
         assert result.exit_code
         assert "Unable to instantiate Kedro session" in result.output
+
+@pytest.mark.usefixtures(
+    "chdir_to_dummy_project", "fake_load_context", "mock_pipelines"
+)
+def test_rank_catalog_factories(
+    fake_project_cli,
+    fake_metadata,
+    mocker,
+    fake_load_context,
+    fake_catalog_with_overlapping_factories,
+):
+    yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
+    mocked_context = fake_load_context.return_value
+    mocked_context.catalog = DataCatalog.from_config(
+        fake_catalog_with_overlapping_factories
+    )
+
+    result = CliRunner().invoke(
+        fake_project_cli, ["catalog", "rank"], obj=fake_metadata
+    )
+    assert not result.exit_code
+
+    expected_patterns_sorted = [
+        "an_example_{place}_{holder}",
+        "an_example_{placeholder}",
+        "an_{example_placeholder}",
+        "on_{example_placeholder}",
+    ]
+
+    assert yaml_dump_mock.call_count == 1
+    assert yaml_dump_mock.call_args[0][0] == expected_patterns_sorted

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -29,6 +29,7 @@ def mock_pipelines(mocker):
     }
     return mocker.patch("kedro.framework.cli.catalog.pipelines", dummy_pipelines)
 
+
 @pytest.fixture
 def fake_catalog_with_overlapping_factories():
     config = {
@@ -54,6 +55,7 @@ def fake_catalog_with_overlapping_factories():
         },
     }
     return config
+
 
 @pytest.mark.usefixtures(
     "chdir_to_dummy_project", "fake_load_context", "mock_pipelines"
@@ -333,6 +335,7 @@ class TestCatalogCreateCommand:
         assert result.exit_code
         assert "Unable to instantiate Kedro session" in result.output
 
+
 @pytest.mark.usefixtures(
     "chdir_to_dummy_project", "fake_load_context", "mock_pipelines"
 )
@@ -363,6 +366,7 @@ def test_rank_catalog_factories(
 
     assert yaml_dump_mock.call_count == 1
     assert yaml_dump_mock.call_args[0][0] == expected_patterns_sorted
+
 
 @pytest.mark.usefixtures(
     "chdir_to_dummy_project",


### PR DESCRIPTION
Takes over #2796 

## Description
This PR introduces the command `kedro catalog rank` which ranks all dataset factories in the catalog config in the order of how they are matched (i.e. if an explicitly named dataset could match several of the factories in the catalog, it would be resolved with the first on the list.)

The priority is determined as such:
1. Decreasing specificity (number of characters outside the curly brackets)
2. Decreasing number of placeholders (number of curly bracket pairs)
3. Alphabetically

#### Added note on streamlining the terminology
It looks like `dataset factory` is equiv to `factory pattern`, `catalog factory`, `dataset pattern`, `dataset factory pattern` and others that have been used interchangeably. As per #2670 any mentions of a catalog entry that makes use of placeholders will be referred to as a `dataset factory`. `Catalog factories` refer to all dataset factories within a specific catalog.

## What this means in practice / Why this is useful
As seen in the test case, a catalog is created with the following patterns:

1. `an_example_{place}_{holder}`,
2.  `an_example_{placeholder}`,
3.  `an_{example_placeholder}`,
5.  `on_{example_placeholder}`,

The explicitly declared `an_example_data_set` could match any of patterns 1, 2, or 3: `an_example_{data}_{set}`, `an_example_{data_set}`, `an_{example_data_set}`. Priority matching means that it will be resolved with the first pattern.
`kedro catalog factories` allows users to confirm the order in which factory patterns are considered for matching.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
