### PR TITLE
Added -keep-going flag to build docs

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -10,5 +10,5 @@ action=$1
 if [ "$action" == "linkcheck" ]; then
   sphinx-build -WETan -j auto -D language=en -b linkcheck -d docs/build/doctrees docs/source docs/build/linkcheck
 elif [ "$action" == "docs" ]; then
-  sphinx-build -WETa -j auto -D language=en -b html -d docs/build/doctrees docs/source docs/build/html
+  sphinx-build -WETa --keep-going -j auto -D language=en -b html -d docs/build/doctrees docs/source docs/build/html
 fi

--- a/docs/source/deployment/airflow_astronomer.md
+++ b/docs/source/deployment/airflow_astronomer.md
@@ -36,7 +36,7 @@ To follow this tutorial, ensure you have the following:
 
 ### Tutorial project setup
 
-1. [Initialise an Airflow project with Astro](https://docs.astronomer.io/astro/create-project). Let's call it `kedro-airflow-iris`
+1. [Initialise an Airflow project with Astro](https://docs.astronomer.io/astro/cli/develop-project). Let's call it `kedro-airflow-iris`
 
     ```shell
     mkdir kedro-airflow-iris


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
MR for issue #3132.
Added the `--keep-going` flag to sphinx-build documentation in `build-docs.sh` (and by extension `make build-docs`.
Because all warnings are treated as errors the build will stop if any warnings happens, with this flag the build will still finish despite all the warnings turned errors.
This will hopefully make it a little less for contributors to worry about.

## Development notes
<!-- What have you changed, and how has this been tested? -->
All that was changes was the added flag `--keep-going`.
It's been tested by building the documentation using `make build-docs` with and without the flag.
With the added flag the build will still finish despite any warnings turned errors.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
