### PR TITLE
Fix broken link in #3121 micropackaging docs

### DIFF
--- a/docs/source/nodes_and_pipelines/micro_packaging.md
+++ b/docs/source/nodes_and_pipelines/micro_packaging.md
@@ -10,7 +10,7 @@ You can package a micro-package by executing: `kedro micropkg package <micropkg_
 
 `kedro micropkg package pipelines.data_processing`
 
-* This will generate a new [source distribution](https://docs.python.org/3/distutils/sourcedist.html) for this micro-package.
+* This will generate a new source distribution for this micro-package.
 * By default, the tar file will be saved into `dist/` directory inside your project.
 * You can customise the target with the `--destination` (`-d`) option.
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
Resolves #3121 by removing offending link.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
