### PR TITLE
Doc fix for Shareable Kedro-viz. 

### DIFF
--- a/docs/source/visualisation/share_kedro_viz.md
+++ b/docs/source/visualisation/share_kedro_viz.md
@@ -20,12 +20,12 @@ When your project is ready, navigate to the root directory of the project.
 
 ## Update and install the dependencies
 
-Kedro-Viz requires specific minimum versions of `fsspec` and `kedro` to publish your project.
+Kedro-Viz requires specific minimum versions of `fsspec[s3]`, and `kedro` to publish your project.
 
 You can ensure you have these correct versions by updating the `requirements.txt` file in the `src` folder of the Kedro project to the following:
 
 ```text
-fsspec>=2023.9.0
+fsspec[s3]>=2023.9.0
 kedro>=0.18.2
 ```
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description

Updated to docs to reflect the correct fsspec the user needs to download which is fsspec[s3] which will also download 's3fs' dependency. 

## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
