### PR TITLE
Make `vale` linter only run when PR opened or reopened

### DIFF
--- a/.github/workflows/docs-language-linter.yml
+++ b/.github/workflows/docs-language-linter.yml
@@ -1,6 +1,7 @@
 name: Language Linter for Kedro Docs
 on:
   pull_request:
+    types: [opened, reopened]
     paths:
       - "docs/**"
       - '**.md'


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
The vale action currently does a whole round of review with each push on a PR. Some of the which comments are spurious are marked as resolved the first time are left as comments again. 
Solution:
Only run the linter when PR is opened or reopened.
If we want to run it again, we can trigger it manually on the PR under "Checks"

Eg - https://github.com/kedro-org/kedro/pull/2904

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
