### PR TITLE
Add organisation for each current Kedro maintainer

### DIFF
--- a/.github/styles/Kedro/ignore-names.txt
+++ b/.github/styles/Kedro/ignore-names.txt
@@ -70,10 +70,12 @@ Mackay
 Malte
 Malloy
 Marcin
+Mehdi
 Meisam
 Merali
 Merel
 Milne
+Naderi
 Nasef
 Nechevska
 Nero
@@ -101,6 +103,7 @@ Theisen
 Tynan
 Tsaousis
 Valtazanos
+Varandi
 Vladimir
 Waylon
 Westenra

--- a/.github/styles/Kedro/ignore.txt
+++ b/.github/styles/Kedro/ignore.txt
@@ -37,3 +37,4 @@ Xebia
 pytest
 transcoding
 transcode
+Claypot

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -105,7 +105,6 @@ Former core team members with significant contributions include
 [Susanna Wong](https://github.com/studioswong) and
 [Zain Patel](https://github.com/mzjp2).
 
-
 ## Application process
 
 Every quarter year, existing maintainers will collect a list of contributors that have shown regular activity on the project over the prior months and want to become maintainers. From this list, maintainer candidates are selected and proposed for a vote.

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -84,8 +84,7 @@ We look for commitment markers who can do the following:
 
 Kedro was originally designed by [Aris Valtazanos](https://github.com/arisvqb) and [Nikolaos Tsaousis](https://github.com/tsanikgr) at [QuantumBlack](https://www.mckinsey.com/capabilities/quantumblack) to solve challenges they faced in their project work. Their work was later turned into an internal product by [Peteris Erins](https://github.com/Pet3ris), [Ivan Danov](https://github.com/idanov), [Nikolaos Kaltsas](https://github.com/nikos-kal), [Meisam Emamjome](https://github.com/misamae) and [Nikolaos Tsaousis](https://github.com/tsanikgr).
 
-Former core team members with significant contributions include:
-
+Former core team members with significant contributions include
 [Andrii Ivaniuk](https://github.com/andrii-ivaniuk),
 [Anton Kirilenko](https://github.com/Flid),
 [Cvetanka Nechevska](https://github.com/cvetankanechevska),

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -10,7 +10,8 @@ On this page we describe:
 
 - [Responsibilities of a maintainer](#responsibilities-of-a-maintainer)
 - [Requirements to become a maintainer](#requirements-to-become-a-maintainer)
-- [Kedro maintainers](#kedro-maintainers)
+- [Current maintainers](#current-maintainers)
+- [Past maintainers](#past-maintainers)
 - [Application process](#application-process)
 - [Voting process](#voting-process)
 
@@ -110,7 +111,7 @@ Former core team members with significant contributions include
 Every quarter year, existing maintainers will collect a list of contributors that have shown regular activity on the project over the prior months and want to become maintainers. From this list, maintainer candidates are selected and proposed for a vote.
 
 Following a successful vote, candidates are added to the `kedro-developers` team on the Kedro GitHub organisation
-and the `kedro-team` channel on the Kedro Slack organisation, and listed as [Kedro maintainers](#kedro-maintainers).
+and the `kedro-team` channel on the Kedro Slack organisation, and listed as [Kedro maintainers](#current-maintainers).
 
 ## Voting process
 
@@ -124,4 +125,4 @@ Voting can change project maintainers and decide on the future of Kedro. The TSC
 
 The decision to add or remove a maintainer is made based on TSC members votes in that pull request. Additions and removals of maintainers require **a 2/3 majority**.
 
-The act of adding or removing maintainers onto the list requires a pull request against the [Kedro maintainers section of this page](#kedro-maintainers).
+The act of adding or removing maintainers onto the list requires a pull request against the ["Current maintainers" section of this page](#current-maintainers).

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -2,7 +2,7 @@
 
 Kedro is an incubating project within [LF AI & Data](https://lfaidata.foundation/).
 
-The term "Technical Steering Committee" (TSC) describes the group of Kedro maintainers. We list [Kedro's current and past maintainers](#kedro-maintainers) on this page.
+The term "Technical Steering Committee" (TSC) describes the group of Kedro maintainers. We list Kedro's [current](#current-maintainers) and [past](#past-maintainers) maintainers on this page.
 
 The TSC is responsible for the project's future development; you can read about our duties in our [Technical Charter](https://github.com/kedro-org/kedro/blob/main/kedro_technical_charter.pdf). We accept new members into the TSC to fuel Kedro's continued development.
 

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -48,40 +48,41 @@ We look for commitment markers who can do the following:
 - Show excitement about the future of Kedro
 - Build a collaborative relationship with the existing team
 
-## Kedro maintainers
+## Current maintainers
 
 <!-- DO NOT EDIT THIS AND MERGE A PR WITHOUT A VOTE TO SIGN OFF ANY CHANGES -->
 
+| Name                                                     | Organisation |
+|----------------------------------------------------------|------------- |
+| [Ahdra Merali](https://github.com/AhdraMeraliQB)         | QuantumBlack |
+| [Andrew Mackay](https://github.com/Mackay031)            | QuantumBlack |
+| [Ankita Katiyar](https://github.com/ankatiyar)           | QuantumBlack |
+| [Antony Milne](https://github.com/antonymilne)           | QuantumBlack |
+| [Deepyaman Datta](https://github.com/deepyaman)          | Claypot AI   |
+| [Dmitry Sorokin](https://github.com/DimedS)              | QuantumBlack |
+| [Huong Nguyen](https://github.com/Huongg)                | QuantumBlack |
+| [Ivan Danov](https://github.com/idanov)                  | QuantumBlack |
+| [Jitendra Gundaniya](https://github.com/jitu5)           | QuantumBlack |
+| [Jo Stichbury](https://github.com/stichbury)             | QuantumBlack |
+| [Joel Schwarzmann](https://github.com/datajoely)         | QuantumBlack |
+| [Juan Luis Cano](https://github.com/astrojuanlu)         | QuantumBlack |
+| [Laura Couto](https://github.com/lrcouto)                | QuantumBlack |
+| [Marcin Zabłocki](https://github.com/marrrcin)           | GetInData    |
+| [Mehdi Naderi Varandi](https://github.com/MehdiNV)       | QuantumBlack |
+| [Merel Theisen](https://github.com/merelcht)             | QuantumBlack |
+| [Nero Okwa](https://github.com/NeroOkwa)                 | QuantumBlack |
+| [Nok Lam Chan](https://github.com/noklam)                | QuantumBlack |
+| [Rashida Kanchwala](https://github.com/rashidakanchwala) | QuantumBlack |
+| [Ravi Kumar Pilla](https://github.com/ravi-kumar-pilla)  | QuantumBlack |
+| [Sajid Alam](https://github.com/SajidAlamQB)             | QuantumBlack |
+| [Stephanie Kaiser](https://github.com/stephkaiser)       | QuantumBlack |
+| [Tynan DeBold](https://github.com/tynandebold)           | QuantumBlack |
+| [Vladimir Nikolic](https://github.com/vladimir-mck)      | QuantumBlack |
+| [Yetunde Dada](https://github.com/yetudada)              | QuantumBlack |
+
+## Past maintainers
+
 Kedro was originally designed by [Aris Valtazanos](https://github.com/arisvqb) and [Nikolaos Tsaousis](https://github.com/tsanikgr) at [QuantumBlack](https://www.mckinsey.com/capabilities/quantumblack) to solve challenges they faced in their project work. Their work was later turned into an internal product by [Peteris Erins](https://github.com/Pet3ris), [Ivan Danov](https://github.com/idanov), [Nikolaos Kaltsas](https://github.com/nikos-kal), [Meisam Emamjome](https://github.com/misamae) and [Nikolaos Tsaousis](https://github.com/tsanikgr).
-
-
-Currently, the core Kedro team consists of:
-
-[Ahdra Merali](https://github.com/AhdraMeraliQB),
-[Andrew Mackay](https://github.com/Mackay031),
-[Ankita Katiyar](https://github.com/ankatiyar),
-[Antony Milne](https://github.com/antonymilne),
-[Deepyaman Datta](https://github.com/deepyaman),
-[Dmitry Sorokin](https://github.com/DimedS),
-[Huong Nguyen](https://github.com/Huongg),
-[Ivan Danov](https://github.com/idanov),
-[Jitendra Gundaniya](https://github.com/jitu5),
-[Jo Stichbury](https://github.com/stichbury),
-[Joel Schwarzmann](https://github.com/datajoely),
-[Juan Luis Cano](https://github.com/astrojuanlu),
-[Laura Couto](https://github.com/lrcouto),
-[Marcin Zabłocki](https://github.com/marrrcin),
-[Mehdi Naderi Varandi](https://github.com/MehdiNV),
-[Merel Theisen](https://github.com/merelcht),
-[Nero Okwa](https://github.com/NeroOkwa),
-[Nok Lam Chan](https://github.com/noklam),
-[Rashida Kanchwala](https://github.com/rashidakanchwala),
-[Ravi Kumar Pilla](https://github.com/ravi-kumar-pilla),
-[Sajid Alam](https://github.com/SajidAlamQB),
-[Stephanie Kaiser](https://github.com/stephkaiser),
-[Tynan DeBold](https://github.com/tynandebold),
-[Vladimir Nikolic](https://github.com/vladimir-mck), and
-[Yetunde Dada](https://github.com/yetudada).
 
 Former core team members with significant contributions include:
 

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -68,7 +68,7 @@ We look for commitment markers who can do the following:
 | [Joel Schwarzmann](https://github.com/datajoely)         | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Juan Luis Cano](https://github.com/astrojuanlu)         | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Laura Couto](https://github.com/lrcouto)                | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
-| [Marcin Zabłocki](https://github.com/marrrcin)           | [GetInData | Part of Xebia](https://getindata.com)                                      |
+| [Marcin Zabłocki](https://github.com/marrrcin)           | [GetInData \| Part of Xebia](https://getindata.com)                                      |
 | [Mehdi Naderi Varandi](https://github.com/MehdiNV)       | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Merel Theisen](https://github.com/merelcht)             | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Nero Okwa](https://github.com/NeroOkwa)                 | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

Second attempt at #3039

## Development notes
<!-- What have you changed, and how has this been tested? -->

Modelled after https://spark.apache.org/committers.html

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
