### PR TITLE
Fix CI - Fail Jupyter notebook e2e test due to traitlets

### DIFF
--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -12,4 +12,4 @@ nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2
-traitlets<=5.9.0  # Temporary fix until https://github.com/microsoft/azuredatastudio/issues/24436 fixed
+traitlets<5.10.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -12,3 +12,4 @@ nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2
+traitlets<=5.9.0  # Temporary fix until https://github.com/microsoft/azuredatastudio/issues/24436 fixed


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
https://github.com/jupyter/notebook/issues/7048, temporary fix until new version is released.

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
