### PR TITLE
changed find_pipelines to account for nested structure

### DIFF
--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -344,15 +344,22 @@ def find_pipelines() -> dict[str, Pipeline]:  # noqa: PLR0912
         if str(exc) == f"No module named '{PACKAGE_NAME}.pipelines'":
             return pipelines_dict
 
-    for pipeline_dir in pipelines_package.iterdir():
+    for pipeline_dir in pipelines_package.glob("**/"):
         if not pipeline_dir.is_dir():
+            continue
+        if not (pipeline_dir / "__init__.py").is_file():
             continue
 
         pipeline_name = pipeline_dir.name
         if pipeline_name == "__pycache__":
             continue
 
-        pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
+        pipeline_relative_path = pipeline_dir.relative_to(pipelines_package)
+        full_pipeline_name = os.path.normpath(pipeline_relative_path).replace(
+            os.path.sep, "."
+        )
+
+        pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{full_pipeline_name}"
         try:
             pipeline_module = importlib.import_module(pipeline_module_name)
         except:  # noqa: bare-except  # noqa: E722

--- a/tests/framework/project/test_pipeline_discovery.py
+++ b/tests/framework/project/test_pipeline_discovery.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import sys
 import textwrap
@@ -16,8 +17,8 @@ def mock_package_name_with_pipelines(tmp_path, request):
     pipelines_dir.mkdir(parents=True)
     (pipelines_dir / "__init__.py").touch()
     for pipeline_name in request.param:
-        pipeline_dir = pipelines_dir / pipeline_name
-        pipeline_dir.mkdir()
+        pipeline_dir = pipelines_dir / os.path.join(*pipeline_name.split("."))
+        pipeline_dir.mkdir(parents=True)
         (pipeline_dir / "__init__.py").write_text(
             textwrap.dedent(
                 f"""
@@ -50,13 +51,14 @@ def pipeline_names(request):
 
 @pytest.mark.parametrize(
     "mock_package_name_with_pipelines,pipeline_names",
-    [(x, x) for x in [set(), {"my_pipeline"}]],
+    [(x, x) for x in [set(), {"my_pipeline", "my_folder.my_nested_pipeline"}]],
     indirect=True,
 )
 def test_find_pipelines(mock_package_name_with_pipelines, pipeline_names):
     configure_project(mock_package_name_with_pipelines)
     pipelines = find_pipelines()
-    assert set(pipelines) == pipeline_names | {"__default__"}
+    final_names = set(name.split(".")[-1] for name in pipeline_names)
+    assert set(pipelines) == final_names | {"__default__"}
     assert sum(pipelines.values()).outputs() == pipeline_names
 
 


### PR DESCRIPTION
## Description
PR was created as support of discussion for issue #3096 

## Development notes
find_pipelines was modified to allow for nested folder structure.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
