### PR TITLE
Docs: ensure section title is visible when linked via a hash in the URL

### DIFF
--- a/docs/source/_static/css/theme-overrides.css
+++ b/docs/source/_static/css/theme-overrides.css
@@ -26,3 +26,10 @@ img[alt^="mermaid-"] {
 .rst-content .important .admonition-title {
   background-color: #f0b37e;
 }
+
+/* Ensure the section title is visible when linked via a hash in the URL */
+:target:before {
+  content: "";
+  display: block;
+  height: 80px;
+}


### PR DESCRIPTION
## Description

When a user visits a URL such at this, https://docs.kedro.org/en/latest/nodes_and_pipelines/pipeline_registry.html#pipeline-autodiscovery, you can't see the section title, in this case `Pipeline autodiscovery`. This should fix that.

<img width="1480" alt="image" src="https://github.com/kedro-org/kedro/assets/16869061/25a48bd3-a5a6-4ae4-a8a2-8e02f26beac5">

## Development notes

Added a small CSS property to fix this.

## QA notes

We'll need to test this on the RTD build for this branch.

Update (from Tynan): seems to be working well.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
