### PR TITLE
fix typo for build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.7"
 dependencies = [
     "anyconfig>=0.10.0",
     "attrs>=21.3",
-    "build>=0.7.0,",
+    "build>=0.7.0",
     "cachetools>=4.1",
     "click>=4.0",
     "cookiecutter>=2.1.1,<3.0",


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
https://github.com/kedro-org/kedro/pull/2922#discussion_r1313324870
removes typo, extra ',' from build in pyproject.toml
    "build>=0.7.0,", 
to 
    "build>=0.7.0", 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
