### PR TITLE
Add new spaceflights starters to `kedro new --starter`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 * Dropped Python 3.7 support.
 * Introduced add-ons to the `kedro new` CLI flow.
+* The new spaceflights starters, `spaceflights-pandas`, `spaceflights-pandas-viz`, `spaceflights-pyspark`, and `spaceflights-pyspark-viz` can be used with the `kedro new` command with the `--starter` flag.
 
 ## Bug fixes and other changes
 
@@ -28,6 +29,7 @@
 * Anonymous nodes are given default names of the form `<function_name>([in1;in2;...]) -> [out1;out2;...]`, with the names of inputs and outputs separated by semicolons.
 * The default project template now has one `pyproject.toml` at the root of the project (containing both the packaging metadata and the Kedro build config).
 * The `requirements.txt` in the default project template moved to the root of the project as well (hence dependencies are now installed with `pip install -r requirements.txt` instead of `pip install -r src/requirements.txt`).
+* The `spaceflights` starter has been renamed to `spaceflights-pandas`.
 
 ## Migration guide from Kedro 0.18.* to 0.19.*
 

--- a/docs/source/deployment/aws_step_functions.md
+++ b/docs/source/deployment/aws_step_functions.md
@@ -23,7 +23,7 @@ To use AWS Step Functions, ensure you have the following:
 
 - An [AWS account set up](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/)
 - [Configured AWS credentials](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html) on your local machine
-- Generated Kedro project called **Spaceflights Step Functions** using [Kedro Spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights/).
+- Generated Kedro project called **Spaceflights Step Functions** using [Kedro Spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas/).
   - The final project directory's name should be `spaceflights-step-functions`.
   - You should complete the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) to understand the project's structure.
 

--- a/docs/source/experiment_tracking/index.md
+++ b/docs/source/experiment_tracking/index.md
@@ -57,7 +57,7 @@ The example code uses a version of Kedro-Viz `>6.2.0`.
 Create a new project using the spaceflights starter. From the terminal run:
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 Feel free to name your project as you like, but this guide assumes the project is named `Spaceflights`.

