### PR TITLE
Add nightly build to `develop` branch

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -2,6 +2,10 @@ name: Run all checks on Kedro
 
 on:
   workflow_call:
+    inputs:
+      branch:
+        type: string
+        default: ''
   push:
     branches:
       - main
@@ -27,6 +31,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      branch: ${{ inputs.branch }}
 
   lint:
     strategy:
@@ -37,6 +42,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      branch: ${{ inputs.branch }}
 
   e2e-tests:
     strategy:
@@ -47,6 +53,7 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      branch: ${{ inputs.branch }}
 
   pip-compile:
     strategy:
@@ -57,3 +64,4 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+      branch: ${{ inputs.branch }}

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -7,6 +7,9 @@ on:
         type: string
       python-version:
         type: string
+      branch:
+        type: string
+        default: ''
 
 env:
   COLUMNS: 120
@@ -18,6 +21,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Python ${{inputs.python-version}}
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
         type: string
       python-version:
         type: string
+      branch:
+        type: string
+        default: ''
 
 jobs:
   lint:
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Python ${{ inputs.python-version }}
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,7 +8,12 @@ on:
 
 jobs:
   kedro-test:
+    strategy:
+      matrix:
+        branch: [ main, develop ]
     uses: ./.github/workflows/all-checks.yml
+    with:
+      branch: ${{ matrix.branch }}
 
   notify-kedro:
     permissions:

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -7,6 +7,9 @@ on:
         type: string
       python-version:
         type: string
+      branch:
+        type: string
+        default: ''
 
 jobs:
   pip-compile:
@@ -14,6 +17,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Python ${{inputs.python-version}}
         uses: actions/setup-python@v3
         with:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -7,12 +7,17 @@ on:
         type: string
       python-version:
         type: string
+      branch:
+        type: string
+        default: ''
 jobs:
   unit-tests:
     runs-on: ${{ inputs.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.branch }}
       - name: Set up Python ${{inputs.python-version}}
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Fix #3208 

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Add `main` and `develop` as strategy matrix options to nightly build
- Pass the "branch" input down to the reusable workflows 
- "branch" input is used with actions/checkout@v3 to checkout the appropriate branch

Tested on my fork - https://github.com/ankatiyar/kedro/actions/runs/6611457423


## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
