### PR TITLE
Remove requirements from removed CLI commands

### DIFF
--- a/docs/source/deployment/aws_batch.md
+++ b/docs/source/deployment/aws_batch.md
@@ -169,7 +169,7 @@ class AWSBatchRunner(ThreadRunner):
 
         return super()._get_required_workers_count(pipeline)
 
-    def _run(  # pylint: disable=too-many-locals,useless-suppression
+    def _run(
         self,
         pipeline: Pipeline,
         catalog: DataCatalog,

--- a/docs/source/deployment/databricks/databricks_deployment_workflow.md
+++ b/docs/source/deployment/databricks/databricks_deployment_workflow.md
@@ -78,7 +78,7 @@ pip install kedro databricks-cli
 
 **Now, you must authenticate the Databricks CLI with your Databricks instance.**
 
-[Refer to the Databricks documentation](https://docs.databricks.com/en/archive/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
+[Refer to the Databricks documentation](https://docs.databricks.com/en/dev-tools/cli/authentication.html) for a complete guide on how to authenticate your CLI. The key steps are:
 
 1. Create a personal access token for your user on your Databricks instance.
 2. Run `databricks configure --token`.

--- a/docs/source/deployment/databricks/databricks_deployment_workflow.md
+++ b/docs/source/deployment/databricks/databricks_deployment_workflow.md
@@ -78,7 +78,7 @@ pip install kedro databricks-cli
 
 **Now, you must authenticate the Databricks CLI with your Databricks instance.**
 
-[Refer to the Databricks documentation](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
+[Refer to the Databricks documentation](https://docs.databricks.com/en/archive/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
 
 1. Create a personal access token for your user on your Databricks instance.
 2. Run `databricks configure --token`.

--- a/docs/source/deployment/databricks/databricks_ide_development_workflow.md
+++ b/docs/source/deployment/databricks/databricks_ide_development_workflow.md
@@ -5,7 +5,7 @@ This guide demonstrates a workflow for developing Kedro projects on Databricks u
 By working in your local environment, you can take advantage of features within an IDE that are not available on Databricks notebooks:
 
 - Auto-completion and suggestions for code, improving your development speed and accuracy.
-- Linters like Pylint or Flake8 can be integrated to catch potential issues in your code.
+- Linters like [Ruff](https://docs.astral.sh/ruff) can be integrated to catch potential issues in your code.
 - Static type checkers like Mypy can check types in your code, helping to identify potential type-related issues early in the development process.
 
 To set up these features, look for instructions specific to your IDE (for instance, [VS Code](https://code.visualstudio.com/docs/python/linting)).

--- a/docs/source/deployment/databricks/databricks_ide_development_workflow.md
+++ b/docs/source/deployment/databricks/databricks_ide_development_workflow.md
@@ -67,7 +67,7 @@ pip install kedro dbx --upgrade
 
 **Now, you must authenticate the Databricks CLI with your Databricks instance.**
 
-[Refer to the Databricks documentation](https://docs.databricks.com/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
+[Refer to the Databricks documentation](https://docs.databricks.com/en/archive/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
 
 1. Create a personal access token for your user on your Databricks instance.
 2. Run `databricks configure --token`.

--- a/docs/source/deployment/databricks/databricks_ide_development_workflow.md
+++ b/docs/source/deployment/databricks/databricks_ide_development_workflow.md
@@ -67,7 +67,7 @@ pip install kedro dbx --upgrade
 
 **Now, you must authenticate the Databricks CLI with your Databricks instance.**
 
-[Refer to the Databricks documentation](https://docs.databricks.com/en/archive/dev-tools/cli/index.html#set-up-authentication) for a complete guide on how to authenticate your CLI. The key steps are:
+[Refer to the Databricks documentation](https://docs.databricks.com/en/dev-tools/cli/authentication.html) for a complete guide on how to authenticate your CLI. The key steps are:
 
 1. Create a personal access token for your user on your Databricks instance.
 2. Run `databricks configure --token`.

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -226,7 +226,6 @@ def cli():
     help=PARAMS_ARG_HELP,
     callback=_split_params,
 )
-# pylint: disable=too-many-arguments,unused-argument
 def run(
     tag,
     env,

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -9,8 +9,7 @@ Linting tools check your code for errors such as a missing bracket or line inden
 As a project grows and goes through various stages of development it becomes important to maintain code quality. Using a consistent format and linting your code ensures that it is consistent, readable, and easy to debug and maintain.
 
 ## Set up Python tools
-There are a variety of Python tools available to use with your Kedro projects. This guide shows you how to use
-[`black`](https://github.com/psf/black), [`ruff`](https://beta.ruff.rs).
+There are a variety of Python tools available to use with your Kedro projects. This guide shows you how to use [`black`](https://github.com/psf/black) and [`ruff`](https://beta.ruff.rs).
 - **`black`** is a [PEP 8](https://peps.python.org/pep-0008/) compliant opinionated Python code formatter. `black` can
 check for styling inconsistencies and reformat your files in place.
 [You can read more in the `black` documentation](https://black.readthedocs.io/en/stable/).
@@ -62,15 +61,9 @@ It is a good practice to [split your line when it is too long](https://beta.ruff
 Use the following commands to run lint checks:
 ```bash
 black --check <project_root>
-isort --profile black --check <project_root>
+ruff check <project_root>
 ```
-You can also have `black` and `isort` automatically format your code by omitting the `--check` flag. Since `isort` and
-`black` both format your imports, adding `--profile black` to the `isort` run helps avoid potential conflicts.
-
-Use the following to invoke `flake8`:
-```bash
-flake8 <project_root>
-```
+You can also have `black` automatically format your code by omitting the `--check` flag.
 
 ## Automated formatting and linting with `pre-commit` hooks
 

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -101,7 +101,7 @@ pip install pre-commit
 ### Add `pre-commit` configuration file
 Create a file named `.pre-commit-config.yaml` in your Kedro project root directory. You can add entries for the hooks
 you want to run before each `commit`.
-Below is a sample `YAML` file with entries for `black`,`flake8`, and `isort`:
+Below is a sample `YAML` file with entries for `ruff` and black`:
 ```yaml
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit

--- a/docs/source/development/linting.md
+++ b/docs/source/development/linting.md
@@ -58,16 +58,6 @@ ignore = ["E501"]  # Black take care off line-too-long
 It is a good practice to [split your line when it is too long](https://beta.ruff.rs/docs/rules/line-too-long/), so it can be read easily even in a small screen. `ruff` treats this slightly different from `black`, when using together we recommend to disable this rule, i.e. `E501` to avoid conflicts.
 ```
 
-#### Configure `flake8`
-
-Store your `flake8` configuration in a file named `.flake8` within your project root. The Kedro default project template use the [following configuration](https://github.com/kedro-org/kedro/blob/main/kedro/templates/project/%7B%7B%20cookiecutter.repo_name%20%7D%7D/.flake8):
-
-```text
-[flake8]
-max-line-length=88
-extend-ignore=E203
-```
-
 ### Run the tools
 Use the following commands to run lint checks:
 ```bash

--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -145,7 +145,7 @@ from kedro.framework.hooks import hook_impl
 
 class MyHooks:
     @hook_impl
-    def after_catalog_created(self, catalog):  # pylint: disable=unused-argument
+    def after_catalog_created(self, catalog):
         logging.info("Reached after_catalog_created hook")
 
 

--- a/docs/source/get_started/kedro_concepts.md
+++ b/docs/source/get_started/kedro_concepts.md
@@ -72,7 +72,6 @@ project-dir         # Parent directory of the template
 ├── notebooks       # Project-related Jupyter notebooks (can be used for experimental code before moving the code to src)
 ├── pyproject.toml  # Identifies the project root and contains configuration information
 ├── README.md       # Project README
-├── .flake8         # Configuration options for `flake8` (linting)
 └── src             # Project source code
 ```
 

--- a/docs/source/kedro_project_setup/starters.md
+++ b/docs/source/kedro_project_setup/starters.md
@@ -155,7 +155,6 @@ Here is the layout of the project as a Cookiecutter template:
 ├── docs                         # Project documentation
 ├── notebooks                    # Project related Jupyter notebooks (can be used for experimental code before moving the code to src)
 ├── README.md                    # Project README
-├── .flake8                      # Configuration options for `flake8` (linting)
 └── src                          # Project source code
     └── {{ cookiecutter.python_package }}
        ├── __init.py__

--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -35,7 +35,6 @@ The spaceflights project dependencies are stored in `src/requirements.txt`(you m
 black==22.0
 flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0
-isort~=5.0
 
 # notebook tooling
 jupyter~=1.0

--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -33,7 +33,6 @@ The spaceflights project dependencies are stored in `src/requirements.txt`(you m
 ```text
 # code quality packages
 black==22.0
-flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0
 
 # notebook tooling

--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -36,7 +36,6 @@ black==22.0
 flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0
 isort~=5.0
-nbstripout~=0.4
 
 # notebook tooling
 jupyter~=1.0

--- a/features/steps/sh_run.py
+++ b/features/steps/sh_run.py
@@ -36,7 +36,6 @@ def run(
     """
     if isinstance(cmd, str) and split:
         cmd = shlex.split(cmd)
-    # pylint: disable=subprocess-run-check
     result = subprocess.run(cmd, input="", capture_output=True, **kwargs)
     result.stdout = result.stdout.decode("utf-8")
     result.stderr = result.stderr.decode("utf-8")

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/.flake8
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length = 88
-extend-ignore = E203

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
@@ -112,7 +112,7 @@ kedro jupyter convert --all
 ```
 
 ### How to ignore notebook output cells in `git`
-To automatically strip out all output cell contents before committing to `git`, you can run `kedro activate-nbstripout`. This will add a hook in `.git/config` which will run `nbstripout` before anything is committed to `git`.
+To automatically strip out all output cell contents before committing to `git`, you can use tools like [`nbstripout`](https://github.com/kynan/nbstripout). For example, you can add a hook in `.git/config` with `nbstripout --install`. This will run `nbstripout` before anything is committed to `git`.
 
 > *Note:* Your output cells will be retained locally.
 

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,9 +3,6 @@ project_name = "{{ cookiecutter.project_name }}"
 project_version = "{{ cookiecutter.kedro_version }}"
 package_name = "{{ cookiecutter.python_package }}"
 
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
 addopts = """
 --cov-report term-missing \

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/pyproject.toml
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/pyproject.toml
@@ -19,7 +19,6 @@ docs = [
     "sphinx~=3.4.3",
     "sphinx_rtd_theme==0.5.1",
     "nbsphinx==0.8.1",
-    "nbstripout~=0.4",
     "sphinx-autodoc-typehints==1.11.1",
     "sphinx_copybutton==0.3.1",
     "ipykernel>=5.3, <7.0",

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -2,7 +2,6 @@ black~=22.0
 flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
-isort~=5.0
 jupyter~=1.0
 jupyterlab_server>=2.11.1, <2.16.0
 jupyterlab~=3.0, <3.6.0

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,5 +1,4 @@
 black~=22.0
-flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -8,7 +8,6 @@ jupyterlab_server>=2.11.1, <2.16.0
 jupyterlab~=3.0, <3.6.0
 kedro[pandas.CSVDataSet]=={{ cookiecutter.kedro_version }}
 kedro-telemetry~=0.2.0
-nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2

--- a/features/steps/util.py
+++ b/features/steps/util.py
@@ -63,7 +63,7 @@ def wait_for(
         try:
             result = func(**kwargs)
             return result
-        except Exception as err:  # pylint: disable=broad-except
+        except Exception as err:
             if print_error:
                 print(err)
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/.flake8
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/.flake8
@@ -1,3 +1,0 @@
-[flake8]
-max-line-length=88
-extend-ignore=E203

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -3,9 +3,6 @@ package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
 
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
 addopts = """
 --cov-report term-missing \

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/pyproject.toml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/pyproject.toml
@@ -19,7 +19,6 @@ docs = [
     "sphinx~=3.4.3",
     "sphinx_rtd_theme==0.5.1",
     "nbsphinx==0.8.1",
-    "nbstripout~=0.4",
     "sphinx-autodoc-typehints==1.11.1",
     "sphinx_copybutton==0.3.1",
     "ipykernel>=5.3, <7.0",

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -2,7 +2,6 @@ black~=22.0
 flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
-isort~=5.0
 jupyter~=1.0
 jupyterlab_server>=2.11.1, <2.16.0
 jupyterlab~=3.0, <3.6.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -1,5 +1,4 @@
 black~=22.0
-flake8>=3.7.9, <5.0
 ipython>=7.31.1, <8.0; python_version < '3.8'
 ipython~=8.10; python_version >= '3.8'
 jupyter~=1.0

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/requirements.txt
@@ -8,7 +8,6 @@ jupyterlab_server>=2.11.1, <2.16.0
 jupyterlab~=3.0, <3.6.0
 kedro~={{ cookiecutter.kedro_version }}
 kedro-telemetry~=0.2.0
-nbstripout~=0.4
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,9 +78,6 @@ version = {attr = "kedro.__version__"}
 [tool.black]
 exclude = "/templates/|^features/steps/test_starter"
 
-[tool.isort]
-profile = "black"
-
 [tool.coverage.report]
 fail_under = 100
 show_missing = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,37 +81,6 @@ exclude = "/templates/|^features/steps/test_starter"
 [tool.isort]
 profile = "black"
 
-
-[tool.pylint]
-[tool.pylint.master]
-ignore = "CVS"
-ignore-patterns = "kedro/templates/*"
-load-plugins = [
-    "pylint.extensions.docparams",
-    "pylint.extensions.no_self_use"
-]
-extension-pkg-whitelist = "cv2"
-unsafe-load-any-extension = false
-[tool.pylint.messages_control]
-disable = [
-    "ungrouped-imports",
-    "duplicate-code",
-    "wrong-import-order",  # taken care of by isort
-]
-enable = ["useless-suppression"]
-[tool.pylint.refactoring]
-max-nested-blocks = 5
-[tool.pylint.format]
-indent-after-paren=4
-indent-string="    "
-[tool.pylint.miscellaneous]
-notes = [
-    "FIXME",
-    "XXX"
-]
-[tool.pylint.design]
-min-public-methods = 1
-
 [tool.coverage.report]
 fail_under = 100
 show_missing = true

--- a/setup.py
+++ b/setup.py
@@ -178,7 +178,6 @@ extras_require["test"] = [
     "pre-commit>=2.9.2, <3.0",  # The hook `mypy` requires pre-commit version 2.9.2.
     "pyarrow>=1.0; python_version < '3.11'",
     "pyarrow>=7.0; python_version >= '3.11'",  # Adding to avoid numpy build errors
-    "pylint>=2.17.0, <3.0",
     "pyproj~=3.0",
     "pyspark>=2.2, <3.4; python_version < '3.11'",
     "pyspark>=3.4; python_version >= '3.11'",

--- a/setup.py
+++ b/setup.py
@@ -155,7 +155,6 @@ extras_require["test"] = [
     "import-linter[toml]==1.8.0",
     "ipython>=7.31.1, <8.0; python_version < '3.8'",
     "ipython~=8.10; python_version >= '3.8'",
-    "isort~=5.0",
     "Jinja2<3.1.0",
     "joblib>=0.14",
     "jupyterlab_server>=2.11.1, <2.16.0",  # 2.16.0 requires importlib_metedata >= 4.8.3 which conflicts with flake8 requirement

--- a/setup.py
+++ b/setup.py
@@ -157,8 +157,8 @@ extras_require["test"] = [
     "ipython~=8.10; python_version >= '3.8'",
     "Jinja2<3.1.0",
     "joblib>=0.14",
-    "jupyterlab_server>=2.11.1, <2.16.0",  # 2.16.0 requires importlib_metedata >= 4.8.3 which conflicts with flake8 requirement
-    "jupyterlab~=3.0, <3.6.0",  # 3.6.0 requires jupyterlab_server~=2.19
+    "jupyterlab_server>=2.11.1",
+    "jupyterlab~=3.0",
     "jupyter~=1.0",
     "lxml~=4.6",
     "matplotlib>=3.0.3, <3.4; python_version < '3.10'",  # 3.4.0 breaks holoviews

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -257,7 +257,6 @@ class TestConfigLoader:
     def test_key_not_found_dict_get(self, tmp_path):
         """Check the error if no config files satisfy a given pattern"""
         with pytest.raises(KeyError):
-            # pylint: disable=expression-not-assigned
             ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV)["non-existent-pattern"]
 
     @use_config_dir
@@ -271,7 +270,6 @@ class TestConfigLoader:
             r"\[\'credentials\*\', \'credentials\*/\**\', \'\**/credentials\*\'\]"
         )
         with pytest.raises(MissingConfigException, match=pattern):
-            # pylint: disable=expression-not-assigned
             ConfigLoader(str(tmp_path), _DEFAULT_RUN_ENV)["credentials"]
 
     def test_duplicate_paths(self, tmp_path, caplog):

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -1,4 +1,3 @@
-# pylint: disable=expression-not-assigned, pointless-statement
 from __future__ import annotations
 
 import configparser
@@ -518,7 +517,7 @@ class TestOmegaConfigLoader:
 
     @use_config_dir
     def test_load_config_from_tar_file(self, tmp_path):
-        subprocess.run(  # pylint: disable=subprocess-run-check
+        subprocess.run(
             [
                 "tar",
                 "--exclude=local/*.yml",

--- a/tests/framework/cli/micropkg/test_micropkg_package.py
+++ b/tests/framework/cli/micropkg/test_micropkg_package.py
@@ -492,10 +492,9 @@ class TestMicropkgPackageCommand:
     "chdir_to_dummy_project", "cleanup_dist", "cleanup_pyproject_toml"
 )
 class TestMicropkgPackageFromManifest:
-    def test_micropkg_package_all(  # pylint: disable=too-many-locals
+    def test_micropkg_package_all(
         self, fake_repo_path, fake_project_cli, fake_metadata, tmp_path, mocker
     ):
-        # pylint: disable=import-outside-toplevel
         from kedro.framework.cli import micropkg
 
         spy = mocker.spy(micropkg, "_package_micropkg")
@@ -535,7 +534,6 @@ class TestMicropkgPackageFromManifest:
     def test_micropkg_package_all_empty_toml(
         self, fake_repo_path, fake_project_cli, fake_metadata, mocker
     ):
-        # pylint: disable=import-outside-toplevel
         from kedro.framework.cli import micropkg
 
         spy = mocker.spy(micropkg, "_package_micropkg")

--- a/tests/framework/cli/micropkg/test_micropkg_pull.py
+++ b/tests/framework/cli/micropkg/test_micropkg_pull.py
@@ -74,7 +74,6 @@ class TestMicropkgPullCommand:
         fake_metadata,
     ):
         """Test for pulling a valid sdist file locally."""
-        # pylint: disable=too-many-locals
         call_pipeline_create(fake_project_cli, fake_metadata)
         call_micropkg_package(fake_project_cli, fake_metadata)
         call_pipeline_delete(fake_project_cli, fake_metadata)
@@ -147,7 +146,6 @@ class TestMicropkgPullCommand:
         into another location and check that unpacked files
         are identical to the ones in the original modular pipeline.
         """
-        # pylint: disable=too-many-locals
         pipeline_name = "another_pipeline"
         call_pipeline_create(fake_project_cli, fake_metadata)
         call_micropkg_package(fake_project_cli, fake_metadata, alias=pipeline_name)
@@ -291,7 +289,7 @@ class TestMicropkgPullCommand:
         expected_test_files = {"__init__.py", "test_pipeline.py"}
         assert actual_test_files == expected_test_files
 
-    def test_micropkg_alias_refactors_imports(  # pylint: disable=too-many-locals
+    def test_micropkg_alias_refactors_imports(
         self, fake_project_cli, fake_package_path, fake_repo_path, fake_metadata
     ):
         call_pipeline_create(fake_project_cli, fake_metadata)
@@ -432,7 +430,6 @@ class TestMicropkgPullCommand:
         """Test for pulling a valid sdist file locally,
         but `tests` directory is missing from the sdist file.
         """
-        # pylint: disable=too-many-locals
         call_pipeline_create(fake_project_cli, fake_metadata)
         test_path = fake_repo_path / "src" / "tests" / "pipelines" / PIPELINE_NAME
         shutil.rmtree(test_path)
@@ -495,7 +492,6 @@ class TestMicropkgPullCommand:
         Test for pulling a valid sdist file locally, but `config` directory is missing
         from the sdist file.
         """
-        # pylint: disable=too-many-locals
         call_pipeline_create(fake_project_cli, fake_metadata)
         source_params_config = (
             fake_repo_path
@@ -560,7 +556,6 @@ class TestMicropkgPullCommand:
         """
         Test for pulling a valid sdist file from pypi.
         """
-        # pylint: disable=too-many-locals
         call_pipeline_create(fake_project_cli, fake_metadata)
         # We mock the `pip download` call, and manually create a package sdist file
         # to simulate the pypi scenario instead
@@ -592,7 +587,7 @@ class TestMicropkgPullCommand:
         # Mock needed to avoid an error when build.util.project_wheel_metadata
         # calls tempfile.TemporaryDirectory, which is mocked
         class _FakeWheelMetadata:
-            def get_all(self, name, failobj=None):  # pylint: disable=unused-argument
+            def get_all(self, name, failobj=None):
                 return []
 
         mocker.patch(
@@ -854,10 +849,9 @@ class TestMicropkgPullCommand:
     "chdir_to_dummy_project", "cleanup_dist", "cleanup_pyproject_toml"
 )
 class TestMicropkgPullFromManifest:
-    def test_micropkg_pull_all(  # pylint: disable=too-many-locals
+    def test_micropkg_pull_all(
         self, fake_repo_path, fake_project_cli, fake_metadata, mocker
     ):
-        # pylint: disable=import-outside-toplevel, line-too-long
         from kedro.framework.cli import micropkg
 
         spy = mocker.spy(micropkg, "_pull_package")
@@ -897,7 +891,6 @@ class TestMicropkgPullFromManifest:
     def test_micropkg_pull_all_empty_toml(
         self, fake_repo_path, fake_project_cli, fake_metadata, mocker
     ):
-        # pylint: disable=import-outside-toplevel
         from kedro.framework.cli import micropkg
 
         spy = mocker.spy(micropkg, "_pull_package")

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -46,7 +46,7 @@ TOO_SHORT_ERROR = "It must be at least 2 characters long."
 @pytest.mark.usefixtures("chdir_to_dummy_project")
 class TestPipelineCreateCommand:
     @pytest.mark.parametrize("env", [None, "local"])
-    def test_create_pipeline(  # pylint: disable=too-many-locals
+    def test_create_pipeline(
         self, fake_repo_path, fake_project_cli, fake_metadata, env, fake_package_path
     ):
         """Test creation of a pipeline"""
@@ -80,7 +80,7 @@ class TestPipelineCreateCommand:
         assert actual_files == expected_files
 
     @pytest.mark.parametrize("env", [None, "local"])
-    def test_create_pipeline_template(  # pylint: disable=too-many-locals
+    def test_create_pipeline_template(
         self,
         fake_repo_path,
         fake_project_cli,
@@ -112,7 +112,7 @@ class TestPipelineCreateCommand:
         assert result.exit_code == 0
 
     @pytest.mark.parametrize("env", [None, "local"])
-    def test_create_pipeline_template_command_line_override(  # pylint: disable=too-many-locals
+    def test_create_pipeline_template_command_line_override(
         self,
         fake_repo_path,
         fake_project_cli,
@@ -171,7 +171,7 @@ class TestPipelineCreateCommand:
         test_dir = fake_repo_path / "src" / "tests" / "pipelines" / PIPELINE_NAME
         assert test_dir.is_dir()
 
-    def test_catalog_and_params(  # pylint: disable=too-many-locals
+    def test_catalog_and_params(
         self, fake_repo_path, fake_project_cli, fake_metadata, fake_package_path
     ):
         """Test that catalog and parameter configs generated in pipeline

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1,4 +1,3 @@
-# pylint: disable=too-many-lines
 from collections import namedtuple
 from itertools import cycle
 from os import rename
@@ -42,17 +41,17 @@ def stub_command():
 
 
 @forward_command(stub_cli, name="forwarded_command")
-def forwarded_command(args, **kwargs):  # pylint: disable=unused-argument
+def forwarded_command(args, **kwargs):
     print("fred", args)
 
 
 @forward_command(stub_cli, name="forwarded_help", forward_help=True)
-def forwarded_help(args, **kwargs):  # pylint: disable=unused-argument
+def forwarded_help(args, **kwargs):
     print("fred", args)
 
 
 @forward_command(stub_cli)
-def unnamed(args, **kwargs):  # pylint: disable=unused-argument
+def unnamed(args, **kwargs):
     print("fred", args)
 
 

--- a/tests/framework/cli/test_cli_hooks.py
+++ b/tests/framework/cli/test_cli_hooks.py
@@ -93,7 +93,7 @@ class TestKedroCLIHooks:
         mocker,
         fake_metadata,
         fake_plugin_distribution,
-        entry_points,  # pylint: disable=unused-argument
+        entry_points,
     ):
         caplog.set_level(logging.DEBUG, logger="kedro")
 

--- a/tests/framework/cli/test_project.py
+++ b/tests/framework/cli/test_project.py
@@ -1,4 +1,3 @@
-# pylint: disable=unused-argument
 import sys
 
 import pytest

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -17,7 +17,7 @@ from kedro.framework.cli.starters import (
     KedroStarterSpec,
 )
 
-FILES_IN_TEMPLATE = 29
+FILES_IN_TEMPLATE = 28
 
 
 @pytest.fixture

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -34,7 +34,7 @@ from kedro.framework.project import (
 MOCK_PACKAGE_NAME = "mock_package_name"
 
 
-class BadCatalog:  # pylint: disable=too-few-public-methods
+class BadCatalog:
     """
     Catalog class that doesn't subclass `DataCatalog`, for testing only.
     """
@@ -188,9 +188,7 @@ def extra_params(request):
 
 
 @pytest.fixture
-def dummy_context(
-    tmp_path, prepare_project_dir, env, extra_params
-):  # pylint: disable=unused-argument
+def dummy_context(tmp_path, prepare_project_dir, env, extra_params):
     configure_project(MOCK_PACKAGE_NAME)
     config_loader = ConfigLoader(str(tmp_path / "conf"), env=env)
     context = KedroContext(

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel
 import logging
 import sys
 from pathlib import Path

--- a/tests/framework/project/test_pipeline_registry.py
+++ b/tests/framework/project/test_pipeline_registry.py
@@ -26,12 +26,11 @@ def mock_package_name_with_pipelines_file(tmpdir):
 
 
 def test_pipelines_without_configure_project_is_empty(
-    mock_package_name_with_pipelines_file,  # pylint: disable=unused-argument
+    mock_package_name_with_pipelines_file,
 ):
     # Reimport `pipelines` from `kedro.framework.project` to ensure that
     # it was not set by a pior call to the `configure_project` function.
     del sys.modules["kedro.framework.project"]
-    # pylint: disable=reimported, import-outside-toplevel
     from kedro.framework.project import pipelines
 
     assert pipelines == {}

--- a/tests/framework/project/test_settings.py
+++ b/tests/framework/project/test_settings.py
@@ -19,7 +19,7 @@ class MyDataCatalog(DataCatalog):
     pass
 
 
-class ProjectHooks:  # pylint: disable=too-few-public-methods
+class ProjectHooks:
     pass
 
 

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -122,7 +122,7 @@ def mock_pipeline() -> Pipeline:
     )
 
 
-class LogRecorder(logging.Handler):  # pylint: disable=abstract-method
+class LogRecorder(logging.Handler):
     """Record logs received from a process-safe log listener"""
 
     def __init__(self):
@@ -370,9 +370,7 @@ def mock_settings(mocker, project_hooks):
 
 
 @pytest.fixture
-def mock_session(
-    mock_settings, mock_package_name, tmp_path
-):  # pylint: disable=unused-argument
+def mock_session(mock_settings, mock_package_name, tmp_path):
     configure_project(mock_package_name)
     session = KedroSession.create(
         mock_package_name, tmp_path, extra_params={"params:key": "value"}

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -31,13 +31,13 @@ _FAKE_PROJECT_NAME = "fake_project"
 _FAKE_PIPELINE_NAME = "fake_pipeline"
 
 
-class BadStore:  # pylint: disable=too-few-public-methods
+class BadStore:
     """
     Store class that doesn't subclass `BaseSessionStore`, for testing only.
     """
 
 
-class BadConfigLoader:  # pylint: disable=too-few-public-methods
+class BadConfigLoader:
     """
     ConfigLoader class that doesn't subclass `AbstractConfigLoader`, for testing only.
     """
@@ -645,7 +645,7 @@ class TestKedroSession:
 
     @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, _FAKE_PIPELINE_NAME])
-    def test_run_multiple_times(  # pylint: disable=too-many-locals
+    def test_run_multiple_times(
         self,
         fake_project,
         fake_session_id,
@@ -730,7 +730,7 @@ class TestKedroSession:
 
     @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, _FAKE_PIPELINE_NAME])
-    def test_run_exception(  # pylint: disable=too-many-locals
+    def test_run_exception(
         self,
         fake_project,
         fake_session_id,
@@ -796,7 +796,7 @@ class TestKedroSession:
 
     @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, _FAKE_PIPELINE_NAME])
-    def test_run_broken_pipeline_multiple_times(  # pylint: disable=too-many-locals
+    def test_run_broken_pipeline_multiple_times(
         self,
         fake_project,
         fake_session_id,

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -419,7 +419,7 @@ class TestDataSetHooks:
             assert record.data.to_dict() == dummy_dataframe.to_dict()
 
 
-class MockDatasetReplacement:  # pylint: disable=too-few-public-methods
+class MockDatasetReplacement:
     pass
 
 

--- a/tests/io/test_cached_dataset.py
+++ b/tests/io/test_cached_dataset.py
@@ -60,10 +60,10 @@ class TestCachedDataset:
 
         cached_ds.save(42)
         assert cached_ds.load() == 42
-        assert wrapped.load.call_count == 0  # pylint: disable=no-member
-        assert wrapped.save.call_count == 1  # pylint: disable=no-member
-        assert cached_ds._cache.load.call_count == 1  # pylint: disable=no-member
-        assert cached_ds._cache.save.call_count == 1  # pylint: disable=no-member
+        assert wrapped.load.call_count == 0
+        assert wrapped.save.call_count == 1
+        assert cached_ds._cache.load.call_count == 1
+        assert cached_ds._cache.save.call_count == 1
 
     def test_load_empty_cache(self, mocker):
         wrapped = MemoryDataset(-42)
@@ -73,8 +73,8 @@ class TestCachedDataset:
         mocker.spy(cached_ds._cache, "load")
 
         assert cached_ds.load() == -42
-        assert wrapped.load.call_count == 1  # pylint: disable=no-member
-        assert cached_ds._cache.load.call_count == 0  # pylint: disable=no-member
+        assert wrapped.load.call_count == 1
+        assert cached_ds._cache.load.call_count == 0
 
     def test_from_yaml(self, mocker):
         config = yaml.safe_load(StringIO(YML_CONFIG))

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -201,7 +201,7 @@ def conflicting_feed_dict():
 class BadDataset(AbstractDataset):  # pragma: no cover
     def __init__(self, filepath):
         self.filepath = filepath
-        raise Exception("Naughty!")  # pylint: disable=broad-exception-raised
+        raise Exception("Naughty!")
 
     def _load(self):
         return None
@@ -472,7 +472,7 @@ class TestDataCatalogFromConfig:
         """Test kedro_datasets default path to the dataset class"""
         # Spy _load_obj because kedro_datasets is not installed and we can't import it.
 
-        import kedro.io.core  # pylint: disable=import-outside-toplevel
+        import kedro.io.core
 
         spy = mocker.spy(kedro.io.core, "_load_obj")
         parse_dataset_definition(sane_config["catalog"]["boats"])
@@ -569,7 +569,6 @@ class TestDataCatalogFromConfig:
         """Test that dependency is missing."""
         pattern = "dependency issue"
 
-        # pylint: disable=unused-argument,inconsistent-return-statements
         def dummy_load(obj_path, *args, **kwargs):
             if obj_path == "kedro_datasets.pandas.CSVDataSet":
                 raise AttributeError(pattern)
@@ -661,7 +660,7 @@ class TestDataCatalogVersioned:
 
         # Verify that `VERSION_FORMAT` can help regenerate `current_ts`.
         actual_timestamp = datetime.strptime(
-            catalog.datasets.boats.resolve_load_version(),  # pylint: disable=no-member
+            catalog.datasets.boats.resolve_load_version(),
             VERSION_FORMAT,
         )
         expected_timestamp = current_ts.replace(
@@ -706,11 +705,11 @@ class TestDataCatalogVersioned:
 
         # Verify that saved version on tracking dataset is the same as on the CSV dataset
         csv_timestamp = datetime.strptime(
-            catalog.datasets.boats.resolve_save_version(),  # pylint: disable=no-member
+            catalog.datasets.boats.resolve_save_version(),
             VERSION_FORMAT,
         )
         tracking_timestamp = datetime.strptime(
-            catalog.datasets.planes.resolve_save_version(),  # pylint: disable=no-member
+            catalog.datasets.planes.resolve_save_version(),
             VERSION_FORMAT,
         )
 
@@ -919,7 +918,7 @@ class TestDataCatalogDatasetFactories:
 
         # Verify that `VERSION_FORMAT` can help regenerate `current_ts`.
         actual_timestamp = datetime.strptime(
-            catalog.datasets.tesla_cars.resolve_load_version(),  # pylint: disable=no-member
+            catalog.datasets.tesla_cars.resolve_load_version(),
             VERSION_FORMAT,
         )
         expected_timestamp = current_ts.replace(

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -1,6 +1,5 @@
 import re
 
-# pylint: disable=unused-argument
 import numpy as np
 import pandas as pd
 import pytest
@@ -218,7 +217,7 @@ def test_infer_mode_deepcopy(data):
 
 
 def test_infer_mode_assign():
-    class DataFrame:  # pylint: disable=too-few-public-methods
+    class DataFrame:
         pass
 
     data = DataFrame()

--- a/tests/io/test_partitioned_dataset.py
+++ b/tests/io/test_partitioned_dataset.py
@@ -46,7 +46,7 @@ LOCAL_DATASET_DEFINITION = [
 ]
 
 
-class FakeDataset:  # pylint: disable=too-few-public-methods
+class FakeDataset:
     pass
 
 

--- a/tests/ipython/test_ipython.py
+++ b/tests/ipython/test_ipython.py
@@ -1,4 +1,3 @@
-# pylint: disable=import-outside-toplevel
 from pathlib import Path
 
 import pytest
@@ -18,7 +17,7 @@ PROJECT_VERSION = "0.1"
 @pytest.fixture(autouse=True)
 def cleanup_pipeline():
     yield
-    from kedro.framework.project import pipelines  # pylint: disable=reimported
+    from kedro.framework.project import pipelines
 
     pipelines.configure()
 
@@ -246,7 +245,6 @@ class TestProjectPathResolution:
         assert result == expected
 
     def test_only_local_namespace_specified(self):
-        # pylint: disable=too-few-public-methods
         class MockKedroContext:
             # A dummy stand-in for KedroContext sufficient for this test
             _project_path = Path("/test").resolve()
@@ -280,7 +278,6 @@ class TestProjectPathResolution:
         assert expected_message in log_messages
 
     def test_project_path_update(self, caplog):
-        # pylint: disable=too-few-public-methods
         class MockKedroContext:
             # A dummy stand-in for KedroContext sufficient for this test
             _project_path = Path("/test").resolve()

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -187,7 +187,7 @@ class TestNodeComparisons:
         pattern = "'<' not supported between instances of 'Node' and 'str'"
 
         with pytest.raises(TypeError, match=pattern):
-            n < "hello"  # pylint: disable=pointless-statement
+            n < "hello"
 
     def test_different_input_list_order_not_equal(self):
         first = node(biconcat, ["input1", "input2"], "output1", name="A")
@@ -300,7 +300,7 @@ def inconsistent_input_kwargs():
     return dummy_func_args, "A", "B"
 
 
-lambda_identity = lambda input1: input1  # noqa: disable=E731 # pylint: disable=C3001
+lambda_identity = lambda input1: input1  # noqa: disable=E731
 
 
 def lambda_inconsistent_input_size():

--- a/tests/pipeline/test_node_run.py
+++ b/tests/pipeline/test_node_run.py
@@ -1,5 +1,3 @@
-# pylint: disable=unused-argument
-
 import pytest
 
 from kedro.io import LambdaDataset

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -383,7 +383,7 @@ class TestInvalidPipeline:
         fred = node(identity, "input", "output")
         pipeline = modular_pipeline([fred])
         with pytest.raises(TypeError):
-            pipeline + fred  # pylint: disable=pointless-statement
+            pipeline + fred
 
     def test_bad_combine_int(self):
         """int cannot be combined to pipeline, tests __radd__"""
@@ -405,7 +405,7 @@ class TestInvalidPipeline:
             "appear more than once:\n\nFree nodes:\n  - a"
         )
         with pytest.raises(ValueError, match=re.escape(pattern)):
-            pipeline1 + new_pipeline  # pylint: disable=pointless-statement
+            pipeline1 + new_pipeline
 
     def test_conflicting_outputs(self):
         """Node outputs must be unique."""
@@ -416,7 +416,7 @@ class TestInvalidPipeline:
             [node(biconcat, ["input", "input2"], ["output", "output2"], name="b")]
         )
         with pytest.raises(OutputNotUniqueError, match=r"\['output'\]"):
-            pipeline1 + new_pipeline  # pylint: disable=pointless-statement
+            pipeline1 + new_pipeline
 
     def test_duplicate_node_confirms(self):
         """Test that non-unique dataset confirms break pipeline concatenation"""
@@ -427,7 +427,7 @@ class TestInvalidPipeline:
             [node(identity, "input2", "output2", confirms=["other", "output2"])]
         )
         with pytest.raises(ConfirmNotUniqueError, match=r"\['other'\]"):
-            pipeline1 + pipeline2  # pylint: disable=pointless-statement
+            pipeline1 + pipeline2
 
 
 class TestPipelineOperators:
@@ -533,7 +533,7 @@ class TestPipelineOperators:
         p = modular_pipeline([])
         pattern = r"unsupported operand type\(s\) for -: 'Pipeline' and 'str'"
         with pytest.raises(TypeError, match=pattern):
-            p - "hello"  # pylint: disable=pointless-statement
+            p - "hello"
 
     def test_combine_same_node(self):
         """Multiple (identical) pipelines are possible"""
@@ -567,7 +567,7 @@ class TestPipelineOperators:
         p = modular_pipeline([])
         pattern = r"unsupported operand type\(s\) for &: 'Pipeline' and 'str'"
         with pytest.raises(TypeError, match=pattern):
-            p & "hello"  # pylint: disable=pointless-statement
+            p & "hello"
 
     def test_union(self):
         pipeline1 = modular_pipeline(
@@ -588,7 +588,7 @@ class TestPipelineOperators:
         p = modular_pipeline([])
         pattern = r"unsupported operand type\(s\) for |: 'Pipeline' and 'str'"
         with pytest.raises(TypeError, match=pattern):
-            p | "hello"  # pylint: disable=pointless-statement
+            p | "hello"
 
     def test_node_unique_confirms(self):
         """Test that unique dataset confirms don't break pipeline concatenation"""

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -15,7 +15,7 @@ def identity(arg):
     return arg
 
 
-def sink(arg):  # pylint: disable=unused-argument
+def sink(arg):
     pass
 
 
@@ -24,7 +24,7 @@ def fan_in(*args):
 
 
 def exception_fn(*args):
-    raise Exception("test exception")  # pylint: disable=broad-exception-raised
+    raise Exception("test exception")
 
 
 def return_none(arg):
@@ -32,7 +32,7 @@ def return_none(arg):
     return arg
 
 
-def return_not_serialisable(arg):  # pylint: disable=unused-argument
+def return_not_serialisable(arg):
     return lambda x: x
 
 
@@ -70,7 +70,6 @@ def persistent_dataset_catalog():
     def _load():
         return 0
 
-    # pylint: disable=unused-argument
     def _save(arg):
         pass
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import pytest
 from kedro.utils import load_obj
 
 
-# pylint: disable=too-few-public-methods
 class DummyClass:
     pass
 


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/issues/1725

## Development notes
Remove:
- `nbstripout` requirement
- `pylint` requirements, setup and left over mentions
- `isort` setup and requirement
- `flake8` setup and requirement

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
