### PR TITLE
Update makefile to pin pip version to fix nightly CI

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -19,6 +19,9 @@ build:
     # pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
     # pip==23.3 breaks dependency resolution
       - python -m pip install -U "pip>=21.2,<23.2"
+    # These are technically installation steps, due to RTD's limit we need to inject the installation earlier.
+      - python -m pip install --upgrade --no-cache-dir sphinx readthedocs-sphinx-ext
+      - python -m pip install --upgrade --upgrade-strategy only-if-needed --no-cache-dir .[docs,test]
     pre_build:
       - pip freeze
       - python -m sphinx -WETan -j auto -D language=en -b linkcheck -d _build/doctrees docs/source _build/linkcheck
@@ -34,10 +37,10 @@ sphinx:
 # configuration: mkdocs.yml
 
 # Optionally set the version of Python and requirements required to build your docs
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - test
+# python:
+#   install:
+#     - method: pip
+#       path: .
+#       extra_requirements:
+#         - docs
+#         - test

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -16,6 +16,9 @@ build:
     post_create_environment:
       - npm install -g @mermaid-js/mermaid-cli
     pre_build:
+    # pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
+    # pip==23.3 breaks dependency resolution
+      - python -m pip install -U "pip>=21.2,<23.2"
       - pip freeze
       - python -m sphinx -WETan -j auto -D language=en -b linkcheck -d _build/doctrees docs/source _build/linkcheck
 

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -15,10 +15,11 @@ build:
   jobs:
     post_create_environment:
       - npm install -g @mermaid-js/mermaid-cli
-    pre_build:
+    pre_install:
     # pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
     # pip==23.3 breaks dependency resolution
       - python -m pip install -U "pip>=21.2,<23.2"
+    pre_build:
       - pip freeze
       - python -m sphinx -WETan -j auto -D language=en -b linkcheck -d _build/doctrees docs/source _build/linkcheck
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,8 @@ package: clean install
 	python -m pip install build && python -m build
 
 install-test-requirements:
+# pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
+# pip==23.3 breaks dependency resolution
 	python -m pip install -U "pip>=21.2,<23.2"
 	pip install .[test]
 

--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ package: clean install
 	python -m pip install build && python -m build
 
 install-test-requirements:
+	python -m pip install -U "pip>=21.2,<23.2"
 	pip install .[test]
 
 install-pre-commit: install-test-requirements

--- a/features/environment.py
+++ b/features/environment.py
@@ -104,8 +104,8 @@ def _setup_minimal_env(context):
             "install",
             "-U",
             # pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
-            "pip>=21.2,<23.2; python_version < '3.8'",
-            "pip>=21.2; python_version >= '3.8'",
+            # pip==23.3 breaks dependency resolution
+            "pip>=21.2,<23.2"
         ],
         env=context.env,
     )

--- a/features/environment.py
+++ b/features/environment.py
@@ -105,7 +105,7 @@ def _setup_minimal_env(context):
             "-U",
             # pip==23.2 breaks pip-tools<7.0, and pip-tools>=7.0 does not support Python 3.7
             # pip==23.3 breaks dependency resolution
-            "pip>=21.2,<23.2"
+            "pip>=21.2,<23.2",
         ],
         env=context.env,
     )


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
https://github.com/pypa/pip/issues/12317

pip 23.2 breaks Python <3.8 and we have pin it in `environment.py`, now pip 23.3 breaks the dependency resolution.

See full log here: https://github.com/kedro-org/kedro/actions/runs/6527279214/job/17743502460

> The conflict is caused by:
>     kedro[test] 0.18.13 depends on dask~=2021.10; extra == "test"
>     dask[complete] 2021.12.0 depends on dask 2021.12.0 (from https://files.pythonhosted.org/packages/15/6d/99c63be3ea8a4a651d845addeea1f1b3bb8e5c6730bc26cfb6176631adf7/dask-2021.12.0-py3-none-any.whl (from https://pypi.org/simple/dask/) (requires-python:>=3.7))

The conflict does not exist and this is because pip switch the backend for dependency resolver.



## Development notes
<!-- What have you changed, and how has this been tested? -->
Cause: pip 23.2 or 23.3 used a new backend for dependency resolver and it’s buggy.

Changes:
Pin pip <23.2 for all Python versions (used to be specific one due to pip-tools)
Change .readthedoc.yml - this one is rather hacky but because RTD has a very rigid build steps that cannot be overrided.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
