### PR TITLE
Load micropackage dependencies statically

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ description = "Kedro helps you build production-ready data and analytics pipelin
 requires-python = ">=3.8"
 dependencies = [
     "attrs>=21.3",
-    "build>=0.7.0",
     "cachetools>=4.1",
     "click>=4.0",
     "cookiecutter>=2.1.1,<3.0",
@@ -29,6 +28,7 @@ dependencies = [
     "parse>=1.19.0",
     "pluggy>=1.0",
     "pre-commit-hooks",
+    "pyproject_metadata",
     "PyYAML>=4.2,<7.0",
     "rich>=12.0,<14.0",
     "rope>=0.21,<2.0",  # subject to LGPLv3 license

--- a/tests/framework/cli/micropkg/test_micropkg_pull.py
+++ b/tests/framework/cli/micropkg/test_micropkg_pull.py
@@ -584,17 +584,6 @@ class TestMicropkgPullCommand:
             return_value=tmp_path,
         )
 
-        # Mock needed to avoid an error when build.util.project_wheel_metadata
-        # calls tempfile.TemporaryDirectory, which is mocked
-        class _FakeWheelMetadata:
-            def get_all(self, name, failobj=None):
-                return []
-
-        mocker.patch(
-            "kedro.framework.cli.micropkg.project_wheel_metadata",
-            return_value=_FakeWheelMetadata(),
-        )
-
         options = ["-e", env] if env else []
         options += ["--alias", alias] if alias else []
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
This avoids building the wheel in an isolated environment just to extract the dependencies.

Cons: It relies on a PEP-621 compliant `pyproject.toml` file to be present, which only happens for Kedro projects created after https://github.com/kedro-org/kedro/issues/2280 was closed. Therefore, it is backwards incompatible.

Pros: It makes `kedro micropkg pull` fast again, cutting the time to run the full test suite in ~half (from 12 to 7 minutes on Linux, from 14 to 6 minutes on Windows 🎉)

## Development notes
<!-- What have you changed, and how has this been tested? -->
This uses `pyproject-metadata` instead of PyPA/build, see https://pypi.org/project/pyproject-metadata/

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
