### PR TITLE
Remove `anyconfig` from requirements

### DIFF
--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import Any, Iterable, Iterator, List, Tuple, Union
 
 import click
+from omegaconf import OmegaConf
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
 from rope.base.project import Project
@@ -259,9 +260,9 @@ def _pull_package(  # noqa: too-many-arguments
 
 def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:
     # noqa: import-outside-toplevel
-    import anyconfig  # for performance reasons
+    import toml  # for performance reasons
 
-    config_dict = anyconfig.load(metadata.config_file)
+    config_dict = toml.load(metadata.config_file)
     config_dict = config_dict["tool"]["kedro"]
     build_specs = config_dict.get("micropkg", {}).get("pull")
 
@@ -283,9 +284,9 @@ def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:
 
 def _package_micropkgs_from_manifest(metadata: ProjectMetadata) -> None:
     # noqa: import-outside-toplevel
-    import anyconfig  # for performance reasons
+    import toml  # for performance reasons
 
-    config_dict = anyconfig.load(metadata.config_file)
+    config_dict = toml.load(metadata.config_file)
     config_dict = config_dict["tool"]["kedro"]
     build_specs = config_dict.get("micropkg", {}).get("package")
 
@@ -366,13 +367,12 @@ def package_micropkg(  # noqa: too-many-arguments
 
 def _get_fsspec_filesystem(location: str, fs_args: str | None):
     # noqa: import-outside-toplevel
-    import anyconfig
     import fsspec
 
     from kedro.io.core import get_protocol_and_path
 
     protocol, _ = get_protocol_and_path(location)
-    fs_args_config = anyconfig.load(fs_args) if fs_args else {}
+    fs_args_config = OmegaConf.to_container(OmegaConf.load(fs_args)) if fs_args else {}
 
     try:
         return fsspec.filesystem(protocol, **fs_args_config)

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -397,13 +397,13 @@ def _config_file_callback(ctx, param, value):  # noqa: unused-argument
     options are passed, they override config file values.
     """
     # for performance reasons
-    import anyconfig  # noqa: import-outside-toplevel
+    from omegaconf import OmegaConf
 
     ctx.default_map = ctx.default_map or {}
     section = ctx.info_name
 
     if value:
-        config = anyconfig.load(value)[section]
+        config = OmegaConf.to_container(OmegaConf.load(value))[section]
         ctx.default_map.update(config)
 
     return value

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -4,7 +4,7 @@ import sys
 from pathlib import Path
 from typing import NamedTuple, Union
 
-import anyconfig
+import toml
 
 from kedro import __version__ as kedro_version
 from kedro.framework.project import configure_project
@@ -74,7 +74,7 @@ def _get_project_metadata(project_path: Union[str, Path]) -> ProjectMetadata:
         )
 
     try:
-        metadata_dict = anyconfig.load(pyproject_toml)
+        metadata_dict = toml.load(pyproject_toml)
     except Exception as exc:
         raise RuntimeError(f"Failed to parse '{_PYPROJECT}' file.") from exc
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ authors = [
 description = "Kedro helps you build production-ready data and analytics pipelines"
 requires-python = ">=3.8"
 dependencies = [
-    "anyconfig>=0.10.0",
     "attrs>=21.3",
     "build>=0.7.0",
     "cachetools>=4.1",

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -3,9 +3,9 @@ from itertools import cycle
 from os import rename
 from pathlib import Path
 
-import anyconfig
 import click
 from click.testing import CliRunner
+from omegaconf import OmegaConf
 from pytest import fixture, mark, raises
 
 from kedro import __version__ as version
@@ -423,14 +423,15 @@ class TestRunCommand:
     @fixture(params=["run_config.yml", "run_config.json"])
     def fake_run_config(request, fake_root_dir):
         config_path = str(fake_root_dir / request.param)
-        anyconfig.dump(
-            {
-                "run": {
-                    "pipeline": "pipeline1",
-                    "tag": ["tag1", "tag2"],
-                    "node_names": ["node1", "node2"],
-                }
-            },
+        config = {
+            "run": {
+                "pipeline": "pipeline1",
+                "tag": ["tag1", "tag2"],
+                "node_names": ["node1", "node2"],
+            }
+        }
+        OmegaConf.save(
+            config,
             config_path,
         )
         return config_path
@@ -438,9 +439,9 @@ class TestRunCommand:
     @staticmethod
     @fixture
     def fake_run_config_with_params(fake_run_config, request):
-        config = anyconfig.load(fake_run_config)
+        config = OmegaConf.to_container(OmegaConf.load(fake_run_config))
         config["run"].update(request.param)
-        anyconfig.dump(config, fake_run_config)
+        OmegaConf.save(config, fake_run_config)
         return fake_run_config
 
     def test_run_successfully(

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -83,7 +83,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -110,7 +110,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -137,7 +137,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
         pattern = (
             "Found unexpected keys in 'pyproject.toml'. Make sure it "
             "only contains the following keys: ['package_name', "
@@ -157,7 +157,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
         pattern = (
             "Missing required keys ['package_name', 'project_name'] "
             "from 'pyproject.toml'."
@@ -168,7 +168,7 @@ class TestGetProjectMetadata:
 
     def test_toml_file_without_kedro_section(self, mocker):
         mocker.patch.object(Path, "is_file", return_value=True)
-        mocker.patch("anyconfig.load", return_value={})
+        mocker.patch("toml.load", return_value={})
 
         pattern = "There's no '[tool.kedro]' section in the 'pyproject.toml'."
 
@@ -188,7 +188,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
 
         project_metadata = _get_project_metadata(self.project_path)
 
@@ -209,7 +209,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "
@@ -234,7 +234,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("anyconfig.load", return_value=pyproject_toml_payload)
+        mocker.patch("toml.load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
