### PR TITLE
Fix `%reload_kedro` line magic

### DIFF
--- a/kedro/ipython/__init__.py
+++ b/kedro/ipython/__init__.py
@@ -132,7 +132,7 @@ def _resolve_project_path(
     else:
         if local_namespace and "context" in local_namespace:
             # noqa: protected-access
-            project_path = local_namespace["context"]._project_path
+            project_path = local_namespace["context"].project_path
         else:
             project_path = _find_kedro_project(Path.cwd())
         if project_path:
@@ -147,7 +147,7 @@ def _resolve_project_path(
         project_path
         and local_namespace
         and "context" in local_namespace
-        and project_path != local_namespace["context"]._project_path
+        and project_path != local_namespace["context"].project_path
     ):
         logger.info("Updating path to Kedro project: %s...", project_path)
 

--- a/tests/ipython/test_ipython.py
+++ b/tests/ipython/test_ipython.py
@@ -247,7 +247,7 @@ class TestProjectPathResolution:
     def test_only_local_namespace_specified(self):
         class MockKedroContext:
             # A dummy stand-in for KedroContext sufficient for this test
-            _project_path = Path("/test").resolve()
+            project_path = Path("/test").resolve()
 
         result = _resolve_project_path(local_namespace={"context": MockKedroContext()})
         expected = Path("/test").resolve()
@@ -280,7 +280,7 @@ class TestProjectPathResolution:
     def test_project_path_update(self, caplog):
         class MockKedroContext:
             # A dummy stand-in for KedroContext sufficient for this test
-            _project_path = Path("/test").resolve()
+            project_path = Path("/test").resolve()
 
         local_namespace = {"context": MockKedroContext()}
         updated_path = Path("/updated_path").resolve()


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
I noticed that `%reload_kedro` wasn't working on `develop` because `_project_path` attribute from `KedroContext` has been removed/ renamed to `project_path`. 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
