### PR TITLE
Allow nested folder structure in pipeline creation

### DIFF
--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -239,11 +239,11 @@ def delete_pipeline(
 
     for dir_to_delete in dirs_to_delete:
         for subdir in dir_to_delete.glob("**/*/"):
-            for init_py_file in subdir.glob("**/__init__.py"):
+            for py_file in subdir.glob("**/*.py"):
                 raise KedroCliError(
                     f"Cannot delete the pipeline '{dir_to_delete}'"
                     " because it contains a child pipeline."
-                    f" Please delete the child pipeline in '{init_py_file}'"
+                    f" Please delete the child pipeline in '{py_file.parent}'"
                     " before deleting this one."
                 )
 
@@ -299,6 +299,8 @@ def _create_pipeline(name: str, template_path: Path, output_dir: Path) -> Path:
             output_dir=str(output_dir),
             no_input=True,
             extra_context=cookie_context,
+            # allows creation of pipelines in parent folder of existing pipeline
+            overwrite_if_exists=True,
         )
     except Exception as exc:
         click.secho("FAILED", fg="red")

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -99,7 +99,7 @@ def _split_on_last_dot(input_string: str) -> tuple[str, str]:
         return "", input_string
 
 
-def transform_dotted_string_to_path(dotted_string: str) -> Path:
+def _transform_dotted_string_to_path(dotted_string: str) -> Path:
     """
     Transform a dotted string into a pathlib Path with OS-independent separator.
 
@@ -176,12 +176,12 @@ def create_pipeline(
         raise ValueError(f"Pipeline {name} already exists: ({file})")
 
     # add necessary subfolders
-    pipeline_dir = package_dir / "pipelines" / transform_dotted_string_to_path(parent)
+    pipeline_dir = package_dir / "pipelines" / _transform_dotted_string_to_path(parent)
     tests_target = (
         package_dir.parent
         / "tests"
         / "pipelines"
-        / transform_dotted_string_to_path(parent)
+        / _transform_dotted_string_to_path(parent)
         / name
     )
 


### PR DESCRIPTION
## Description
This PR was created as support for discussion for issue #3105 	
Its goal is to enhance the kedro cli (pipeline create and delete) as well as the find_pipelines function to natively work with nested folder structure. 

## Development notes
`create_pipeline`, `delete_pipeline` and `find_pipelines` were modified and the associated unit tests were created. 
Note that I had to put overwrite_if_exists to True in cookiecutter to allow creating a pipeline if a child pipeline already exists. 

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
