### PR TITLE
Fix docstrings on kedro/extras/datasets

### DIFF
--- a/docs/source/kedro_datasets.rst
+++ b/docs/source/kedro_datasets.rst
@@ -41,6 +41,7 @@ kedro_datasets
    kedro_datasets.plotly.JSONDataSet
    kedro_datasets.plotly.PlotlyDataSet
    kedro_datasets.polars.CSVDataSet
+   kedro_datasets.polars.GenericDataSet
    kedro_datasets.redis.PickleDataSet
    kedro_datasets.snowflake.SnowparkTableDataSet
    kedro_datasets.spark.DeltaTableDataSet

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -17,9 +17,9 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
     """``APIDataSet`` loads the data from HTTP(S) APIs.
     It uses the python requests library: https://requests.readthedocs.io/en/latest/
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -36,7 +36,7 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.api import APIDataSet

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -17,9 +17,10 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
     """``APIDataSet`` loads the data from HTTP(S) APIs.
     It uses the python requests library: https://requests.readthedocs.io/en/latest/
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -36,8 +36,7 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.api import APIDataSet
         >>>

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -37,8 +37,7 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.api import APIDataSet
         >>>

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -36,7 +36,9 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.api import APIDataSet
         >>>

--- a/kedro/extras/datasets/dask/parquet_dataset.py
+++ b/kedro/extras/datasets/dask/parquet_dataset.py
@@ -22,7 +22,7 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -38,7 +38,7 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.dask import ParquetDataSet

--- a/kedro/extras/datasets/dask/parquet_dataset.py
+++ b/kedro/extras/datasets/dask/parquet_dataset.py
@@ -38,8 +38,7 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.dask import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/dask/parquet_dataset.py
+++ b/kedro/extras/datasets/dask/parquet_dataset.py
@@ -39,8 +39,8 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
+    ::
 
-    .. code-block:: python
 
         >>> from kedro.extras.datasets.dask import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/dask/parquet_dataset.py
+++ b/kedro/extras/datasets/dask/parquet_dataset.py
@@ -38,7 +38,9 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.dask import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -27,7 +27,7 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -40,7 +40,7 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.json import JSONDataSet

--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -40,7 +40,9 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.json import JSONDataSet
         >>>

--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -40,8 +40,7 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.json import JSONDataSet
         >>>