--- a/docs/source/kedro_project_setup/starters.md
+++ b/docs/source/kedro_project_setup/starters.md
@@ -51,7 +51,10 @@ The Kedro team maintains the following starters for a range of Kedro projects:
 * [`pandas-iris`](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris): The [Kedro Iris dataset example project](../get_started/new_project.md)
 * [`pyspark-iris`](https://github.com/kedro-org/kedro-starters/tree/main/pyspark-iris): An alternative Kedro Iris dataset example, using [PySpark](../integrations/pyspark_integration.md)
 * [`pyspark`](https://github.com/kedro-org/kedro-starters/tree/main/pyspark): The configuration and initialisation code for a [Kedro pipeline using PySpark](../integrations/pyspark_integration.md)
-* [`spaceflights`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code
+* [`spaceflights-pandas`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pandas` datasets.
+* [`spaceflights-pandas-viz`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas-viz): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pandas` datasets and visualisation and experiment tracking `kedro-viz` features.
+* [`spaceflights-pyspark`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pyspark): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pyspark` datasets.
+* [`spaceflights-pyspark-viz`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pyspark-viz): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pyspark` datasets and visualisation and experiment tracking `kedro-viz` features.
 
 ## Starter versioning
 

--- a/docs/source/nodes_and_pipelines/pipeline_registry.md
+++ b/docs/source/nodes_and_pipelines/pipeline_registry.md
@@ -31,7 +31,7 @@ The order in which you add the pipelines together is not significant (`data_scie
 
 ## Pipeline autodiscovery
 
-In the above example, you need to update the `register_pipelines()` function whenever you create a pipeline that should be returned as part of the project's pipelines. Since Kedro 0.18.3, you can achieve the same result with less code using [`find_pipelines()`](/kedro.framework.project.find_pipelines). The [updated pipeline registry](https://github.com/kedro-org/kedro-starters/blob/main/spaceflights/%7B%7B%20cookiecutter.repo_name%20%7D%7D/src/%7B%7B%20cookiecutter.python_package%20%7D%7D/pipeline_registry.py) contains no project-specific code:
+In the above example, you need to update the `register_pipelines()` function whenever you create a pipeline that should be returned as part of the project's pipelines. Since Kedro 0.18.3, you can achieve the same result with less code using [`find_pipelines()`](/kedro.framework.project.find_pipelines). The [updated pipeline registry](https://github.com/kedro-org/kedro-starters/blob/main/spaceflights-pandas/%7B%7B%20cookiecutter.repo_name%20%7D%7D/src/%7B%7B%20cookiecutter.python_package%20%7D%7D/pipeline_registry.py) contains no project-specific code:
 
 ```python
 def register_pipelines() -> Dict[str, Pipeline]:

--- a/docs/source/tutorial/tutorial_template.md
+++ b/docs/source/tutorial/tutorial_template.md
@@ -1,6 +1,6 @@
 # Set up the spaceflights project
 
-This section shows how to create a new project (with `kedro new` using the [Kedro spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights)) and install project dependencies (with `pip install -r requirements.txt`).
+This section shows how to create a new project (with `kedro new` using the [Kedro spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas)) and install project dependencies (with `pip install -r requirements.txt`).
 
 ## Create a new project
 
@@ -10,10 +10,10 @@ This section shows how to create a new project (with `kedro new` using the [Kedr
 We recommend that you use the same version of Kedro that was most recently used to test this tutorial (0.18.6). To check the version installed, type `kedro -V` in your terminal window.
 ```
 
-In your terminal, navigate to the folder you want to store the project. Type the following to generate the project from the [Kedro spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights). The project will be populated with a complete set of working example code:
+In your terminal, navigate to the folder you want to store the project. Type the following to generate the project from the [Kedro spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas). The project will be populated with a complete set of working example code:
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 When prompted for a project name, you should accept the default choice (`Spaceflights`) as the rest of this tutorial assumes that project name.

--- a/docs/source/visualisation/kedro-viz_visualisation.md
+++ b/docs/source/visualisation/kedro-viz_visualisation.md
@@ -7,10 +7,10 @@ If you haven't installed Kedro [follow the documentation to get set up](../get_s
 
 Then, in your terminal window, navigate to the folder you want to store the project.
 
-Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights):
+Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas):
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 When prompted for a project name, you can enter anything, but we will assume `Spaceflights` throughout.

--- a/docs/source/visualisation/preview_datasets.md
+++ b/docs/source/visualisation/preview_datasets.md
@@ -2,7 +2,7 @@
 
 This page describes how to preview data from different datasets in a Kedro project with Kedro-Viz. Dataset preview was introduced in Kedro-Viz version 6.3.0, which offers preview for `CSVDatasets` and `ExcelDatasets`.
 
-We use the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) to demonstrate how to add data preview for the `customer`, `shuttle` and `reviews` datasets. Even if you have not yet worked through the tutorial, you can still follow this example; you'll need to use the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights) to generate a copy of the project with working code in place.
+We use the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) to demonstrate how to add data preview for the `customer`, `shuttle` and `reviews` datasets. Even if you have not yet worked through the tutorial, you can still follow this example; you'll need to use the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas) to generate a copy of the project with working code in place.
 
 If you haven't installed Kedro [follow the documentation to get set up](../get_started/install.md).
 
@@ -11,7 +11,7 @@ Then, in your terminal window, navigate to the folder you want to store the proj
 Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights):
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 When prompted for a project name, you can enter anything, but we will assume `Spaceflights` throughout.

--- a/docs/source/visualisation/preview_datasets.md
+++ b/docs/source/visualisation/preview_datasets.md
@@ -8,7 +8,7 @@ If you haven't installed Kedro [follow the documentation to get set up](../get_s
 
 Then, in your terminal window, navigate to the folder you want to store the project.
 
-Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights):
+Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas):
 
 ```bash
 kedro new --starter=spaceflights-pandas

--- a/docs/source/visualisation/share_kedro_viz.md
+++ b/docs/source/visualisation/share_kedro_viz.md
@@ -8,10 +8,10 @@ This page describes how to publish Kedro-Viz so you can share it with others. It
 
 If you haven't installed Kedro [follow the documentation to get set up](../get_started/install.md). In your terminal window, navigate to the folder you want to store the project.
 
-If you have not yet worked through the tutorial, use the [Kedro starter for spaceflights](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights) to generate the project with working code in place. Type the following in your terminal:
+If you have not yet worked through the tutorial, use the [Kedro starter for spaceflights](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas) to generate the project with working code in place. Type the following in your terminal:
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 When prompted for a project name, you can enter anything, but we will assume `Spaceflights` throughout.

--- a/docs/source/visualisation/visualise_charts_with_plotly.md
+++ b/docs/source/visualisation/visualise_charts_with_plotly.md
@@ -4,16 +4,16 @@ This page describes how to make interactive visualisations of a Kedro project wi
 
 ## Visualisation with Plotly
 
-We use the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) and add a reporting pipeline that uses Plotly. Even if you have not yet worked through the tutorial, you can still follow this example; you'll need to use the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights) to generate a copy of the project with working code in place.
+We use the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) and add a reporting pipeline that uses Plotly. Even if you have not yet worked through the tutorial, you can still follow this example; you'll need to use the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas) to generate a copy of the project with working code in place.
 
 If you haven't installed Kedro [follow the documentation to get set up](../get_started/install.md).
 
 Then, in your terminal window, navigate to the folder you want to store the project.
 
-Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights):
+Generate a copy of the spaceflights tutorial project with all the code in place by using the [Kedro starter for the spaceflights tutorial](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas):
 
 ```bash
-kedro new --starter=spaceflights
+kedro new --starter=spaceflights-pandas
 ```
 
 When prompted for a project name, you can enter anything, but we will assume `Spaceflights` throughout.

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -78,7 +78,14 @@ _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec("pandas-iris", _STARTERS_REPO, "pandas-iris"),
     KedroStarterSpec("pyspark", _STARTERS_REPO, "pyspark"),
     KedroStarterSpec("pyspark-iris", _STARTERS_REPO, "pyspark-iris"),
-    KedroStarterSpec("spaceflights", _STARTERS_REPO, "spaceflights"),
+    KedroStarterSpec("spaceflights-pandas", _STARTERS_REPO, "spaceflights-pandas"),
+    KedroStarterSpec(
+        "spaceflights-pandas-viz", _STARTERS_REPO, "spaceflights-pandas-viz"
+    ),
+    KedroStarterSpec("spaceflights-pyspark", _STARTERS_REPO, "spaceflights-pyspark"),
+    KedroStarterSpec(
+        "spaceflights-pyspark-viz", _STARTERS_REPO, "spaceflights-pyspark-viz"
+    ),
     KedroStarterSpec("databricks-iris", _STARTERS_REPO, "databricks-iris"),
 ]
 # Set the origin for official starters

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -697,13 +697,13 @@ class TestNewWithStarterValid:
     def test_alias(self, fake_kedro_cli, mock_determine_repo_dir, mock_cookiecutter):
         CliRunner().invoke(
             fake_kedro_cli,
-            ["new", "--starter", "spaceflights"],
+            ["new", "--starter", "spaceflights-pandas"],
             input=_make_cli_prompt_input(),
         )
         kwargs = {
             "template": "git+https://github.com/kedro-org/kedro-starters.git",
             "checkout": version,
-            "directory": "spaceflights",
+            "directory": "spaceflights-pandas",
         }
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
@@ -713,13 +713,13 @@ class TestNewWithStarterValid:
     ):
         CliRunner().invoke(
             fake_kedro_cli,
-            ["new", "--starter", "spaceflights", "--checkout", "my_checkout"],
+            ["new", "--starter", "spaceflights-pandas", "--checkout", "my_checkout"],
             input=_make_cli_prompt_input(),
         )
         kwargs = {
             "template": "git+https://github.com/kedro-org/kedro-starters.git",
             "checkout": "my_checkout",
-            "directory": "spaceflights",
+            "directory": "spaceflights-pandas",
         }
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
@@ -798,7 +798,7 @@ class TestNewWithStarterInvalid:
     @pytest.mark.parametrize(
         "starter, repo",
         [
-            ("spaceflights", "https://github.com/kedro-org/kedro-starters.git"),
+            ("spaceflights-pandas", "https://github.com/kedro-org/kedro-starters.git"),
             (
                 "git+https://github.com/fake/fake.git",
                 "https://github.com/fake/fake.git",


### PR DESCRIPTION

## Description
<!-- Why was this PR created? -->
Resolve #3112 

Waiting on the renaming of `spaceflights-pandas` to be merged in the `kedro-starters` repo. 

- [ ] https://github.com/kedro-org/kedro-starters/pull/162

## Development notes
<!-- What have you changed, and how has this been tested? -->
Added the new starters to `--starter`
- spaceflights-pandas
- spaceflights-pandas-viz
- spaceflights-pyspark
- spaceflights-pyspark-viz



## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
