### PR TITLE
Make nightly build on develop use `make test` instead of `make test-no-spark`

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: pip freeze
         run: pip freeze
       - name: Run unit tests
-        if: inputs.os == 'ubuntu-latest'
+        if: inputs.os == 'ubuntu-latest' or inputs.branch == 'develop'
         run: make test
       - name: Run unit tests without spark (Windows)
         if: inputs.os == 'windows-latest'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,7 +47,7 @@ jobs:
       - name: pip freeze
         run: pip freeze
       - name: Run unit tests
-        if: inputs.os == 'ubuntu-latest' or inputs.branch == 'develop'
+        if: inputs.os == 'ubuntu-latest' || inputs.branch == 'develop'
         run: make test
       - name: Run unit tests without spark (Windows)
         if: inputs.os == 'windows-latest'

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,5 +50,5 @@ jobs:
         if: inputs.os == 'ubuntu-latest' || inputs.branch == 'develop'
         run: make test
       - name: Run unit tests without spark (Windows)
-        if: inputs.os == 'windows-latest'
+        if: inputs.os == 'windows-latest' && inputs.branch != 'develop'
         run: make test-no-spark


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Fix #3225 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
