### PR TITLE
Remove mentions of old kedro CLI commands

### DIFF
--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
@@ -4,7 +4,7 @@
 
 This is your new Kedro project, which was generated using `Kedro {{ cookiecutter.kedro_version }}`.
 
-Take a look at the [Kedro documentation](https://kedro.readthedocs.io) to get started.
+Take a look at the [Kedro documentation](https://docs.kedro.org) to get started.
 
 ## Rules and guidelines
 
@@ -48,7 +48,7 @@ To configure the coverage threshold, look at the `.coveragerc` file.
 
 To see and update the dependency requirements for your project use `src/requirements.txt`. You can install the project requirements with `pip install -r src/requirements.txt`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -94,4 +94,4 @@ To automatically strip out all output cell contents before committing to `git`, 
 
 ## Package your Kedro project
 
-[Further information about building project documentation and packaging your project](https://kedro.readthedocs.io/en/stable/tutorial/package_a_project.html)
+[Further information about building project documentation and packaging your project](https://docs.kedro.org/en/stable/tutorial/package_a_project.html)

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/README.md
@@ -38,7 +38,7 @@ kedro run
 Have a look at the file `src/tests/test_run.py` for instructions on how to write your tests. You can run your tests as follows:
 
 ```
-kedro test
+pytest
 ```
 
 To configure the coverage threshold, look at the `.coveragerc` file.
@@ -46,15 +46,7 @@ To configure the coverage threshold, look at the `.coveragerc` file.
 
 ## Project dependencies
 
-To generate or update the dependency requirements for your project:
-
-```
-kedro build-reqs
-```
-
-This will `pip-compile` the contents of `src/requirements.txt` into a new file `src/requirements.lock`. You can see the output of the resolution by opening `src/requirements.lock`.
-
-After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
+To see and update the dependency requirements for your project use `src/requirements.txt`. You can install the project requirements with `pip install -r src/requirements.txt`.
 
 [Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
@@ -93,22 +85,6 @@ And if you want to run an IPython session:
 
 ```
 kedro ipython
-```
-
-### How to convert notebook cells to nodes in a Kedro project
-You can move notebook code over into a Kedro project structure using a mixture of [cell tagging](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#id35) and Kedro CLI commands.
-
-By adding the `node` tag to a cell and running the command below, the cell's source code will be copied over to a Python file within `src/<package_name>/nodes/`:
-
-```
-kedro jupyter convert <filepath_to_my_notebook>
-```
-> *Note:* The name of the Python file matches the name of the original notebook.
-
-Alternatively, you may want to transform all your notebooks in one go. Run the following command to convert all notebook files found in the project root directory and under any of its sub-folders:
-
-```
-kedro jupyter convert --all
 ```
 
 ### How to ignore notebook output cells in `git`

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -962,8 +962,8 @@ def _append_package_reqs(
             file.write(sep.join(sorted_reqs))
 
     click.secho(
-        "Use 'pip install -r src/requirements.txt' to install "
-        "the updated list of requirements."
+        "Use 'pip-compile src/requirements.txt --output-file src/requirements.lock' to compile "
+        "and 'pip install -r src/requirements.lock' to install the updated list of requirements."
     )
 
 

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -962,7 +962,7 @@ def _append_package_reqs(
             file.write(sep.join(sorted_reqs))
 
     click.secho(
-        "Use 'kedro build-reqs' to compile and 'pip install -r src/requirements.lock' to install "
+        "Use 'pip install -r src/requirements.txt' to install "
         "the updated list of requirements."
     )
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
@@ -38,24 +38,17 @@ kedro run
 Have a look at the file `src/tests/test_run.py` for instructions on how to write your tests. You can run your tests as follows:
 
 ```
-kedro test
+pytest
 ```
 
-To configure the coverage threshold, go to the `.coveragerc` file.
+To configure the coverage threshold, look at the `.coveragerc` file.
+
 
 ## Project dependencies
 
-To generate or update the dependency requirements for your project:
+To see and update the dependency requirements for your project use `src/requirements.txt`. You can install the project requirements with `pip install -r src/requirements.txt`.
 
-```
-kedro build-reqs
-```
-
-This will `pip-compile` the contents of `src/requirements.txt` into a new file `src/requirements.lock`. You can see the output of the resolution by opening `src/requirements.lock`.
-
-After this, if you'd like to update your project requirements, please update `src/requirements.txt` and re-run `kedro build-reqs`.
-
-[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 
@@ -94,22 +87,6 @@ And if you want to run an IPython session:
 
 ```
 kedro ipython
-```
-
-### How to convert notebook cells to nodes in a Kedro project
-You can move notebook code over into a Kedro project structure using a mixture of [cell tagging](https://jupyter-notebook.readthedocs.io/en/stable/changelog.html#release-5-0-0) and Kedro CLI commands.
-
-By adding the `node` tag to a cell and running the command below, the cell's source code will be copied over to a Python file within `src/<package_name>/nodes/`:
-
-```
-kedro jupyter convert <filepath_to_my_notebook>
-```
-> *Note:* The name of the Python file matches the name of the original notebook.
-
-Alternatively, you may want to transform all your notebooks in one go. Run the following command to convert all notebook files found in the project root directory and under any of its sub-folders:
-
-```
-kedro jupyter convert --all
 ```
 
 ### How to ignore notebook output cells in `git`

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/README.md
@@ -48,7 +48,7 @@ To configure the coverage threshold, look at the `.coveragerc` file.
 
 To see and update the dependency requirements for your project use `src/requirements.txt`. You can install the project requirements with `pip install -r src/requirements.txt`.
 
-[Further information about project dependencies](https://kedro.readthedocs.io/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
+[Further information about project dependencies](https://docs.kedro.org/en/stable/kedro_project_setup/dependencies.html#project-specific-dependencies)
 
 ## How to work with Kedro and notebooks
 


### PR DESCRIPTION
## Description
There were still some references to `kedro test`, `kedro build-reqs` and `kedro jupyter convert` in the codebase.

## Development notes
Removed and updated those mentions. 

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
