### PR TITLE
Pin `tables` version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -196,7 +196,7 @@ extras_require["test"] = [
     "SQLAlchemy~=1.2",
     "tables~=3.6.0; platform_system == 'Windows' and python_version<'3.8'",
     "tables~=3.8.0; platform_system == 'Windows' and python_version>='3.8'",  # Import issues with python 3.8 with pytables pinning to 3.8.0 fixes this https://github.com/PyTables/PyTables/issues/933#issuecomment-1555917593
-    "tables~=3.6; platform_system != 'Windows'",
+    "tables~=3.6, <3.9.0; platform_system != 'Windows'",
     "tensorflow~=2.0; platform_system != 'Darwin' or platform_machine != 'arm64'",
     # https://developer.apple.com/metal/tensorflow-plugin/
     "tensorflow-macos~=2.0; platform_system == 'Darwin' and platform_machine == 'arm64'",


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
CI failing because of `pytables` release 3.9.0. 
Relevant commits - https://github.com/PyTables/PyTables/commit/ae1e60e & https://github.com/PyTables/PyTables/commit/47f5946
They've dropped support for python 3.8.
This test requirement will go away from `kedro 0.19.0` since it is datasets related so I've pinned it here in the test requirements. 




## Development notes
<!-- What have you changed, and how has this been tested? -->

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
