### PR TITLE
Correct pip-compile Command Usage and Output File on Dependencies Page

### DIFF
--- a/docs/source/kedro_project_setup/dependencies.md
+++ b/docs/source/kedro_project_setup/dependencies.md
@@ -15,7 +15,7 @@ pip install pip-tools
 To add or remove dependencies to a project, edit the `src/requirements.txt` file, then run the following:
 
 ```bash
-pip-compile --output-file=<project_root>/src/requirements.txt --input-file=<project_root>/src/requirements.txt
+pip-compile <project_root>/src/requirements.txt --output-file <project_root>/src/requirements.lock
 ```
 
 This will [pip compile](https://github.com/jazzband/pip-tools#example-usage-for-pip-compile) the requirements listed in


### PR DESCRIPTION
## Description
The `pip-compile` command is currently not accepting the `--input-file` argument as expected. Additionally, the generated output file should be named `requirements.lock` instead of `requirements.txt`. This PR addresses these issues to ensure proper functionality and consistency.

