### PR TITLE
Configure `ruff format`, use it instead of `black`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,16 @@ default_stages: [commit, manual]
 
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      # Ruff version.
-      rev: v0.0.277
+      rev: v0.1.3
       hooks:
         - id: ruff
           name: "ruff on kedro/, tests/ and docs/"
           args: ["--fix", "--exit-non-zero-on-fix"]
           exclude: "^kedro/templates/|^features/steps/test_starter/"
+        - id: ruff-format
+          name: "ruff format on kedro/, features/ and tests/"
+          files: "^kedro/|^features/|^tests/"
+          exclude: "^features/steps/test_starter|^kedro/templates/"
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v2.2.3
@@ -59,13 +62,6 @@ repos:
 
     - repo: local
       hooks:
-          - id: black
-            name: "Black"
-            language: system
-            files: ^kedro/|^features/|^tests/
-            types: [file, python]
-            exclude: ^features/steps/test_starter|^kedro/templates/
-            entry: black
           - id: imports
             name: "Import Linter"
             language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,7 +57,8 @@ repos:
       rev: v1.12.1
       hooks:
           - id: blacken-docs
-            additional_dependencies: [black~=22.0]
+            additional_dependencies:
+            - black==23.10.1
             entry: blacken-docs --skip-errors
 
     - repo: local

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,7 +58,7 @@ repos:
       hooks:
           - id: blacken-docs
             additional_dependencies:
-            - black==23.10.1
+            - black~=23.0
             entry: blacken-docs --skip-errors
 
     - repo: local

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -445,13 +445,13 @@ def log_suggestions(lines: list[str], name: str):
                 "["
                 + str(i)
                 + "] "
-                + re.sub(existing, r"{}".format(style(obj, fg="magenta")), lines[i])
+                + re.sub(existing, rf"{style(obj, fg='magenta')}", lines[i])
             )
             print(
                 "["
                 + str(i)
                 + "] "
-                + re.sub(existing, r"``{}``".format(style(obj, fg="green")), lines[i])
+                + re.sub(existing, rf"``{style(obj, fg='green')}``", lines[i])
             )
 
     if title_printed:
@@ -476,8 +476,8 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):  # noqa: PL
         print(
             style(
                 "Failed to check for class name mentions that can be "
-                "converted to reStructuredText links in docstring of {}. "
-                "Error is: \n{}".format(name, str(e)),
+                f"converted to reStructuredText links in docstring of {name}. "
+                f"Error is: \n{str(e)}",
                 fg="red",
             )
         )
@@ -539,7 +539,7 @@ except Exception as e:
         style(
             "Failed to create list of (regex, reStructuredText link "
             "replacement) for class names and method names in docstrings. "
-            "Error is: \n{}".format(str(e)),
+            f"Error is: \n{str(e)}",
             fg="red",
         )
     )

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -503,9 +503,7 @@ def _add_jinja_filters(app):
 
     # LaTeXBuilder is used in the PDF docs build,
     # and it doesn't have attribute 'templates'
-    if not (
-        isinstance(app.builder, (LaTeXBuilder,CheckExternalLinksBuilder))
-    ):
+    if not (isinstance(app.builder, (LaTeXBuilder, CheckExternalLinksBuilder))):
         app.builder.templates.environment.filters["env_override"] = env_override
 
 

--- a/docs/source/get_started/kedro_concepts.md
+++ b/docs/source/get_started/kedro_concepts.md
@@ -21,12 +21,14 @@ Here are two simple nodes as an example:
 ```python
 from kedro.pipeline import node
 
+
 # First node
 def return_greeting():
     return "Hello"
 
 
 return_greeting_node = node(func=return_greeting, inputs=None, outputs="my_salutation")
+
 
 # Second node
 def join_statements(greeting):

--- a/docs/source/hooks/examples.md
+++ b/docs/source/hooks/examples.md
@@ -116,7 +116,6 @@ import great_expectations as ge
 
 
 class DataValidationHooks:
-
     # Map expectation to dataset
     DATASET_EXPECTATION_MAPPING = {
         "companies": "raw_companies_dataset_expectation",
@@ -207,7 +206,6 @@ import great_expectations as ge
 
 
 class DataValidationHooks:
-
     # Map checkpoint to dataset
     DATASET_CHECKPOINT_MAPPING = {
         "companies": "raw_companies_dataset_checkpoint",

--- a/docs/source/notebooks_and_ipython/notebook-example/add_kedro_to_a_notebook.md
+++ b/docs/source/notebooks_and_ipython/notebook-example/add_kedro_to_a_notebook.md
@@ -391,7 +391,6 @@ random_state = conf_params["model_options"]["random_state"]
 
 ```python
 def big_function():
-
     ####################
     # Data processing  #
     ####################
@@ -469,14 +468,12 @@ def _parse_money(x: pd.Series) -> pd.Series:
 
 
 def preprocess_companies(companies: pd.DataFrame) -> pd.DataFrame:
-
     companies["iata_approved"] = _is_true(companies["iata_approved"])
     companies["company_rating"] = _parse_percentage(companies["company_rating"])
     return companies
 
 
 def preprocess_shuttles(shuttles: pd.DataFrame) -> pd.DataFrame:
-
     shuttles["d_check_complete"] = _is_true(shuttles["d_check_complete"])
     shuttles["moon_clearance_complete"] = _is_true(shuttles["moon_clearance_complete"])
     shuttles["price"] = _parse_money(shuttles["price"])
@@ -486,7 +483,6 @@ def preprocess_shuttles(shuttles: pd.DataFrame) -> pd.DataFrame:
 def create_model_input_table(
     shuttles: pd.DataFrame, companies: pd.DataFrame, reviews: pd.DataFrame
 ) -> pd.DataFrame:
