### PR TITLE
Trigger only docs build when release notes updated

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -7,12 +7,14 @@ on:
       - develop
     paths-ignore:
       - "docs/**"
+      - '**.md'
   pull_request:
     branches:
       - main
       - develop
     paths-ignore:
       - "docs/**"
+      - '**.md'
 
 jobs:
   unit-tests:

--- a/.github/workflows/docs-only-checks.yml
+++ b/.github/workflows/docs-only-checks.yml
@@ -7,12 +7,14 @@ on:
       - develop
     paths:
       - "docs/**"
+      - '**.md'
   pull_request:
     branches:
       - main
       - develop
     paths:
       - "docs/**"
+      - '**.md'
 
 jobs:
   lint-tests:


### PR DESCRIPTION
## Description
While working on https://github.com/kedro-org/kedro/pull/2887 I noticed that when I updated the release notes all code build were triggered even though the only changes in that PR are to the docs an release notes. 

I added an extra path filter to the Github actions to only run the docs build when `.md` files are updated. 

## Development notes
I tested this by branching of this branch and triggering a GA build for this branch temporarily (https://github.com/kedro-org/kedro/pull/2908). There might be a better way to do this though? @ankatiyar / @SajidAlamQB 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
