### PR TITLE
Remove instructions for `pip install "kedro[all]"`

### DIFF
--- a/docs/source/kedro_project_setup/dependencies.md
+++ b/docs/source/kedro_project_setup/dependencies.md
@@ -5,9 +5,11 @@ Both `pip install kedro` and `conda install -c conda-forge kedro` install the co
 When you create a project, you then introduce additional dependencies for the tasks it performs.
 
 ## Project-specific dependencies
+
 You can specify a project's exact dependencies in the `src/requirements.txt` file to make it easier for you and others to run your project in the future,
 and to avoid version conflicts downstream. This can be achieved with the help of [`pip-tools`](https://pypi.org/project/pip-tools/).
 To install `pip-tools` in your virtual environment, run the following command:
+
 ```bash
 pip install pip-tools
 ```
@@ -30,21 +32,12 @@ The `src/requirements.txt` file contains "source" requirements, while `src/requi
 
 To further update the project requirements, modify the `src/requirements.txt` file (not `src/requirements.lock`) and re-run the `pip-compile` command above.
 
-
 ## Install project-specific dependencies
 
 To install the project-specific dependencies, navigate to the root directory of the project and run:
 
 ```bash
 pip install -r src/requirements.txt
-```
-
-## Workflow dependencies
-
-To install all of Kedro's dependencies (recorded in `pyproject.toml`), run the following:
-
-```bash
-pip install "kedro[all]"
 ```
 
 ### Install dependencies related to the Data Catalog


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
https://kedro-org.slack.com/archives/C054U0LJLAC/p1696949530599349?thread_ts=1696928450.731069&cid=C054U0LJLAC

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
