### PR TITLE
Make default project entrypoint interactive (Databricks) friendly

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 * The new spaceflights starters, `spaceflights-pandas`, `spaceflights-pandas-viz`, `spaceflights-pyspark`, and `spaceflights-pyspark-viz` can be used with the `kedro new` command with the `--starter` flag.
 * Added the `--conf-source` option to `%reload_kedro`, allowing users to specify a source for project configuration.
 * Added the functionality to choose a merging strategy for config files loaded with `OmegaConfigLoader`.
+* Improved the default template's entrypoint to allow for `IPython` and Databricks executions without separate scripts.
 
 
 ## Bug fixes and other changes
@@ -62,7 +63,6 @@ We are grateful to every community member who made a PR to Kedro that's found it
 ## Major features and improvements
 * Allowed using of custom cookiecutter templates for creating pipelines with `--template` flag for `kedro pipeline create` or via `template/pipeline` folder.
 * Allowed overriding of configuration keys with runtime parameters using the `runtime_params` resolver with `OmegaConfigLoader`.
-* Improved the default template's entrypoint to allow for `IPython` and Databricks executions without separate scripts.
 
 ## Bug fixes and other changes
 * Updated dataset factories to resolve nested catalog config properly.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -62,6 +62,7 @@ We are grateful to every community member who made a PR to Kedro that's found it
 ## Major features and improvements
 * Allowed using of custom cookiecutter templates for creating pipelines with `--template` flag for `kedro pipeline create` or via `template/pipeline` folder.
 * Allowed overriding of configuration keys with runtime parameters using the `runtime_params` resolver with `OmegaConfigLoader`.
+* Improved the default template's entrypoint to allow for `IPython` and Databricks executions without separate scripts.
 
 ## Bug fixes and other changes
 * Updated dataset factories to resolve nested catalog config properly.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -41,12 +41,9 @@ def main(*args, **kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
-
-    if kwargs is None:
-        kwargs = {}
     interactive = not hasattr(sys, 'ps1')
-    kwargs = {**kwargs, **dict(standalone_mode=not interactive)}
-
+    kwargs["standalone_mode"] = not interactive
+    
     run(*args, **kwargs)
 
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -2,6 +2,7 @@
 as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package }}`
 """
 import importlib
+import sys
 from pathlib import Path
 
 from kedro.framework.cli.utils import KedroCliError, load_entry_points
@@ -40,6 +41,12 @@ def main(*args, **kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
+
+    if kwargs is None:
+        kwargs = {}
+    interactive = not hasattr(sys, 'ps1')
+    kwargs = {**kwargs, **dict(standalone_mode=not interactive)}
+
     run(*args, **kwargs)
 
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -41,9 +41,10 @@ def main(*args, **kwargs):
     package_name = Path(__file__).parent.name
     configure_project(package_name)
     run = _find_run_command(package_name)
+
     interactive = not hasattr(sys, 'ps1')
     kwargs["standalone_mode"] = not interactive
-    
+
     run(*args, **kwargs)
 
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description

Currently the recommended Databricks workflow suggests creating a separate entrypoint if you would like a schedule your Kedro project as a Databricks job. The reason for that is because of the way `click` works (more on the topic can be found in https://github.com/kedro-org/kedro/issues/1807 and https://github.com/kedro-org/kedro/issues/2682). This problem exists not only in Databricks, but in all IPython or Python interactive sessions (apparently Databricks runs everything through an IPython session).

This goes against the idea of a uniform entrypoint for all Kedro situations and makes Databricks deployment more difficult. The change suggested here will make the entrypoint accommodate to interactive and non-interactive workflows automatically. After this change, we can simplify further our guides for Databricks, more specifically dropping this part: https://docs.kedro.org/en/stable/deployment/databricks/databricks_deployment_workflow.html#create-an-entry-point-for-databricks and even dig deeper into how to avoid creating custom scripts or notebooks in the other two Databricks sections.

## Development notes

Previous attempt to fix this was tried in https://github.com/kedro-org/kedro/pull/1423 by @antonymilne, but that PR had way too many goals, including allowing to import `main()` and run it from a notebook, which delayed its merge and it was postponed. The current solution only addresses the ability to run a packaged project directly in an interactive session, which is already a big improvement. I have changed only the default starter template. It's been tested manually on Databricks on my own research and also in a Databricks environment by a user.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
