### PR TITLE
Fix reference to _register_hook_setuptools in dask deployment documentation

### DIFF
--- a/docs/source/deployment/dask.md
+++ b/docs/source/deployment/dask.md
@@ -41,7 +41,7 @@ from distributed import Client, as_completed, worker_client
 from kedro.framework.hooks.manager import (
     _create_hook_manager,
     _register_hooks,
-    _register_hooks_setuptools,
+    _register_hooks_entry_points,
 )
 from kedro.framework.project import settings
 from kedro.io import AbstractDataset, DataCatalog
@@ -145,7 +145,7 @@ class DaskRunner(AbstractRunner):
         """
         hook_manager = _create_hook_manager()
         _register_hooks(hook_manager, settings.HOOKS)
-        _register_hooks_setuptools(hook_manager, settings.DISABLE_HOOKS_FOR_PLUGINS)
+        _register_hooks_entry_points(hook_manager, settings.DISABLE_HOOKS_FOR_PLUGINS)
 
         return run_node(node, catalog, hook_manager, is_async, session_id)
 


### PR DESCRIPTION
Signed-off-by: Yolan Honoré-Rougé <yolan.honore.rouge@gmail.com>

> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->

The Dask deployment documentation refers to a ``_register_hook_setuptools`` privet function which has been renamed ``_register_hooks_entry_points`` in ???. TBH, I haven't tested end to end the documentation to see if the tutorial is up to date, but at least it is no longer "obviously" failing. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ]  Updated the documentation to reflect the code changes -> N/A
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file -> N/A
- [ ] Added tests to cover my changes -> N/A
- [X] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
