### PR TITLE
[Bug fix] - Make cookiecutter arguments consistent for all kedro new path

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -633,12 +633,6 @@ def _create_project(template_path: str, cookiecutter_args: dict[str, Any]):
         ) from exc
 
     _clean_pycache(Path(result_path))
-    extra_context = cookiecutter_args["extra_context"]
-    project_name = extra_context.get("project_name", "New Kedro Project")
-    python_package = extra_context.get(
-        "python_package", project_name.lower().replace(" ", "_").replace("-", "_")
-    )
-    add_ons = extra_context.get("add_ons")
 
     # Only core template and spaceflight starters have configurable add-ons
     if template_path == str(TEMPLATE_PATH) or (

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -560,8 +560,6 @@ def _make_cookiecutter_args(
         config["add_ons"] = [
             ADD_ONS_DICT[add_on] for add_on in _parse_add_ons_input(add_ons)  # type: ignore
         ]
-        config["add_ons"] = str(config["add_ons"])
-
     cookiecutter_args = {
         "output_dir": config.get("output_dir", str(Path.cwd().resolve())),
         "no_input": True,
@@ -579,6 +577,8 @@ def _make_cookiecutter_args(
 def fetch_template_based_on_add_ons(template_path, cookiecutter_args: dict[str, Any]):
     extra_context = cookiecutter_args["extra_context"]
     add_ons = extra_context.get("add_ons")
+    print("DEBUG**")
+    print(add_ons, type(add_ons))
     if add_ons and "Pyspark" in add_ons:
         cookiecutter_args["directory"] = "spaceflights-pyspark"
         pyspark_path = "git+https://github.com/kedro-org/kedro-starters.git"

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -33,7 +33,7 @@ from kedro.framework.cli.utils import (
 
 KEDRO_PATH = Path(kedro.__file__).parent
 TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
-_STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
+_STARTERS_REPO = "git+https://github.com/noklam/kedro-starters.git"
 
 
 @define(order=True)

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -617,7 +617,15 @@ def _create_project(template_path: str, cookiecutter_args: dict[str, Any]):
     # noqa: import-outside-toplevel
     from cookiecutter.main import cookiecutter  # for performance reasons
 
+    extra_context = cookiecutter_args["extra_context"]
+    project_name = extra_context.get("project_name", "New Kedro Project")
+    python_package = extra_context.get(
+        "python_package", project_name.lower().replace(" ", "_").replace("-", "_")
+    )
+    add_ons = extra_context.get("add_ons")
+
     try:
+        # This will trigger post_gen_hook.py
         result_path = cookiecutter(template=template_path, **cookiecutter_args)
     except Exception as exc:
         raise KedroCliError(

--- a/kedro/templates/project/hooks/post_gen_project.py
+++ b/kedro/templates/project/hooks/post_gen_project.py
@@ -14,7 +14,10 @@ def main():
     python_package_name = '{{ cookiecutter.python_package }}'
 
     # Get the selected add-ons from cookiecutter
-    selected_add_ons = "{{ cookiecutter.add_ons }}"
+    # Use `_cookiecutter` insteaf of `cookiecutter` because of a bug
+    # https://github.com/cookiecutter/cookiecutter/issues/1975
+
+    selected_add_ons = "{{ _cookiecutter.add_ons }}"
 
     # Handle template directories and requirements according to selected add-ons
     setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name)

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 import shutil
 import toml
@@ -105,11 +107,11 @@ def _remove_file(path: Path) -> None:
         path.unlink()
 
 
-def _handle_starter_setup(selected_add_ons_list: str, python_package_name: str) -> None:
+def _handle_starter_setup(selected_add_ons_list: list[str], python_package_name: str) -> None:
     """Clean up the unnecessary files in the starters template.
 
     Args:
-        selected_add_ons_list (str): A string contains the selected add-ons.
+        selected_add_ons_list (list[str]): A list of the selected add-ons.
         python_package_name (str): The name of the python package.
     """
     # Remove all .csv and .xlsx files from data/01_raw/
@@ -144,11 +146,11 @@ def _handle_starter_setup(selected_add_ons_list: str, python_package_name: str) 
     _remove_file(test_pipeline_path)
 
 
-def setup_template_add_ons(selected_add_ons_list: str, requirements_file_path: str, pyproject_file_path: str, python_package_name: str) -> None:
+def setup_template_add_ons(selected_add_ons_list: list[str], requirements_file_path: str, pyproject_file_path: str, python_package_name: str) -> None:
     """Setup the templates according to the choice of add-ons.
 
     Args:
-        selected_add_ons_list (str): A string contains the selected add-ons.
+        selected_add_ons_list (list[str]): A string contains the selected add-ons.
         requirements_file_path (str): The path of the `requiremenets.txt` in the template.
         pyproject_file_path (str): The path of the `pyproject.toml` in the template
         python_package_name (str): The name of the python package.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -24,4 +24,4 @@ namespaces = false
 package_name = "{{ cookiecutter.python_package }}"
 project_name = "{{ cookiecutter.project_name }}"
 kedro_init_version = "{{ cookiecutter.kedro_version }}"
-add_ons = {{ cookiecutter.add_ons | string | replace("\'", "\"") }}
+add_ons = {{ cookiecutter.add_ons | tojson }}


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Make sure the cookiecutter args is consistent, thus generating the same `pyproject.toml` in starters.
- Added two tests `test_cookiecutter_args`, this catch a bug that we missed. For example `kedro new --addons none` return a  `''` for cookiecutter args, but `[]` for `kedro new` -> none (interactive prompt)
- extra_context["add_ons"] should always return a list. (which is long string previously i.e. `"Linting, PySpark"`)
- In addition, upgrade `pytest-mock` because `spy.return_value` requires at least 1.10.0. Note, I think we should upgrade `pytest-mock`
  - The pin is very old (not urgent)
  - We shouldn't pin [`pytest-mock` in templates](https://github.com/kedro-org/kedro-starters/blob/28a2a02e8e5c0fc14982c68e3640bac8cad26290/spaceflights-pandas-viz/%7B%7B%20cookiecutter.repo_name%20%7D%7D/requirements.txt#L12) at all. kedro project doesn't necessary follow `kedro`'s test requirements. (create a new ticket)
 
Tests are failing because we need to propogate the same changes to `kedro-starters`, I have to use `_cookiecutter` instead of `cookiecutter` because of https://github.com/cookiecutter/cookiecutter/issues/1975.

Notes:
- starters are updated - you need to test this either with a local copy of `kedro-starters` or use the `--checkout` option (it's a temporary hack that still work because we haven't disable using both options and `cookiecutter` is fine with it, actually why do we want to block the `--checkout` option?)


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