-
     rated_shuttles = shuttles.merge(reviews, left_on="id", right_on="shuttle_id")
     model_input_table = rated_shuttles.merge(
         companies, left_on="company_id", right_on="id"
@@ -590,14 +586,12 @@ def _parse_money(x: pd.Series) -> pd.Series:
 
 
 def preprocess_companies(companies: pd.DataFrame) -> pd.DataFrame:
-
     companies["iata_approved"] = _is_true(companies["iata_approved"])
     companies["company_rating"] = _parse_percentage(companies["company_rating"])
     return companies
 
 
 def preprocess_shuttles(shuttles: pd.DataFrame) -> pd.DataFrame:
-
     shuttles["d_check_complete"] = _is_true(shuttles["d_check_complete"])
     shuttles["moon_clearance_complete"] = _is_true(shuttles["moon_clearance_complete"])
     shuttles["price"] = _parse_money(shuttles["price"])
@@ -607,7 +601,6 @@ def preprocess_shuttles(shuttles: pd.DataFrame) -> pd.DataFrame:
 def create_model_input_table(
     shuttles: pd.DataFrame, companies: pd.DataFrame, reviews: pd.DataFrame
 ) -> pd.DataFrame:
-
     rated_shuttles = shuttles.merge(reviews, left_on="id", right_on="shuttle_id")
     model_input_table = rated_shuttles.merge(
         companies, left_on="company_id", right_on="id"

--- a/docs/source/visualisation/visualise_charts_with_plotly.md
+++ b/docs/source/visualisation/visualise_charts_with_plotly.md
@@ -85,6 +85,7 @@ import plotly.express as px
 import plotly.graph_objs as go
 import pandas as pd
 
+
 # This function uses plotly.express
 def compare_passenger_capacity_exp(preprocessed_shuttles: pd.DataFrame):
     return (
@@ -96,7 +97,6 @@ def compare_passenger_capacity_exp(preprocessed_shuttles: pd.DataFrame):
 
 # This function uses plotly.graph_objects
 def compare_passenger_capacity_go(preprocessed_shuttles: pd.DataFrame):
-
     data_frame = (
         preprocessed_shuttles.groupby(["shuttle_type"])
         .mean(numeric_only=True)

--- a/features/steps/sh_run.py
+++ b/features/steps/sh_run.py
@@ -36,8 +36,7 @@ def run(
     """
     if isinstance(cmd, str) and split:
         cmd = shlex.split(cmd)
-    # pylint: disable=subprocess-run-check
-    result = subprocess.run(cmd, input="", capture_output=True, **kwargs)
+    result = subprocess.run(cmd, input="", capture_output=True, **kwargs)  # noqa: PLW1510
     result.stdout = result.stdout.decode("utf-8")
     result.stderr = result.stderr.decode("utf-8")
     if print_output:

--- a/kedro/config/config.py
+++ b/kedro/config/config.py
@@ -66,7 +66,7 @@ class ConfigLoader(AbstractConfigLoader):
 
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         conf_source: str,
         env: str = None,

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -76,7 +76,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         conf_source: str,
         env: str = None,
@@ -254,7 +254,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
             f"config_patterns={self.config_patterns})"
         )
 
-    def load_and_merge_dir_config(  # noqa: too-many-arguments
+    def load_and_merge_dir_config(  # noqa: PLR0913
         self,
         conf_path: str,
         patterns: Iterable[str],

--- a/kedro/config/templated_config.py
+++ b/kedro/config/templated_config.py
@@ -89,7 +89,7 @@ class TemplatedConfigLoader(AbstractConfigLoader):
     https://github.com/jmespath/jmespath.py and https://jmespath.org/.
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         conf_source: str,
         env: str = None,

--- a/kedro/extras/datasets/api/api_dataset.py
+++ b/kedro/extras/datasets/api/api_dataset.py
@@ -57,7 +57,7 @@ class APIDataSet(AbstractDataset[None, requests.Response]):
         >>> data = data_set.load()
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         url: str,
         method: str = "GET",

--- a/kedro/extras/datasets/biosequence/biosequence_dataset.py
+++ b/kedro/extras/datasets/biosequence/biosequence_dataset.py
@@ -44,7 +44,7 @@ class BioSequenceDataSet(AbstractDataset[List, List]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/dask/parquet_dataset.py
+++ b/kedro/extras/datasets/dask/parquet_dataset.py
@@ -92,7 +92,7 @@ class ParquetDataSet(AbstractDataset[dd.DataFrame, dd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"write_index": False}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/email/message_dataset.py
+++ b/kedro/extras/datasets/email/message_dataset.py
@@ -25,9 +25,7 @@ from kedro.io.core import (
 # in kedro-plugins (https://github.com/kedro-org/kedro-plugins)
 
 
-class EmailMessageDataSet(
-    AbstractVersionedDataset[Message, Message]
-):  # pylint: disable=too-many-instance-attributes
+class EmailMessageDataSet(AbstractVersionedDataset[Message, Message]):  # pylint: disable=too-many-instance-attributes
     """``EmailMessageDataSet`` loads/saves an email message from/to a file
     using an underlying filesystem (e.g.: local, S3, GCS). It uses the
     ``email`` package in the standard library to manage email messages.

--- a/kedro/extras/datasets/email/message_dataset.py
+++ b/kedro/extras/datasets/email/message_dataset.py
@@ -58,7 +58,7 @@ class EmailMessageDataSet(AbstractVersionedDataset[Message, Message]):  # pylint
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/geopandas/geojson_dataset.py
+++ b/kedro/extras/datasets/geopandas/geojson_dataset.py
@@ -52,7 +52,7 @@ class GeoJSONDataSet(
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"driver": "GeoJSON"}
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/holoviews/holoviews_writer.py
+++ b/kedro/extras/datasets/holoviews/holoviews_writer.py
@@ -44,7 +44,7 @@ class HoloviewsWriter(AbstractVersionedDataset[HoloViews, NoReturn]):
 
     DEFAULT_SAVE_ARGS = {"fmt": "png"}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         fs_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/json/json_dataset.py
+++ b/kedro/extras/datasets/json/json_dataset.py
@@ -56,7 +56,7 @@ class JSONDataSet(AbstractVersionedDataset[Any, Any]):
 
     DEFAULT_SAVE_ARGS = {"indent": 2}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         save_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/matplotlib/matplotlib_writer.py
+++ b/kedro/extras/datasets/matplotlib/matplotlib_writer.py
@@ -111,7 +111,7 @@ class MatplotlibWriter(
 
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         fs_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/networkx/gml_dataset.py
+++ b/kedro/extras/datasets/networkx/gml_dataset.py
@@ -44,7 +44,7 @@ class GMLDataSet(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/networkx/graphml_dataset.py
+++ b/kedro/extras/datasets/networkx/graphml_dataset.py
@@ -43,7 +43,7 @@ class GraphMLDataSet(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/networkx/json_dataset.py
+++ b/kedro/extras/datasets/networkx/json_dataset.py
@@ -44,7 +44,7 @@ class JSONDataSet(AbstractVersionedDataset[networkx.Graph, networkx.Graph]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/csv_dataset.py
+++ b/kedro/extras/datasets/pandas/csv_dataset.py
@@ -73,7 +73,7 @@ class CSVDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"index": False}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/excel_dataset.py
+++ b/kedro/extras/datasets/pandas/excel_dataset.py
@@ -113,7 +113,7 @@ class ExcelDataSet(
     DEFAULT_LOAD_ARGS = {"engine": "openpyxl"}
     DEFAULT_SAVE_ARGS = {"index": False}
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         engine: str = "openpyxl",

--- a/kedro/extras/datasets/pandas/feather_dataset.py
+++ b/kedro/extras/datasets/pandas/feather_dataset.py
@@ -73,7 +73,7 @@ class FeatherDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/gbq_dataset.py
+++ b/kedro/extras/datasets/pandas/gbq_dataset.py
@@ -70,7 +70,7 @@ class GBQTableDataSet(AbstractDataset[None, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"progress_bar": False}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         dataset: str,
         table_name: str,
@@ -209,7 +209,7 @@ class GBQQueryDataSet(AbstractDataset[None, pd.DataFrame]):
 
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         sql: str = None,
         project: str = None,

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -186,7 +186,6 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
             )
 
     def _load(self) -> pd.DataFrame:
-
         self._ensure_file_system_target()
 
         load_path = get_filepath_str(self._get_load_path(), self._protocol)
@@ -201,7 +200,6 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
         )
 
     def _save(self, data: pd.DataFrame) -> None:
-
         self._ensure_file_system_target()
 
         save_path = get_filepath_str(self._get_save_path(), self._protocol)

--- a/kedro/extras/datasets/pandas/generic_dataset.py
+++ b/kedro/extras/datasets/pandas/generic_dataset.py
@@ -90,7 +90,7 @@ class GenericDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         file_format: str,

--- a/kedro/extras/datasets/pandas/hdf_dataset.py
+++ b/kedro/extras/datasets/pandas/hdf_dataset.py
@@ -65,7 +65,7 @@ class HDFDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         key: str,

--- a/kedro/extras/datasets/pandas/json_dataset.py
+++ b/kedro/extras/datasets/pandas/json_dataset.py
@@ -69,7 +69,7 @@ class JSONDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/parquet_dataset.py
+++ b/kedro/extras/datasets/pandas/parquet_dataset.py
@@ -81,7 +81,7 @@ class ParquetDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/sql_dataset.py
+++ b/kedro/extras/datasets/pandas/sql_dataset.py
@@ -337,7 +337,7 @@ class SQLQueryDataSet(AbstractDataset[None, pd.DataFrame]):
     # sqlalchemy.engine.Engine or sqlalchemy.engine.base.Engine
     engines: Dict[str, Any] = {}
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         sql: str = None,
         credentials: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pandas/xml_dataset.py
+++ b/kedro/extras/datasets/pandas/xml_dataset.py
@@ -51,7 +51,7 @@ class XMLDataSet(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"index": False}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/pickle/pickle_dataset.py
+++ b/kedro/extras/datasets/pickle/pickle_dataset.py
@@ -77,7 +77,7 @@ class PickleDataSet(AbstractVersionedDataset[Any, Any]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments,too-many-locals
+    def __init__(  # noqa: PLR0913,too-many-locals
         self,
         filepath: str,
         backend: str = "pickle",

--- a/kedro/extras/datasets/pillow/image_dataset.py
+++ b/kedro/extras/datasets/pillow/image_dataset.py
@@ -40,7 +40,7 @@ class ImageDataSet(AbstractVersionedDataset[Image.Image, Image.Image]):
 
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         save_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/plotly/json_dataset.py
+++ b/kedro/extras/datasets/plotly/json_dataset.py
@@ -58,7 +58,7 @@ class JSONDataSet(
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/plotly/plotly_dataset.py
+++ b/kedro/extras/datasets/plotly/plotly_dataset.py
@@ -71,7 +71,7 @@ class PlotlyDataSet(JSONDataSet):
 
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         plotly_args: Dict[str, Any],

--- a/kedro/extras/datasets/redis/redis_dataset.py
+++ b/kedro/extras/datasets/redis/redis_dataset.py
@@ -65,7 +65,7 @@ class PickleDataSet(AbstractDataset[Any, Any]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         key: str,
         backend: str = "pickle",

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -234,7 +234,7 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # ruff: noqa: PLR0913
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         file_format: str = "parquet",

--- a/kedro/extras/datasets/spark/spark_dataset.py
+++ b/kedro/extras/datasets/spark/spark_dataset.py
@@ -345,7 +345,6 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
 
     @staticmethod
     def _load_schema_from_file(schema: Dict[str, Any]) -> StructType:
-
         filepath = schema.get("filepath")
         if not filepath:
             raise DatasetError(
@@ -361,7 +360,6 @@ class SparkDataSet(AbstractVersionedDataset[DataFrame, DataFrame]):
 
         # Open schema file
         with file_system.open(load_path) as fs_file:
-
             try:
                 return StructType.fromJson(json.loads(fs_file.read()))
             except Exception as exc:

--- a/kedro/extras/datasets/spark/spark_hive_dataset.py
+++ b/kedro/extras/datasets/spark/spark_hive_dataset.py
@@ -72,7 +72,7 @@ class SparkHiveDataSet(AbstractDataset[DataFrame, DataFrame]):
 
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         database: str,
         table: str,

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -72,7 +72,7 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         url: str,
         table: str,

--- a/kedro/extras/datasets/spark/spark_jdbc_dataset.py
+++ b/kedro/extras/datasets/spark/spark_jdbc_dataset.py
@@ -131,7 +131,6 @@ class SparkJDBCDataSet(AbstractDataset[DataFrame, DataFrame]):
 
         # Update properties in load_args and save_args with credentials.
         if credentials is not None:
-
             # Check credentials for bad inputs.
             for cred_key, cred_value in credentials.items():
                 if cred_value is None:

--- a/kedro/extras/datasets/svmlight/svmlight_dataset.py
+++ b/kedro/extras/datasets/svmlight/svmlight_dataset.py
@@ -91,7 +91,7 @@ class SVMLightDataSet(AbstractVersionedDataset[_DI, _DO]):
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
+++ b/kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py
@@ -69,7 +69,7 @@ class TensorFlowModelDataset(AbstractVersionedDataset[tf.keras.Model, tf.keras.M
     DEFAULT_LOAD_ARGS = {}  # type: Dict[str, Any]
     DEFAULT_SAVE_ARGS = {"save_format": "tf"}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         load_args: Dict[str, Any] = None,

--- a/kedro/extras/datasets/yaml/yaml_dataset.py
+++ b/kedro/extras/datasets/yaml/yaml_dataset.py
@@ -54,7 +54,7 @@ class YAMLDataSet(AbstractVersionedDataset[Dict, Dict]):
 
     DEFAULT_SAVE_ARGS = {"default_flow_style": False}  # type: Dict[str, Any]
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         filepath: str,
         save_args: Dict[str, Any] = None,

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -10,7 +10,7 @@ import tarfile
 import tempfile
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Iterable, Iterator, List, Tuple, Union
+from typing import Any, Iterable, Iterator, Union
 
 import click
 from build.util import project_wheel_metadata
@@ -824,13 +824,10 @@ def _refactor_code_for_package(
         _move_package_with_conflicting_name(tests_target, "tests")
 
 
-_SourcePathType = Union[Path, List[Tuple[Path, str]]]
-
-
 def _generate_sdist_file(  # noqa: too-many-arguments,too-many-locals
     micropkg_name: str,
     destination: Path,
-    source_paths: tuple[_SourcePathType, ...],
+    source_paths: tuple[Path, Path, list[tuple[Path, str]]],
     version: str,
     metadata: ProjectMetadata,
     alias: str = None,
@@ -847,20 +844,20 @@ def _generate_sdist_file(  # noqa: too-many-arguments,too-many-locals
             package_source,
             tests_source,
             alias,
-            metadata,  # type: ignore
+            metadata,
         )
         project.close()
 
         # Copy & "refactor" config
         _, _, conf_target = _get_package_artifacts(temp_dir_path, package_name)
-        _sync_path_list(conf_source, conf_target)  # type: ignore
+        _sync_path_list(conf_source, conf_target)
         if conf_target.is_dir() and alias:
             _rename_files(conf_target, micropkg_name, alias)
 
         # Build a pyproject.toml on the fly
         try:
             install_requires = _make_install_requires(
-                package_source / "requirements.txt"  # type: ignore
+                package_source / "requirements.txt"
             )
         except Exception as exc:
             click.secho("FAILED", fg="red")

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -10,7 +10,7 @@ import tarfile
 import tempfile
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Iterable, Iterator, Union
+from typing import Any, Iterable, Iterator
 
 import click
 from build.util import project_wheel_metadata

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -154,7 +154,7 @@ def micropkg():
     help="Location of a configuration file for the fsspec filesystem used to pull the package.",
 )
 @click.pass_obj  # this will pass the metadata as first argument
-def pull_package(  # noqa: unused-argument, PLR0913
+def pull_package(  # noqa: PLR0913
     metadata: ProjectMetadata,
     package_path,
     env,

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -154,7 +154,7 @@ def micropkg():
     help="Location of a configuration file for the fsspec filesystem used to pull the package.",
 )
 @click.pass_obj  # this will pass the metadata as first argument
-def pull_package(  # noqa: unused-argument, too-many-arguments
+def pull_package(  # noqa: unused-argument, PLR0913
     metadata: ProjectMetadata,
     package_path,
     env,
@@ -189,7 +189,7 @@ def pull_package(  # noqa: unused-argument, too-many-arguments
     click.secho(message, fg="green")
 
 
-def _pull_package(  # noqa: too-many-arguments
+def _pull_package(  # noqa: PLR0913
     package_path: str,
     metadata: ProjectMetadata,
     env: str = None,
@@ -331,7 +331,7 @@ def _package_micropkgs_from_manifest(metadata: ProjectMetadata) -> None:
 )
 @click.argument("module_path", nargs=1, required=False, callback=_check_module_path)
 @click.pass_obj  # this will pass the metadata as first argument
-def package_micropkg(  # noqa: too-many-arguments
+def package_micropkg(  # noqa: PLR0913
     metadata: ProjectMetadata,
     module_path,
     env,
@@ -443,7 +443,7 @@ def _rename_files(conf_source: Path, old_name: str, new_name: str):
         config_file.rename(config_file.parent / new_config_name)
 
 
-def _refactor_code_for_unpacking(  # noqa: too-many-arguments
+def _refactor_code_for_unpacking(  # noqa: PLR0913
     project: Project,
     package_path: Path,
     tests_path: Path,
@@ -524,7 +524,7 @@ def _refactor_code_for_unpacking(  # noqa: too-many-arguments
     return refactored_package_path, refactored_tests_path
 
 
-def _install_files(  # noqa: too-many-arguments, too-many-locals
+def _install_files(  # noqa: PLR0913, too-many-locals
     project_metadata: ProjectMetadata,
     package_name: str,
     source_path: Path,
@@ -824,7 +824,7 @@ def _refactor_code_for_package(
         _move_package_with_conflicting_name(tests_target, "tests")
 
 
-def _generate_sdist_file(  # noqa: too-many-arguments,too-many-locals
+def _generate_sdist_file(  # noqa: PLR0913,too-many-locals
     micropkg_name: str,
     destination: Path,
     source_paths: tuple[Path, Path, list[tuple[Path, str]]],

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -843,7 +843,11 @@ def _generate_sdist_file(  # noqa: too-many-arguments,too-many-locals
 
         project = Project(temp_dir_path)  # project where to do refactoring
         _refactor_code_for_package(
-            project, package_source, tests_source, alias, metadata  # type: ignore
+            project,
+            package_source,
+            tests_source,
+            alias,
+            metadata,  # type: ignore
         )
         project.close()
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -140,9 +140,7 @@ def create_pipeline(
     "-y", "--yes", is_flag=True, help="Confirm deletion of pipeline non-interactively."
 )
 @click.pass_obj  # this will pass the metadata as first argument
-def delete_pipeline(
-    metadata: ProjectMetadata, name, env, yes, **kwargs
-):  # noqa: unused-argument
+def delete_pipeline(metadata: ProjectMetadata, name, env, yes, **kwargs):  # noqa: unused-argument
     """Delete a modular pipeline by providing a name."""
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -408,7 +408,7 @@ def activate_nbstripout(metadata: ProjectMetadata, **kwargs):  # noqa: unused-ar
     help=PARAMS_ARG_HELP,
     callback=_split_params,
 )
-def run(  # noqa: too-many-arguments,unused-argument,too-many-locals
+def run(  # noqa: PLR0913,unused-argument,too-many-locals
     tag,
     tags,
     env,

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -99,9 +99,7 @@ def test(metadata: ProjectMetadata, args, **kwargs):  # noqa: ument
 @click.option("-c", "--check-only", is_flag=True, help=LINT_CHECK_ONLY_HELP)
 @click.argument("files", type=click.Path(exists=True), nargs=-1)
 @click.pass_obj  # this will pass the metadata as first argument
-def lint(
-    metadata: ProjectMetadata, files, check_only, **kwargs
-):  # noqa: unused-argument
+def lint(metadata: ProjectMetadata, files, check_only, **kwargs):  # noqa: unused-argument
     """Run flake8, isort and black. (DEPRECATED)"""
     deprecation_message = (
         "DeprecationWarning: Command 'kedro lint' is deprecated and "
@@ -234,9 +232,7 @@ def build_docs(metadata: ProjectMetadata, open_docs):
     help=OUTPUT_FILE_HELP,
 )
 @click.pass_obj  # this will pass the metadata as first argument
-def build_reqs(
-    metadata: ProjectMetadata, input_file, output_file, args, **kwargs
-):  # noqa: unused-argument
+def build_reqs(metadata: ProjectMetadata, input_file, output_file, args, **kwargs):  # noqa: unused-argument
     """Run `pip-compile` on src/requirements.txt or the user defined input file and save
     the compiled requirements to src/requirements.lock or the user defined output file.
     (DEPRECATED)

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -300,7 +300,7 @@ def activate_nbstripout(metadata: ProjectMetadata, **kwargs):  # noqa: unused-ar
         ) from exc
 
     try:
-        res = subprocess.run(  # noqa: subprocess-run-check
+        res = subprocess.run(  # noqa: PLW1510
             ["git", "rev-parse", "--git-dir"],
             capture_output=True,
         )

--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -27,9 +27,7 @@ def list_registered_pipelines():
 @command_with_verbosity(registry, "describe")
 @click.argument("name", nargs=1, default="__default__")
 @click.pass_obj
-def describe_registered_pipeline(
-    metadata: ProjectMetadata, name, **kwargs
-):  # noqa: unused-argument, protected-access
+def describe_registered_pipeline(metadata: ProjectMetadata, name, **kwargs):  # noqa: unused-argument, protected-access
     """Describe a registered pipeline by providing a pipeline name.
     Defaults to the `__default__` pipeline.
     """

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -50,8 +50,7 @@ def call(cmd: list[str], **kwargs):  # pragma: no cover
         click.exceptions.Exit: If `subprocess.run` returns non-zero code.
     """
     click.echo(" ".join(shlex.quote(c) for c in cmd))
-    # noqa: subprocess-run-check
-    code = subprocess.run(cmd, **kwargs).returncode
+    code = subprocess.run(cmd, **kwargs).returncode  # noqa: PLW1510
     if code:
         raise click.exceptions.Exit(code=code)
 
@@ -220,7 +219,7 @@ def get_pkg_version(reqs_path: (str | Path), package_name: str) -> str:
     pattern = re.compile(package_name + r"([^\w]|$)")
     with reqs_path.open("r", encoding="utf-8") as reqs_file:
         for req_line in reqs_file:
-            req_line = req_line.strip()  # noqa: redefined-loop-name
+            req_line = req_line.strip()  # noqa: PLW2901
             if pattern.search(req_line):
                 return req_line
 
@@ -443,7 +442,7 @@ def _split_params(ctx, param, value):
             # which should not be replaced by =
             pass
         else:
-            item = item.replace(":", "=", 1)  # noqa: redefined-loop-name
+            item = item.replace(":", "=", 1)  # noqa: PLW2901
         items = item.split("=", 1)
         if len(items) != 2:  # noqa: PLR2004
             ctx.fail(

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -158,7 +158,7 @@ class KedroContext:
     Kedro's main functionality.
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         package_name: str,
         project_path: Path | str,

--- a/kedro/framework/hooks/specs.py
+++ b/kedro/framework/hooks/specs.py
@@ -18,7 +18,7 @@ class DataCatalogSpecs:
     """Namespace that defines all specifications for a data catalog's lifecycle hooks."""
 
     @hook_spec
-    def after_catalog_created(  # noqa: too-many-arguments
+    def after_catalog_created(  # noqa: PLR0913
         self,
         catalog: DataCatalog,
         conf_catalog: dict[str, Any],
@@ -48,7 +48,7 @@ class NodeSpecs:
     """Namespace that defines all specifications for a node's lifecycle hooks."""
 
     @hook_spec
-    def before_node_run(  # noqa: too-many-arguments
+    def before_node_run(  # noqa: PLR0913
         self,
         node: Node,
         catalog: DataCatalog,
@@ -76,7 +76,7 @@ class NodeSpecs:
         pass
 
     @hook_spec
-    def after_node_run(  # noqa: too-many-arguments
+    def after_node_run(  # noqa: PLR0913
         self,
         node: Node,
         catalog: DataCatalog,
@@ -104,7 +104,7 @@ class NodeSpecs:
         pass
 
     @hook_spec
-    def on_node_error(  # noqa: too-many-arguments
+    def on_node_error(  # noqa: PLR0913
         self,
         error: Exception,
         node: Node,

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -362,7 +362,7 @@ def find_pipelines() -> dict[str, Pipeline]:  # noqa: PLR0912
         pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
         try:
             pipeline_module = importlib.import_module(pipeline_module_name)
-        except:  # noqa: bare-except  # noqa: E722
+        except:  # noqa: E722
             warnings.warn(
                 IMPORT_ERROR_MESSAGE.format(
                     module=pipeline_module_name, tb_exc=traceback.format_exc()

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -101,7 +101,7 @@ class KedroSession:
 
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         session_id: str,
         package_name: str = None,
@@ -126,7 +126,7 @@ class KedroSession:
         )
 
     @classmethod
-    def create(  # noqa: too-many-arguments
+    def create(  # noqa: PLR0913
         cls,
         package_name: str = None,
         project_path: Path | str | None = None,
@@ -313,7 +313,7 @@ class KedroSession:
             self._log_exception(exc_type, exc_value, tb_)
         self.close()
 
-    def run(  # noqa: too-many-arguments,too-many-locals
+    def run(  # noqa: PLR0913,too-many-locals
         self,
         pipeline_name: str = None,
         tags: Iterable[str] = None,

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -141,7 +141,7 @@ class DataCatalog:
     to the underlying data sets.
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         data_sets: dict[str, AbstractDataset] = None,
         feed_dict: dict[str, Any] = None,

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -286,7 +286,7 @@ class DataCatalog:
         layers: dict[str, set[str]] = defaultdict(set)
 
         for ds_name, ds_config in catalog.items():
-            ds_config = _resolve_credentials(  # noqa: redefined-loop-name
+            ds_config = _resolve_credentials(  # noqa: PLW2901
                 ds_config, credentials
             )
             if cls._is_pattern(ds_name):

--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -81,7 +81,7 @@ class LambdaDataset(AbstractDataset):
         else:
             self.__release()
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         load: Callable[[], Any] | None,
         save: Callable[[Any], None] | None,

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -321,7 +321,7 @@ class PartitionedDataset(AbstractDataset):
             kwargs[self._filepath_arg] = self._join_protocol(partition)
             dataset = self._dataset_type(**kwargs)  # type: ignore
             if callable(partition_data):
-                partition_data = partition_data()  # noqa: redefined-loop-name
+                partition_data = partition_data()  # noqa: PLW2901
             dataset.save(partition_data)
         self._invalidate_caches()
 

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -137,7 +137,7 @@ class PartitionedDataset(AbstractDataset):
 
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         path: str,
         dataset: str | type[AbstractDataset] | dict[str, Any],
@@ -388,7 +388,7 @@ class IncrementalDataset(PartitionedDataset):
     DEFAULT_CHECKPOINT_TYPE = "kedro.extras.datasets.text.TextDataSet"
     DEFAULT_CHECKPOINT_FILENAME = "CHECKPOINT"
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         path: str,
         dataset: str | type[AbstractDataset] | dict[str, Any],

--- a/kedro/io/partitioned_dataset.py
+++ b/kedro/io/partitioned_dataset.py
@@ -400,7 +400,6 @@ class IncrementalDataset(PartitionedDataset):
         fs_args: dict[str, Any] = None,
         metadata: dict[str, Any] = None,
     ):
-
         """Creates a new instance of ``IncrementalDataset``.
 
         Args:

--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -150,7 +150,7 @@ def _get_param_names_mapping(
     return params
 
 
-def pipeline(  # noqa: too-many-arguments
+def pipeline(  # noqa: PLR0913
     pipe: Iterable[Node | Pipeline] | Pipeline,
     *,
     inputs: str | set[str] | dict[str, str] | None = None,

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -19,7 +19,7 @@ class Node:
     run user-provided functions as part of Kedro pipelines.
     """
 
-    def __init__(  # noqa: too-many-arguments
+    def __init__(  # noqa: PLR0913
         self,
         func: Callable,
         inputs: None | str | list[str] | dict[str, str],
@@ -519,7 +519,7 @@ def _node_error_message(msg) -> str:
     )
 
 
-def node(  # noqa: too-many-arguments
+def node(  # noqa: PLR0913
     func: Callable,
     inputs: None | str | list[str] | dict[str, str],
     outputs: None | str | list[str] | dict[str, str],

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -679,7 +679,7 @@ class Pipeline:  # noqa: too-many-public-methods
         nodes = [node for node in self.nodes if tags & node.tags]
         return Pipeline(nodes)
 
-    def filter(  # noqa: too-many-arguments
+    def filter(  # noqa: PLR0913
         self,
         tags: Iterable[str] = None,
         from_nodes: Iterable[str] = None,

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -104,7 +104,7 @@ def _bootstrap_subprocess(package_name: str, logging_config: dict[str, Any]):
     configure_logging(logging_config)
 
 
-def _run_node_synchronization(  # noqa: too-many-arguments
+def _run_node_synchronization(  # noqa: PLR0913
     node: Node,
     catalog: DataCatalog,
     is_async: bool = False,

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -335,7 +335,7 @@ def run_node(
     return node
 
 
-def _collect_inputs_from_hook(  # noqa: too-many-arguments
+def _collect_inputs_from_hook(  # noqa: PLR0913
     node: Node,
     catalog: DataCatalog,
     inputs: dict[str, Any],
@@ -368,7 +368,7 @@ def _collect_inputs_from_hook(  # noqa: too-many-arguments
     return additional_inputs
 
 
-def _call_node_run(  # noqa: too-many-arguments
+def _call_node_run(  # noqa: PLR0913
     node: Node,
     catalog: DataCatalog,
     inputs: dict[str, Any],

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -343,7 +343,6 @@ def _collect_inputs_from_hook(  # noqa: too-many-arguments
     hook_manager: PluginManager,
     session_id: str = None,
 ) -> dict[str, Any]:
-
     inputs = inputs.copy()  # shallow copy to prevent in-place modification by the hook
     hook_response = hook_manager.hook.before_node_run(
         node=node,
@@ -377,7 +376,6 @@ def _call_node_run(  # noqa: too-many-arguments
     hook_manager: PluginManager,
     session_id: str = None,
 ) -> dict[str, Any]:
-
     try:
         outputs = node.run(inputs)
     except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,12 +74,11 @@ include = ["kedro*"]
 readme = {file = "README.md", content-type = "text/markdown"}
 version = {attr = "kedro.__version__"}
 
-[tool.black]
-exclude = "/templates/|^features/steps/test_starter"
+[tool.ruff.format]
+exclude = ["**/templates", "features/steps/test_starter"]
 
 [tool.isort]
 profile = "black"
-
 
 [tool.pylint]
 [tool.pylint.master]
@@ -216,7 +215,7 @@ select = [
     "PL",  # Pylint
     "T201", # Print Statement
 ]
-ignore = ["E501"]  # Black takes care of line-too-long
+ignore = ["E501"]  # ruff format takes care of line-too-long
 
 [tool.ruff.isort]
 known-first-party = ["kedro"]

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -518,7 +518,7 @@ class TestOmegaConfigLoader:
 
     @use_config_dir
     def test_load_config_from_tar_file(self, tmp_path):
-        subprocess.run(  # pylint: disable=subprocess-run-check
+        subprocess.run(  # noqa: PLW1510
             [
                 "tar",
                 "--exclude=local/*.yml",

--- a/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
+++ b/tests/extras/datasets/matplotlib/test_matplotlib_writer.py
@@ -103,9 +103,7 @@ def overwrite(request):
 
 
 @pytest.fixture
-def plot_writer(
-    mocked_s3_bucket, fs_args, save_args, overwrite
-):  # pylint: disable=unused-argument
+def plot_writer(mocked_s3_bucket, fs_args, save_args, overwrite):  # pylint: disable=unused-argument
     return MatplotlibWriter(
         filepath=FULL_PATH,
         credentials=AWS_CREDENTIALS,
@@ -170,7 +168,6 @@ class TestMatplotlibWriter:
         plot_writer.save(mock_dict_plot)
 
         for colour in COLOUR_LIST:
-
             download_path = tmp_path / "downloaded_image.png"
             actual_filepath = tmp_path / "locally_saved.png"
 
@@ -361,7 +358,6 @@ class TestMatplotlibWriterVersioned:
         versioned_plot_writer.save(mock_list_plot)
 
         for index in range(5):
-
             test_path = tmp_path / "test_image.png"
             versioned_filepath = str(versioned_plot_writer._get_load_path())
 

--- a/tests/extras/datasets/pandas/test_gbq_dataset.py
+++ b/tests/extras/datasets/pandas/test_gbq_dataset.py
@@ -26,9 +26,7 @@ def mock_bigquery_client(mocker):
 
 
 @pytest.fixture
-def gbq_dataset(
-    load_args, save_args, mock_bigquery_client
-):  # pylint: disable=unused-argument
+def gbq_dataset(load_args, save_args, mock_bigquery_client):  # pylint: disable=unused-argument
     return GBQTableDataSet(
         dataset=DATASET,
         table_name=TABLE_NAME,
@@ -57,9 +55,7 @@ def sql_file(tmp_path: PosixPath):
 
 
 @pytest.fixture(params=[{}])
-def gbq_sql_file_dataset(
-    load_args, sql_file, mock_bigquery_client
-):  # pylint: disable=unused-argument
+def gbq_sql_file_dataset(load_args, sql_file, mock_bigquery_client):  # pylint: disable=unused-argument
     return GBQQueryDataSet(
         filepath=sql_file,
         project=PROJECT,

--- a/tests/extras/datasets/spark/test_spark_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_dataset.py
@@ -539,7 +539,7 @@ class TestSparkDataSetVersionedLocal:
     sys.platform.startswith("win"), reason="DBFS doesn't work on Windows"
 )
 class TestSparkDataSetVersionedDBFS:
-    def test_load_latest(  # noqa: too-many-arguments
+    def test_load_latest(  # noqa: PLR0913
         self, mocker, versioned_dataset_dbfs, version, tmp_path, sample_spark_df
     ):
         mocked_glob = mocker.patch.object(versioned_dataset_dbfs, "_glob_function")
@@ -566,7 +566,7 @@ class TestSparkDataSetVersionedDBFS:
 
         assert reloaded.exceptAll(sample_spark_df).count() == 0
 
-    def test_save(  # noqa: too-many-arguments
+    def test_save(  # noqa: PLR0913
         self, mocker, versioned_dataset_dbfs, version, tmp_path, sample_spark_df
     ):
         mocked_glob = mocker.patch.object(versioned_dataset_dbfs, "_glob_function")
@@ -579,7 +579,7 @@ class TestSparkDataSetVersionedDBFS:
         )
         assert (tmp_path / FILENAME / version.save / FILENAME).exists()
 
-    def test_exists(  # noqa: too-many-arguments
+    def test_exists(  # noqa: PLR0913
         self, mocker, versioned_dataset_dbfs, version, tmp_path, sample_spark_df
     ):
         mocked_glob = mocker.patch.object(versioned_dataset_dbfs, "_glob_function")

--- a/tests/extras/datasets/spark/test_spark_dataset.py
+++ b/tests/extras/datasets/spark/test_spark_dataset.py
@@ -498,8 +498,8 @@ class TestSparkDataSetVersionedLocal:
         )
 
         pattern = (
-            r"Save version '{ev.save}' did not match load version "
-            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
+            rf"Save version '{exact_version.save}' did not match load version "
+            rf"'{exact_version.load}' for SparkDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_local.save(sample_spark_df)
@@ -712,9 +712,7 @@ class TestSparkDataSetVersionedS3:
 
         versioned_dataset_s3.load()
 
-        mocked_glob.assert_called_once_with(
-            "{b}/{f}/*/{f}".format(b=BUCKET_NAME, f=FILENAME)
-        )
+        mocked_glob.assert_called_once_with(f"{BUCKET_NAME}/{FILENAME}/*/{FILENAME}")
         get_spark.return_value.read.load.assert_called_once_with(
             "s3a://{b}/{f}/{v}/{f}".format(
                 b=BUCKET_NAME, f=FILENAME, v="mocked_version"
@@ -733,7 +731,7 @@ class TestSparkDataSetVersionedS3:
         ds_s3.load()
 
         get_spark.return_value.read.load.assert_called_once_with(
-            "s3a://{b}/{f}/{v}/{f}".format(b=BUCKET_NAME, f=FILENAME, v=ts), "parquet"
+            f"s3a://{BUCKET_NAME}/{FILENAME}/{ts}/{FILENAME}", "parquet"
         )
 
     def test_save(self, versioned_dataset_s3, version, mocker):
@@ -747,7 +745,7 @@ class TestSparkDataSetVersionedS3:
 
         versioned_dataset_s3.save(mocked_spark_df)
         mocked_spark_df.write.save.assert_called_once_with(
-            "s3a://{b}/{f}/{v}/{f}".format(b=BUCKET_NAME, f=FILENAME, v=version.save),
+            f"s3a://{BUCKET_NAME}/{FILENAME}/{version.save}/{FILENAME}",
             "parquet",
         )
 
@@ -761,15 +759,13 @@ class TestSparkDataSetVersionedS3:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save version '{ev.save}' did not match load version "
-            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
+            rf"Save version '{exact_version.save}' did not match load version "
+            rf"'{exact_version.load}' for SparkDataSet\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             ds_s3.save(mocked_spark_df)
         mocked_spark_df.write.save.assert_called_once_with(
-            "s3a://{b}/{f}/{v}/{f}".format(
-                b=BUCKET_NAME, f=FILENAME, v=exact_version.save
-            ),
+            f"s3a://{BUCKET_NAME}/{FILENAME}/{exact_version.save}/{FILENAME}",
             "parquet",
         )
 
@@ -853,7 +849,7 @@ class TestSparkDataSetVersionedHdfs:
         versioned_hdfs.load()
 
         get_spark.return_value.read.load.assert_called_once_with(
-            "hdfs://{fn}/{f}/{v}/{f}".format(fn=FOLDER_NAME, f=FILENAME, v=ts),
+            f"hdfs://{FOLDER_NAME}/{FILENAME}/{ts}/{FILENAME}",
             "parquet",
         )
 
@@ -875,13 +871,11 @@ class TestSparkDataSetVersionedHdfs:
         versioned_hdfs.save(mocked_spark_df)
 
         hdfs_status.assert_called_once_with(
-            "{fn}/{f}/{v}/{f}".format(fn=FOLDER_NAME, v=version.save, f=FILENAME),
+            f"{FOLDER_NAME}/{FILENAME}/{version.save}/{FILENAME}",
             strict=False,
         )
         mocked_spark_df.write.save.assert_called_once_with(
-            "hdfs://{fn}/{f}/{v}/{f}".format(
-                fn=FOLDER_NAME, v=version.save, f=FILENAME
-            ),
+            f"hdfs://{FOLDER_NAME}/{FILENAME}/{version.save}/{FILENAME}",
             "parquet",
         )
 
@@ -894,16 +888,14 @@ class TestSparkDataSetVersionedHdfs:
         mocked_spark_df = mocker.Mock()
 
         pattern = (
-            r"Save version '{ev.save}' did not match load version "
-            r"'{ev.load}' for SparkDataSet\(.+\)".format(ev=exact_version)
+            rf"Save version '{exact_version.save}' did not match load version "
+            rf"'{exact_version.load}' for SparkDataSet\(.+\)"
         )
 
         with pytest.warns(UserWarning, match=pattern):
             versioned_hdfs.save(mocked_spark_df)
         mocked_spark_df.write.save.assert_called_once_with(
-            "hdfs://{fn}/{f}/{sv}/{f}".format(
-                fn=FOLDER_NAME, f=FILENAME, sv=exact_version.save
-            ),
+            f"hdfs://{FOLDER_NAME}/{FILENAME}/{exact_version.save}/{FILENAME}",
             "parquet",
         )
 
@@ -925,7 +917,7 @@ class TestSparkDataSetVersionedHdfs:
             versioned_hdfs.save(mocked_spark_df)
 
         hdfs_status.assert_called_once_with(
-            "{fn}/{f}/{v}/{f}".format(fn=FOLDER_NAME, v=version.save, f=FILENAME),
+            f"{FOLDER_NAME}/{FILENAME}/{version.save}/{FILENAME}",
             strict=False,
         )
         mocked_spark_df.write.save.assert_not_called()

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -549,7 +549,6 @@ def test_no_overwrite(
 def test_no_param_datasets_in_resolve(
     fake_project_cli, fake_metadata, fake_load_context, mocker, mock_pipelines
 ):
-
     yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
     mocked_context = fake_load_context.return_value
 

--- a/tests/framework/cli/test_jupyter.py
+++ b/tests/framework/cli/test_jupyter.py
@@ -207,7 +207,7 @@ class TestConvertNotebookCommand:
         with NamedTemporaryFile() as f:
             yield Path(f.name)
 
-    # noqa: too-many-arguments
+    # noqa: PLR0913
     def test_convert_one_file_overwrite(
         self,
         mocker,

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -48,7 +48,7 @@ def _make_cli_prompt_input(project_name="", repo_name="", python_package=""):
     return "\n".join([project_name, repo_name, python_package])
 
 
-# noqa: too-many-arguments
+# noqa: PLR0913
 def _assert_template_ok(
     result,
     project_name="New Kedro Project",

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -187,9 +187,7 @@ def extra_params(request):
 
 
 @pytest.fixture
-def dummy_context(
-    tmp_path, prepare_project_dir, env, extra_params
-):  # pylint: disable=unused-argument
+def dummy_context(tmp_path, prepare_project_dir, env, extra_params):  # pylint: disable=unused-argument
     configure_project(MOCK_PACKAGE_NAME)
     config_loader = ConfigLoader(str(tmp_path / "conf"), env=env)
     context = KedroContext(

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -370,9 +370,7 @@ def mock_settings(mocker, project_hooks):
 
 
 @pytest.fixture
-def mock_session(
-    mock_settings, mock_package_name, tmp_path
-):  # pylint: disable=unused-argument
+def mock_session(mock_settings, mock_package_name, tmp_path):  # pylint: disable=unused-argument
     configure_project(mock_package_name)
     session = KedroSession.create(
         mock_package_name, tmp_path, extra_params={"params:key": "value"}

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -728,7 +728,6 @@ class TestKedroSession:
     def test_run_non_existent_pipeline(
         self, fake_project, mock_package_name, mock_runner
     ):
-
         pattern = (
             "Failed to find the pipeline named 'doesnotexist'. "
             "It needs to be generated and returned "

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -236,7 +236,6 @@ class TestNodeHooks:
     @SKIP_ON_WINDOWS
     @pytest.mark.usefixtures("mock_broken_pipelines")
     def test_on_node_error_hook_parallel_runner(self, mock_session, logs_listener):
-
         with pytest.raises(ValueError, match="broken"):
             mock_session.run(
                 runner=ParallelRunner(max_workers=2), node_names=["node1", "node2"]

--- a/tests/pipeline/test_modular_pipeline.py
+++ b/tests/pipeline/test_modular_pipeline.py
@@ -219,7 +219,7 @@ class TestPipelineHelper:
     )
     def test_missing_dataset_name(
         self, func, inputs, outputs, inputs_map, outputs_map, expected_missing
-    ):  # noqa: too-many-arguments
+    ):  # noqa: PLR0913
         raw_pipeline = modular_pipeline([node(func, inputs, outputs)])
 
         with pytest.raises(ModularPipelineError, match=r"Failed to map datasets") as e:

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -300,7 +300,7 @@ def inconsistent_input_kwargs():
     return dummy_func_args, "A", "B"
 
 
-lambda_identity = lambda input1: input1  # noqa: disable=E731 # pylint: disable=C3001
+lambda_identity = lambda input1: input1  # noqa: E731
 
 
 def lambda_inconsistent_input_size():

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -106,7 +106,7 @@ class TestMaxWorkers:
         cpu_cores,
         user_specified_number,
         expected_number,
-    ):  # noqa: too-many-arguments
+    ):  # noqa: PLR0913
         """
         The system has 2 cores, but we initialize the runner with max_workers=4.
         `fan_out_fan_in` pipeline needs 3 processes.

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -55,7 +55,7 @@ class TestMaxWorkers:
         catalog,
         user_specified_number,
         expected_number,
-    ):  # noqa: too-many-arguments
+    ):  # noqa: PLR0913
         """
         We initialize the runner with max_workers=4.
         `fan_out_fan_in` pipeline needs 3 threads.


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->
It's worth noting that there are a lot of warnings emitted by ruff (introduce an error on purpose, and run `make lint` to see them):

```
warning: Invalid `# noqa` directive on kedro/framework/session/session.py:53: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/session/session.py:81: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/session/session.py:189: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/session/session.py:420: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:108: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:117: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:261: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:285: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:368: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:379: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/micropkg.py:397: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/hooks/manager.py:2: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/pipeline.py:68: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/pipeline.py:74: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/pipeline.py:103: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/pipeline.py:143: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/pipeline.py:211: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/io/data_catalog.py:432: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/config/omegaconf_config.py:284: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:96: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:100: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:168: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:226: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:279: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/parallel_runner.py:302: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:71: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:79: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:102: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:135: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:235: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/project.py:278: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/context/context.py:134: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/pipeline/modular_pipeline.py:215: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/io/partitioned_dataset.py:41: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/io/partitioned_dataset.py:195: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/io/partitioned_dataset.py:257: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/io/partitioned_dataset.py:513: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/runner/runner.py:289: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/ipython/__init__.py:142: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/ipython/__init__.py:153: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/config/common.py:127: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:229: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:265: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:291: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:296: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:355: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:361: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:393: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/utils.py:399: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/cli/cli.py:164: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/pipeline/pipeline.py:74: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/project/__init__.py:3: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/project/__init__.py:134: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/project/__init__.py:211: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/framework/project/__init__.py:332: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py:139: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
warning: Invalid `# noqa` directive on kedro/extras/datasets/tensorflow/tensorflow_model_dataset.py:160: expected a comma-separated list of codes (e.g., `# noqa: F401, F841`).
```

All of these `noqa` directives aren't getting parsed, so they're essentially useless. I haven't tried to clean this up in this PR.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
