### PR TITLE
Mute deprecation warnings coming from `io.core` that a user can't change

### DIFF
--- a/kedro/io/__init__.py
+++ b/kedro/io/__init__.py
@@ -3,7 +3,9 @@ number of data sets. At the core of the library is the ``AbstractDataset`` class
 """
 from __future__ import annotations
 
-from .cached_dataset import CachedDataSet, CachedDataset
+import warnings
+
+from .cached_dataset import CachedDataset
 from .core import (
     AbstractDataset,
     AbstractVersionedDataset,
@@ -13,14 +15,19 @@ from .core import (
     Version,
 )
 from .data_catalog import DataCatalog
-from .lambda_dataset import LambdaDataSet, LambdaDataset
-from .memory_dataset import MemoryDataSet, MemoryDataset
+from .lambda_dataset import LambdaDataset
+from .memory_dataset import MemoryDataset
 from .partitioned_dataset import (
-    IncrementalDataSet,
     IncrementalDataset,
-    PartitionedDataSet,
     PartitionedDataset,
 )
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    from .cached_dataset import CachedDataSet
+    from .lambda_dataset import LambdaDataSet
+    from .memory_dataset import MemoryDataSet
+    from .partitioned_dataset import IncrementalDataSet, PartitionedDataSet
 
 # https://github.com/pylint-dev/pylint/issues/4300#issuecomment-1043601901
 DataSetError: type[DatasetError]


### PR DESCRIPTION
## Description
Resolves https://github.com/kedro-org/kedro/issues/3107

## Development notes
Added warnings filter to not show `KedroDeprecationWarning` for the imports inside `io.core`, because a user can't change those. The deprecation warning will still be shown if a user directly access any of the core datasets. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
