### PR TITLE
added keep-going flag to build-docs

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -10,5 +10,5 @@ action=$1
 if [ "$action" == "linkcheck" ]; then
   sphinx-build -WETan -j auto -D language=en -b linkcheck -d docs/build/doctrees docs/source docs/build/linkcheck
 elif [ "$action" == "docs" ]; then
-  sphinx-build -WETa -j auto -D language=en -b html -d docs/build/doctrees docs/source docs/build/html
+  sphinx-build -WETa --keep-going -j auto -D language=en -b html -d docs/build/doctrees docs/source docs/build/html
 fi


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

MR for issue #3132
Added the `--keep-trying` flag to `build-docs.sh` (which is called by `make build-docs`).
Because of the ~W~ flag any warning is treated as an error, with the `--keep-going` flag the build will finish despite the warnings turned error.

## Development notes
<!-- What have you changed, and how has this been tested? -->
All that was changed was an added flag to `build-docs.sh`.
I have tried running the `make build-docs`

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