--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -41,8 +41,7 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.json import JSONDataSet
         >>>

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -33,7 +33,7 @@ class MatplotlibWriter(
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -45,7 +45,7 @@ class MatplotlibWriter(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> import matplotlib.pyplot as plt

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -46,8 +46,7 @@ class MatplotlibWriter(
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> import matplotlib.pyplot as plt
         >>> from kedro.extras.datasets.matplotlib import MatplotlibWriter

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -45,8 +45,7 @@ class MatplotlibWriter(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> import matplotlib.pyplot as plt
         >>> from kedro.extras.datasets.matplotlib import MatplotlibWriter

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -45,7 +45,9 @@ class MatplotlibWriter(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> import matplotlib.pyplot as plt
         >>> from kedro.extras.datasets.matplotlib import MatplotlibWriter

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -32,7 +32,7 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -54,7 +54,7 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import CSVDataSet

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -54,8 +54,7 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import CSVDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -54,7 +54,9 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import CSVDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -55,8 +55,7 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import CSVDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -37,7 +37,7 @@ class ExcelDataSet(
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -58,7 +58,7 @@ class ExcelDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import ExcelDataSet
@@ -78,7 +78,7 @@ class ExcelDataSet(
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_
+    data_catalog_yaml_examples.html>`_
     for a multi-sheet Excel file:
 
     .. code-block:: yaml
@@ -91,7 +91,7 @@ class ExcelDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_
+    advanced_data_catalog_usage.html>`_
     for a multi-sheet Excel file:
     ::
 

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -59,8 +59,7 @@ class ExcelDataSet(
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import ExcelDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -58,7 +58,9 @@ class ExcelDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import ExcelDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -58,8 +58,7 @@ class ExcelDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import ExcelDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -34,7 +34,7 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -52,7 +52,7 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import FeatherDataSet

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -52,8 +52,7 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import FeatherDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -52,7 +52,9 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import FeatherDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -53,8 +53,7 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import FeatherDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -31,7 +31,7 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -48,7 +48,7 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import GBQTableDataSet

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -49,8 +49,7 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import GBQTableDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -48,8 +48,7 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import GBQTableDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -48,7 +48,9 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import GBQTableDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -41,7 +41,7 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -71,7 +71,7 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import GenericDataSet

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -71,7 +71,9 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import GenericDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -72,8 +72,7 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import GenericDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -71,8 +71,7 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import GenericDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -42,8 +42,7 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import HDFDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -28,9 +28,9 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``HDFDataSet`` loads/saves data from/to a hdf file using an underlying
     filesystem (e.g. local, S3, GCS). It uses pandas.HDFStore to handle the hdf file.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -42,7 +42,7 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import HDFDataSet

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -43,8 +43,7 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import HDFDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -28,9 +28,10 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``HDFDataSet`` loads/saves data from/to a hdf file using an underlying
     filesystem (e.g. local, S3, GCS). It uses pandas.HDFStore to handle the hdf file.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -42,7 +42,9 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import HDFDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -50,8 +50,7 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import JSONDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -30,9 +30,10 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``JSONDataSet`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the json file.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -49,8 +49,7 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import JSONDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -49,7 +49,9 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import JSONDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -30,9 +30,9 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``JSONDataSet`` loads/saves data from/to a JSON file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the json file.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -49,7 +49,7 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import JSONDataSet

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -62,8 +62,7 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -61,7 +61,9 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -31,9 +31,10 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``ParquetDataSet`` loads/saves data from/to a Parquet file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -31,9 +31,9 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     """``ParquetDataSet`` loads/saves data from/to a Parquet file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses pandas to handle the Parquet file.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -61,7 +61,7 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import ParquetDataSet

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -61,8 +61,7 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import ParquetDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -132,7 +132,9 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import SQLTableDataSet
         >>> import pandas as pd
@@ -310,7 +312,9 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import SQLQueryDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -132,8 +132,7 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import SQLTableDataSet
         >>> import pandas as pd
@@ -311,8 +310,7 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import SQLQueryDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -107,9 +107,10 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
     the data with no index. This is designed to make load and save methods
     symmetric.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 
@@ -278,9 +279,10 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
     To save data to a SQL server use ``SQLTableDataSet``.
 
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -107,9 +107,9 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
     the data with no index. This is designed to make load and save methods
     symmetric.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -132,7 +132,7 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import SQLTableDataSet
@@ -278,9 +278,9 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
     To save data to a SQL server use ``SQLTableDataSet``.
 
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -311,7 +311,7 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import SQLQueryDataSet

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -133,8 +133,7 @@ class SQLTableDataSet(AbstractDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import SQLTableDataSet
         >>> import pandas as pd
@@ -313,8 +312,8 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
+    ::
 
-    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import SQLQueryDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -32,7 +32,7 @@ class XMLDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pandas import XMLDataSet

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -32,8 +32,7 @@ class XMLDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pandas import XMLDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -33,8 +33,7 @@ class XMLDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pandas import XMLDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -32,7 +32,9 @@ class XMLDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pandas import XMLDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -50,8 +50,7 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pickle import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -51,8 +51,7 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pickle import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -29,9 +29,10 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
     the specified backend library passed in (defaults to the ``pickle`` library), so it
     supports all allowed options for loading and saving pickle files.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -29,9 +29,9 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
     the specified backend library passed in (defaults to the ``pickle`` library), so it
     supports all allowed options for loading and saving pickle files.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -50,7 +50,7 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pickle import PickleDataSet

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -50,7 +50,9 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pickle import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/pillow/image_dataset.py
+++ b/kedro/extras/datasets/pillow/image_dataset.py
@@ -27,7 +27,7 @@ class ImageDataSet(AbstractVersionedDataset[Image.Image, Image.Image]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.pillow import ImageDataSet

--- a/kedro/extras/datasets/pillow/image_dataset.py
+++ b/kedro/extras/datasets/pillow/image_dataset.py
@@ -27,8 +27,7 @@ class ImageDataSet(AbstractVersionedDataset[Image.Image, Image.Image]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.pillow import ImageDataSet
         >>>

--- a/kedro/extras/datasets/pillow/image_dataset.py
+++ b/kedro/extras/datasets/pillow/image_dataset.py
@@ -27,7 +27,9 @@ class ImageDataSet(AbstractVersionedDataset[Image.Image, Image.Image]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.pillow import ImageDataSet
         >>>

--- a/kedro/extras/datasets/pillow/image_dataset.py
+++ b/kedro/extras/datasets/pillow/image_dataset.py
@@ -28,8 +28,7 @@ class ImageDataSet(AbstractVersionedDataset[Image.Image, Image.Image]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.pillow import ImageDataSet
         >>>

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -41,7 +41,9 @@ class JSONDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.plotly import JSONDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -41,8 +41,7 @@ class JSONDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.plotly import JSONDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -42,8 +42,7 @@ class JSONDataSet(
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.plotly import JSONDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -27,9 +27,9 @@ class JSONDataSet(
     """``JSONDataSet`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -41,7 +41,7 @@ class JSONDataSet(
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.plotly import JSONDataSet

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -27,9 +27,10 @@ class JSONDataSet(
     """``JSONDataSet`` loads/saves a plotly figure from/to a JSON file using an
     underlying filesystem (e.g.: local, S3, GCS).
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -26,9 +26,9 @@ class PlotlyDataSet(JSONDataSet):
     ``PlotlyDataSet`` is a convenience wrapper for ``plotly.JSONDataSet``. It generates
     the JSON file directly from a pandas DataFrame through ``plotly_args``.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -48,7 +48,7 @@ class PlotlyDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.plotly import PlotlyDataSet

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -49,8 +49,7 @@ class PlotlyDataSet(JSONDataSet):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.plotly import PlotlyDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -48,8 +48,7 @@ class PlotlyDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.plotly import PlotlyDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -48,7 +48,9 @@ class PlotlyDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.plotly import PlotlyDataSet
         >>> import plotly.express as px

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -26,9 +26,10 @@ class PlotlyDataSet(JSONDataSet):
     ``PlotlyDataSet`` is a convenience wrapper for ``plotly.JSONDataSet``. It generates
     the JSON file directly from a pandas DataFrame through ``plotly_args``.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -22,9 +22,10 @@ class PickleDataSet(AbstractDataset[Any, Any]):
     all allowed options for instantiating the redis app ``from_url`` and setting
     a value.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -45,7 +45,9 @@ class PickleDataSet(AbstractDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.redis import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -22,9 +22,9 @@ class PickleDataSet(AbstractDataset[Any, Any]):
     all allowed options for instantiating the redis app ``from_url`` and setting
     a value.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -45,7 +45,7 @@ class PickleDataSet(AbstractDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.redis import PickleDataSet

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -46,8 +46,7 @@ class PickleDataSet(AbstractDataset[Any, Any]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.redis import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -45,8 +45,7 @@ class PickleDataSet(AbstractDataset[Any, Any]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.redis import PickleDataSet
         >>> import pandas as pd

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -22,9 +22,9 @@ from kedro.io.core import AbstractDataset, DatasetError
 class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
     """``DeltaTableDataSet`` loads data into DeltaTable objects.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -39,7 +39,7 @@ class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from pyspark.sql import SparkSession

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -22,9 +22,10 @@ from kedro.io.core import AbstractDataset, DatasetError
 class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
     """``DeltaTableDataSet`` loads data into DeltaTable objects.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -39,8 +39,7 @@ class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -40,8 +40,7 @@ class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/deltatable_dataset.py
+++ b/kedro/extras/datasets/spark/deltatable_dataset.py
@@ -39,7 +39,9 @@ class DeltaTableDataSet(AbstractDataset[None, DeltaTable]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -202,8 +202,7 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -201,7 +201,9 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -201,8 +201,7 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -165,9 +165,10 @@ class KedroHdfsInsecureClient(InsecureClient):
 class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
     """``SparkDataSet`` loads and saves Spark dataframes.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -165,9 +165,9 @@ class KedroHdfsInsecureClient(InsecureClient):
 class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
     """``SparkDataSet`` loads and saves Spark dataframes.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -201,7 +201,7 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from pyspark.sql import SparkSession

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -31,9 +31,9 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
     to external changes to the target table while executing.
     Upsert methodology works by leveraging Spark DataFrame execution plan checkpointing.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -45,7 +45,7 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from pyspark.sql import SparkSession

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -45,8 +45,7 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -45,7 +45,9 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -46,8 +46,7 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from pyspark.sql import SparkSession
         >>> from pyspark.sql.types import (StructField, StringType,

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -31,9 +31,10 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
     to external changes to the target table while executing.
     Upsert methodology works by leveraging Spark DataFrame execution plan checkpointing.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -21,9 +21,9 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
     ``pyspark.sql.DataFrameReader`` and ``pyspark.sql.DataFrameWriter``
     internally, so it supports all allowed PySpark options on ``jdbc``.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -41,7 +41,7 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> import pandas as pd

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -42,8 +42,7 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> import pandas as pd
         >>>

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -41,8 +41,7 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> import pandas as pd
         >>>

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -21,9 +21,10 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
     ``pyspark.sql.DataFrameReader`` and ``pyspark.sql.DataFrameWriter``
     internally, so it supports all allowed PySpark options on ``jdbc``.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -41,7 +41,9 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> import pandas as pd
         >>>

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -71,8 +71,7 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.svmlight import SVMLightDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -43,9 +43,9 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
     This format is used as the default format for both svmlight and the
     libsvm command line programs.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -70,7 +70,7 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.svmlight import SVMLightDataSet

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -70,8 +70,7 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.svmlight import SVMLightDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -43,9 +43,10 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
     This format is used as the default format for both svmlight and the
     libsvm command line programs.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -70,7 +70,9 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.svmlight import SVMLightDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -48,8 +48,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.tensorflow import TensorFlowModelDataset
         >>> import tensorflow as tf

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -47,7 +47,9 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.tensorflow import TensorFlowModelDataset
         >>> import tensorflow as tf

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -29,9 +29,9 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     The underlying functionality is supported by, and passes input arguments through to,
     TensorFlow 2.X load_model and save_model methods.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -47,7 +47,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.tensorflow import TensorFlowModelDataset

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -29,9 +29,10 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     The underlying functionality is supported by, and passes input arguments through to,
     TensorFlow 2.X load_model and save_model methods.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -47,8 +47,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.tensorflow import TensorFlowModelDataset
         >>> import tensorflow as tf

--- a/kedro/extras/datasets/text/text_dataset.py
+++ b/kedro/extras/datasets/text/text_dataset.py
@@ -36,8 +36,7 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.text import TextDataSet
         >>>

--- a/kedro/extras/datasets/text/text_dataset.py
+++ b/kedro/extras/datasets/text/text_dataset.py
@@ -24,9 +24,9 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
     """``TextDataSet`` loads/saves data from/to a text file using an underlying
     filesystem (e.g.: local, S3, GCS)
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -36,7 +36,7 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.text import TextDataSet

--- a/kedro/extras/datasets/text/text_dataset.py
+++ b/kedro/extras/datasets/text/text_dataset.py
@@ -24,9 +24,10 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
     """``TextDataSet`` loads/saves data from/to a text file using an underlying
     filesystem (e.g.: local, S3, GCS)
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/text/text_dataset.py
+++ b/kedro/extras/datasets/text/text_dataset.py
@@ -36,7 +36,9 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.text import TextDataSet
         >>>

--- a/kedro/extras/datasets/text/text_dataset.py
+++ b/kedro/extras/datasets/text/text_dataset.py
@@ -37,8 +37,7 @@ class TextDataSet(AbstractVersionedDataset[str, str]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.text import TextDataSet
         >>>

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -18,9 +18,10 @@ class JSONDataSet(JDS):
     The ``JSONDataSet`` is part of Kedro Experiment Tracking.
     The dataset is write-only and it is versioned by default.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -30,8 +30,7 @@ class JSONDataSet(JDS):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.tracking import JSONDataSet
         >>>

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -31,8 +31,7 @@ class JSONDataSet(JDS):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.tracking import JSONDataSet
         >>>

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -18,9 +18,9 @@ class JSONDataSet(JDS):
     The ``JSONDataSet`` is part of Kedro Experiment Tracking.
     The dataset is write-only and it is versioned by default.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -30,7 +30,7 @@ class JSONDataSet(JDS):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.tracking import JSONDataSet

--- a/kedro/extras/datasets/tracking/json_dataset.py
+++ b/kedro/extras/datasets/tracking/json_dataset.py
@@ -30,7 +30,9 @@ class JSONDataSet(JDS):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.tracking import JSONDataSet
         >>>

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -32,8 +32,7 @@ class MetricsDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.tracking import MetricsDataSet
         >>>

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -20,9 +20,9 @@ class MetricsDataSet(JSONDataSet):
     ``MetricsDataSet`` is part of Kedro Experiment Tracking. The dataset is write-only,
     it is versioned by default and only takes metrics of numeric values.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -32,7 +32,7 @@ class MetricsDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.tracking import MetricsDataSet

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -32,7 +32,9 @@ class MetricsDataSet(JSONDataSet):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.tracking import MetricsDataSet
         >>>

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -20,9 +20,10 @@ class MetricsDataSet(JSONDataSet):
     ``MetricsDataSet`` is part of Kedro Experiment Tracking. The dataset is write-only,
     it is versioned by default and only takes metrics of numeric values.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/tracking/metrics_dataset.py
+++ b/kedro/extras/datasets/tracking/metrics_dataset.py
@@ -33,8 +33,7 @@ class MetricsDataSet(JSONDataSet):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.tracking import MetricsDataSet
         >>>

--- a/kedro/extras/datasets/video/video_dataset.py
+++ b/kedro/extras/datasets/video/video_dataset.py
@@ -213,7 +213,9 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.video import VideoDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/video/video_dataset.py
+++ b/kedro/extras/datasets/video/video_dataset.py
@@ -196,9 +196,10 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
     """``VideoDataSet`` loads / save video data from a given filepath as sequence
     of PIL.Image.Image using OpenCV.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/video/video_dataset.py
+++ b/kedro/extras/datasets/video/video_dataset.py
@@ -196,9 +196,9 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
     """``VideoDataSet`` loads / save video data from a given filepath as sequence
     of PIL.Image.Image using OpenCV.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -213,7 +213,7 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.video import VideoDataSet

--- a/kedro/extras/datasets/video/video_dataset.py
+++ b/kedro/extras/datasets/video/video_dataset.py
@@ -214,8 +214,7 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.video import VideoDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/video/video_dataset.py
+++ b/kedro/extras/datasets/video/video_dataset.py
@@ -213,8 +213,7 @@ class VideoDataSet(AbstractDataset[AbstractVideo, AbstractVideo]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.video import VideoDataSet
         >>> import numpy as np

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -25,9 +25,10 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
     """``YAMLDataSet`` loads/saves data from/to a YAML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses PyYAML to handle the YAML file.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -37,8 +37,7 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> from kedro.extras.datasets.yaml import YAMLDataSet
         >>>

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -37,7 +37,9 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> from kedro.extras.datasets.yaml import YAMLDataSet
         >>>

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -25,9 +25,9 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
     """``YAMLDataSet`` loads/saves data from/to a YAML file using an underlying
     filesystem (e.g.: local, S3, GCS). It uses PyYAML to handle the YAML file.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -37,7 +37,7 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> from kedro.extras.datasets.yaml import YAMLDataSet

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -38,8 +38,7 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> from kedro.extras.datasets.yaml import YAMLDataSet
         >>>

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -434,7 +434,7 @@ class IncrementalDataset(PartitionedDataset):
                 the dataset or the checkpoint configuration contains explicit
                 credentials spec, then such spec will take precedence.
                 All possible credentials management scenarios are documented here:
-                https://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#partitioned-datasets
+                https://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#checkpoint-configuration
             load_args: Keyword arguments to be passed into ``find()`` method of
                 the filesystem implementation.
             fs_args: Extra arguments to pass into underlying filesystem class constructor

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -43,8 +43,8 @@ class PartitionedDataset(AbstractDataset):
     https://github.com/intake/filesystem_spec.
 
     It also supports advanced features like
-    `lazy saving <https://kedro.readthedocs.io/en/stable/data/\
-    kedro_io.html#partitioned-dataset-lazy-saving>`_.
+    `lazy saving <https://docs.kedro.org/en/stable/data/\
+    partitioned_and_incremental_datasets.html#partitioned-dataset-lazy-saving>`_.
 
     Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -419,7 +419,7 @@ class IncrementalDataset(PartitionedDataset):
                 with the corresponding dataset definition including ``filepath``
                 (unlike ``dataset`` argument). Checkpoint configuration is
                 described here:
-                https://kedro.readthedocs.io/en/stable/data/kedro_io.html#checkpoint-configuration
+                https://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#checkpoint-configuration
                 Credentials for the checkpoint can be explicitly specified
                 in this configuration.
             filepath_arg: Underlying dataset initializer argument that will
@@ -434,7 +434,7 @@ class IncrementalDataset(PartitionedDataset):
                 the dataset or the checkpoint configuration contains explicit
                 credentials spec, then such spec will take precedence.
                 All possible credentials management scenarios are documented here:
-                https://kedro.readthedocs.io/en/stable/data/kedro_io.html#partitioned-dataset-credentials
+                https://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#partitioned-datasets
             load_args: Keyword arguments to be passed into ``find()`` method of
                 the filesystem implementation.
             fs_args: Extra arguments to pass into underlying filesystem class constructor

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -179,7 +179,7 @@ class PartitionedDataset(AbstractDataset):
                 and the dataset initializer. If the dataset config contains
                 explicit credentials spec, then such spec will take precedence.
                 All possible credentials management scenarios are documented here:
-                https://kedro.readthedocs.io/en/stable/data/kedro_io.html#partitioned-dataset-credentials
+                https://kedro.readthedocs.io/en/stable/data/kedro.io.PartitionedDataset.html
             load_args: Keyword arguments to be passed into ``find()`` method of
                 the filesystem implementation.
             fs_args: Extra arguments to pass into underlying filesystem class constructor

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -67,8 +67,7 @@ class PartitionedDataset(AbstractDataset):
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
     advanced_data_catalog_usage.html>`_:
-
-    .. code-block:: python
+    ::
 
         >>> import pandas as pd
         >>> from kedro.io import PartitionedDataset

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -66,7 +66,9 @@ class PartitionedDataset(AbstractDataset):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_: ::
+    advanced_data_catalog_usage.html>`_:
+
+    .. code-block:: python
 
         >>> import pandas as pd
         >>> from kedro.io import PartitionedDataset

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -46,9 +46,10 @@ class PartitionedDataset(AbstractDataset):
     `lazy saving <https://kedro.readthedocs.io/en/stable/data/\
     kedro_io.html#partitioned-dataset-lazy-saving>`_.
 
-        Example usage for the
+    Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
     data_catalog_yaml_examples.html>`_:
+
 
     .. code-block:: yaml
 

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -66,8 +66,7 @@ class PartitionedDataset(AbstractDataset):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    advanced_data_catalog_usage.html>`_:
-    ::
+    advanced_data_catalog_usage.html>`_: ::
 
         >>> import pandas as pd
         >>> from kedro.io import PartitionedDataset

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -46,9 +46,9 @@ class PartitionedDataset(AbstractDataset):
     `lazy saving <https://kedro.readthedocs.io/en/stable/data/\
     kedro_io.html#partitioned-dataset-lazy-saving>`_.
 
-    Example usage for the
+        Example usage for the
     `YAML API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-yaml-api>`_:
+    data_catalog_yaml_examples.html>`_:
 
     .. code-block:: yaml
 
@@ -66,7 +66,7 @@ class PartitionedDataset(AbstractDataset):
 
     Example usage for the
     `Python API <https://kedro.readthedocs.io/en/stable/data/\
-    data_catalog.html#use-the-data-catalog-with-the-code-api>`_:
+    advanced_data_catalog_usage.html>`_:
     ::
 
         >>> import pandas as pd

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -179,7 +179,7 @@ class PartitionedDataset(AbstractDataset):
                 and the dataset initializer. If the dataset config contains
                 explicit credentials spec, then such spec will take precedence.
                 All possible credentials management scenarios are documented here:
-                https://kedro.readthedocs.io/en/stable/data/kedro.io.PartitionedDataset.html
+                https://docs.kedro.org/en/stable/data/partitioned_and_incremental_datasets.html#partitioned-dataset-credentials
             load_args: Keyword arguments to be passed into ``find()`` method of
                 the filesystem implementation.
             fs_args: Extra arguments to pass into underlying filesystem class constructor

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ extras_require = {
         "sphinxcontrib-mermaid~=0.7.1",
         "myst-parser~=1.0.0",
         "Jinja2<3.1.0",
-        "kedro-datasets[all]~=1.6.0",
+        "kedro-datasets[all]~=1.7.0",
     ],
     "geopandas": _collect_requirements(geopandas_require),
     "matplotlib": _collect_requirements(matplotlib_require),


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

Fix broken links on docstrings on `kedro/extras/datasets` that were affecting the Read The Docs build.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
