### PR TITLE
Fix typo in plugin.md

### DIFF
--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -34,7 +34,7 @@ From version 0.18.14, Kedro replaced `setup.py` with `pyproject.toml`. The plugi
 To add the entry point to `pyproject.toml`, the plugin needs to provide the following `entry_points` configuration:
 ```toml
 [project.entry-points."kedro.project_commands"]
-kedrojson = kedrojson.plugin.commands
+kedrojson = "kedrojson.plugin:commands"
 ```
 
 Once the plugin is installed, you can run it as follows:
@@ -76,7 +76,7 @@ In your `pyproject.toml`, you need to register the specifications to `kedro.star
 
 ```toml
 [project.entry-points."kedro.starters"]
-starter = plugin.starters
+starter = "plugin:starters"
 ```
 
 After that you can use this starter with `kedro new --starter=test_plugin_starter`.
@@ -132,7 +132,7 @@ To enable this for your custom plugin, simply add the following entry in `pyproj
 To use `pyproject.toml`, specify
 ```toml
 [project.entry-points."kedro.hooks"]
-plugin_name = plugin_name.plugin.hooks
+plugin_name = "plugin_name.plugin:hooks"
 ```
 
 where `plugin.py` is the module where you declare hook implementations:
@@ -163,7 +163,7 @@ You can also develop Hook implementations to extend Kedro's CLI behaviour in you
 
 ```toml
 [project.entry-points."kedro.cli_hooks"]
-plugin_name = plugin_name.plugin.cli_hooks
+plugin_name = "plugin_name.plugin:cli_hooks"
 ```
 
 (where `plugin.py` is the module where you declare Hook implementations):


### PR DESCRIPTION
Signed-off-by: Nok <nok.lam.chan@quantumblack.com>
Follow up on #3013, close #1940.

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
