### PR TITLE
[Draft] Trying to use dataset factories for default datasets 

### DIFF
--- a/kedro/io/__init__.py
+++ b/kedro/io/__init__.py
@@ -14,7 +14,7 @@ from .core import (
 )
 from .data_catalog import DataCatalog
 from .lambda_dataset import LambdaDataset
-from .memory_dataset import MemoryDataset
+from .memory_dataset import MemoryDataset, SharedMemoryDataset
 
 __all__ = [
     "AbstractDataset",
@@ -26,5 +26,6 @@ __all__ = [
     "DatasetNotFoundError",
     "LambdaDataset",
     "MemoryDataset",
+    "SharedMemoryDataset",
     "Version",
 ]

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -438,6 +438,12 @@ class DataCatalog:
             return True
         return False
 
+    def add_default_pattern(self, dataset_type):
+        for pattern, _ in self._dataset_patterns.items():
+            if self._specificity(pattern) == 0:
+                return
+        self._dataset_patterns["{default}"] = {"type": dataset_type}
+
     @classmethod
     def _resolve_config(
         cls,

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -140,12 +140,12 @@ def _copy_with_mode(data: Any, copy_mode: str) -> Any:
     return copied_data
 
 
-class SharedMemoryDataset:
+class SharedMemoryDataset(AbstractDataset):
     """``_SharedMemoryDataset`` is a wrapper class for a shared MemoryDataset in SyncManager.
     It is not inherited from AbstractDataset class.
     """
 
-    def __init__(self, manager: SyncManager):
+    def __init__(self, manager: SyncManager = None):
         """Creates a new instance of ``_SharedMemoryDataset``,
         and creates shared memorydataset attribute.
 
@@ -153,6 +153,12 @@ class SharedMemoryDataset:
             manager: An instance of multiprocessing manager for shared objects.
 
         """
+        if manager:
+            self.shared_memory_dataset = manager.MemoryDataset()  # type: ignore
+        else:
+            self.shared_memory_dataset = None  # type: ignore
+
+    def set_manager(self, manager: SyncManager):
         self.shared_memory_dataset = manager.MemoryDataset()  # type: ignore
 
     def __getattr__(self, name):
@@ -175,3 +181,12 @@ class SharedMemoryDataset:
                     "implicit memory datasets can only be used with serialisable data"
                 ) from serialisation_exc
             raise exc
+
+    def _load(self) -> Any:
+        return self.shared_memory_dataset.load()
+
+    def _save(self, data: Any):
+        return self.shared_memory_dataset.save(data)
+
+    def _describe(self):
+        return "Shared memory dataset"

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import copy
+import pickle
+from multiprocessing.managers import SyncManager
 from typing import Any
 
 from kedro.io.core import AbstractDataset, DatasetError
@@ -136,3 +138,40 @@ def _copy_with_mode(data: Any, copy_mode: str) -> Any:
         )
 
     return copied_data
+
+
+class SharedMemoryDataset:
+    """``_SharedMemoryDataset`` is a wrapper class for a shared MemoryDataset in SyncManager.
+    It is not inherited from AbstractDataset class.
+    """
+
+    def __init__(self, manager: SyncManager):
+        """Creates a new instance of ``_SharedMemoryDataset``,
+        and creates shared memorydataset attribute.
+
+        Args:
+            manager: An instance of multiprocessing manager for shared objects.
+
+        """
+        self.shared_memory_dataset = manager.MemoryDataset()  # type: ignore
+
+    def __getattr__(self, name):
+        # This if condition prevents recursive call when deserialising
+        if name == "__setstate__":
+            raise AttributeError()
+        return getattr(self.shared_memory_dataset, name)
+
+    def save(self, data: Any):
+        """Calls save method of a shared MemoryDataset in SyncManager."""
+        try:
+            self.shared_memory_dataset.save(data)
+        except Exception as exc:
+            # Checks if the error is due to serialisation or not
+            try:
+                pickle.dumps(data)
+            except Exception as serialisation_exc:  # SKIP_IF_NO_SPARK
+                raise DatasetError(
+                    f"{str(data.__class__)} cannot be serialised. ParallelRunner "
+                    "implicit memory datasets can only be used with serialisable data"
+                ) from serialisation_exc
+            raise exc

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -75,7 +75,7 @@ class ParallelRunnerManager(SyncManager):
     """
 
 
-ParallelRunnerManager.register("MemoryDataset", MemoryDataset)  # noqa: no-member
+# ParallelRunnerManager.register("MemoryDataset", MemoryDataset)  # noqa: no-member
 
 
 def _bootstrap_subprocess(package_name: str, logging_config: dict[str, Any]):
@@ -147,6 +147,8 @@ class ParallelRunner(AbstractRunner):
         """
         super().__init__(is_async=is_async)
         self._manager = ParallelRunnerManager()
+        # print("REGISTERING @@@@@@@@")
+        self._manager.register("MemoryDataset", MemoryDataset)
         self._manager.start()  # noqa: consider-using-with
 
         # This code comes from the concurrent.futures library

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -21,7 +21,7 @@ from more_itertools import interleave
 from pluggy import PluginManager
 
 from kedro.framework.hooks.manager import _NullPluginManager
-from kedro.io import AbstractDataset, DataCatalog, MemoryDataset
+from kedro.io import DataCatalog, MemoryDataset
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 
@@ -90,11 +90,12 @@ class AbstractRunner(ABC):
         # Check if there's any output datasets that aren't in the catalog and don't match a pattern
         # in the catalog.
         free_outputs = pipeline.outputs() - set(registered_ds)
-        unregistered_ds = pipeline.datasets() - set(registered_ds)
+        # unregistered_ds = pipeline.datasets() - set(registered_ds)
 
+        # catalog.add_default_pattern("MemoryDataset")
         # Create a default dataset for unregistered datasets
-        for ds_name in unregistered_ds:
-            catalog.add(ds_name, self.create_default_dataset(ds_name))
+        # for ds_name in unregistered_ds:
+        #     catalog.add(ds_name, self.create_default_dataset(ds_name))
 
         if self._is_async:
             self._logger.info(
@@ -163,18 +164,18 @@ class AbstractRunner(ABC):
         """
         pass
 
-    @abstractmethod  # pragma: no cover
-    def create_default_dataset(self, ds_name: str) -> AbstractDataset:
-        """Factory method for creating the default dataset for the runner.
-
-        Args:
-            ds_name: Name of the missing dataset.
-
-        Returns:
-            An instance of an implementation of ``AbstractDataset`` to be
-            used for all unregistered datasets.
-        """
-        pass
+    # @abstractmethod  # pragma: no cover
+    # def create_default_dataset(self, ds_name: str) -> AbstractDataset:
+    #     """Factory method for creating the default dataset for the runner.
+    #
+    #     Args:
+    #         ds_name: Name of the missing dataset.
+    #
+    #     Returns:
+    #         An instance of an implementation of ``AbstractDataset`` to be
+    #         used for all unregistered datasets.
+    #     """
+    #     pass
 
     def _suggest_resume_scenario(
         self,
@@ -412,6 +413,7 @@ def _run_node_sequential(
     for name in node.inputs:
         hook_manager.hook.before_dataset_loaded(dataset_name=name, node=node)
         inputs[name] = catalog.load(name)
+
         hook_manager.hook.after_dataset_loaded(
             dataset_name=name, data=inputs[name], node=node
         )

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -8,7 +8,7 @@ from itertools import chain
 
 from pluggy import PluginManager
 
-from kedro.io import AbstractDataset, DataCatalog, MemoryDataset
+from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline
 from kedro.runner.runner import AbstractRunner, run_node
 
@@ -29,18 +29,18 @@ class SequentialRunner(AbstractRunner):
         """
         super().__init__(is_async=is_async)
 
-    def create_default_dataset(self, ds_name: str) -> AbstractDataset:
-        """Factory method for creating the default data set for the runner.
-
-        Args:
-            ds_name: Name of the missing data set
-
-        Returns:
-            An instance of an implementation of AbstractDataset to be used
-            for all unregistered data sets.
-
-        """
-        return MemoryDataset()
+    # def create_default_dataset(self, ds_name: str) -> AbstractDataset:
+    #     """Factory method for creating the default data set for the runner.
+    #
+    #     Args:
+    #         ds_name: Name of the missing data set
+    #
+    #     Returns:
+    #         An instance of an implementation of AbstractDataset to be used
+    #         for all unregistered data sets.
+    #
+    #     """
+    #     return MemoryDataset()
 
     def _run(
         self,
@@ -62,7 +62,7 @@ class SequentialRunner(AbstractRunner):
         """
         nodes = pipeline.nodes
         done_nodes = set()
-
+        catalog.add_default_pattern("MemoryDataset")
         load_counts = Counter(chain.from_iterable(n.inputs for n in nodes))
 
         for exec_index, node in enumerate(nodes):

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -11,7 +11,7 @@ from itertools import chain
 
 from pluggy import PluginManager
 
-from kedro.io import DataCatalog, MemoryDataset
+from kedro.io import DataCatalog
 from kedro.pipeline import Pipeline
 from kedro.pipeline.node import Node
 from kedro.runner.runner import AbstractRunner, run_node
@@ -51,18 +51,18 @@ class ThreadRunner(AbstractRunner):
 
         self._max_workers = max_workers
 
-    def create_default_dataset(self, ds_name: str) -> MemoryDataset:  # type: ignore
-        """Factory method for creating the default dataset for the runner.
-
-        Args:
-            ds_name: Name of the missing dataset.
-
-        Returns:
-            An instance of ``MemoryDataset`` to be used for all
-            unregistered datasets.
-
-        """
-        return MemoryDataset()
+    # def create_default_dataset(self, ds_name: str) -> MemoryDataset:  # type: ignore
+    #     """Factory method for creating the default dataset for the runner.
+    #
+    #     Args:
+    #         ds_name: Name of the missing dataset.
+    #
+    #     Returns:
+    #         An instance of ``MemoryDataset`` to be used for all
+    #         unregistered datasets.
+    #
+    #     """
+    #     return MemoryDataset()
 
     def _get_required_workers_count(self, pipeline: Pipeline):
         """
@@ -102,6 +102,7 @@ class ThreadRunner(AbstractRunner):
         """
         nodes = pipeline.nodes
         load_counts = Counter(chain.from_iterable(n.inputs for n in nodes))
+        catalog.add_default_pattern("MemoryDataset")
         node_dependencies = pipeline.node_dependencies
         todo_nodes = set(node_dependencies.keys())
         done_nodes: set[Node] = set()

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -13,7 +13,6 @@ from kedro.io import (
     DatasetError,
     LambdaDataset,
     MemoryDataset,
-    SharedMemoryDataset,
 )
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
@@ -51,10 +50,10 @@ class SingleProcessDataset(AbstractDataset):
     sys.platform.startswith("win"), reason="Due to bug in parallel runner"
 )
 class TestValidParallelRunner:
-    def test_create_default_dataset(self):
-        # dataset is a proxy to a dataset in another process.
-        dataset = ParallelRunner().create_default_dataset("")
-        assert isinstance(dataset, SharedMemoryDataset)
+    # def test_create_default_dataset(self):
+    #     # dataset is a proxy to a dataset in another process.
+    #     dataset = ParallelRunner().create_default_dataset("")
+    #     assert isinstance(dataset, SharedMemoryDataset)
 
     @pytest.mark.parametrize("is_async", [False, True])
     def test_parallel_run(self, is_async, fan_out_fan_in, catalog):

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -13,6 +13,7 @@ from kedro.io import (
     DatasetError,
     LambdaDataset,
     MemoryDataset,
+    SharedMemoryDataset,
 )
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
@@ -21,7 +22,6 @@ from kedro.runner.parallel_runner import (
     _MAX_WINDOWS_WORKERS,
     ParallelRunnerManager,
     _run_node_synchronization,
-    _SharedMemoryDataset,
 )
 from tests.runner.conftest import (
     exception_fn,
@@ -54,7 +54,7 @@ class TestValidParallelRunner:
     def test_create_default_dataset(self):
         # dataset is a proxy to a dataset in another process.
         dataset = ParallelRunner().create_default_dataset("")
-        assert isinstance(dataset, _SharedMemoryDataset)
+        assert isinstance(dataset, SharedMemoryDataset)
 
     @pytest.mark.parametrize("is_async", [False, True])
     def test_parallel_run(self, is_async, fan_out_fan_in, catalog):

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -14,9 +14,9 @@ from tests.runner.conftest import exception_fn, identity, return_none, sink, sou
 
 
 class TestValidThreadRunner:
-    def test_create_default_dataset(self):
-        dataset = ThreadRunner().create_default_dataset("")
-        assert isinstance(dataset, MemoryDataset)
+    # def test_create_default_dataset(self):
+    #     dataset = ThreadRunner().create_default_dataset("")
+    #     assert isinstance(dataset, MemoryDataset)
 
     def test_thread_run(self, fan_out_fan_in, catalog):
         catalog.add_feed_dict({"A": 42})


### PR DESCRIPTION
## Description

This PR is a quick prototype for #2668 

## Current behaviour
* creation of default datasets is handled in the `runner` -
* Each runner has a `create_default_dataset()` class which returns an `MemoryDataset`/`SharedMemoryDataset`(for parallel runner) object for each "unregistered dataset"(not mentioned in the catalog as an explicit entry but mentioned in the pipeline inputs or outputs) and adds it to the catalog.


Updating this behaviour to use a **dataset factories** instead for `SequentialRunner` and `ThreadRunner` is straight forward -
- Just add a catch-all pattern to the catalog with `MemoryDataset` : 
```
"{default}":
  type: MemoryDataset
```
- Add a function to catalog `catalog.add_pattern(name, config)` which can be called either -
   - With the current behaviour, in `runner.run()` after the "free outputs" have been calculated as these datasets are returned as the output for the session
   - Before `runner.run()` is called in the session, but then some logic to determine which datasets are "free outputs" needs to be added.

### Issues with `ParallelRunner`
- The default dataset for `ParallelRunner` is `SharedMemoryDataset` which is a wrapper around `MemoryDataset`. It is **not** an `AbstractDataset` -> therefore, doesn't have a `from_config()` function that the catalog uses in `catalog._get_dataset()/from_config()` to initialise datasets on creation
- `ParallelRunner` has a `_manager` attribute which is passed to the `SharedMemoryDataset` object on initialisation (can't be done in a declarative way by simply adding a catalog entry)

### Solution 
I've managed to hack together a solution in the draft PR #3269 

Some of these things can be cherry-picked and implemented regardless of whether we decide to go for the whole thing -

- Moved `SharedMemoryDataset` to `kedro/io` - it's currently defined in `kedro/runner/parallel_runner.py`
- Make `SharedMemoryDataset` a subclass of `AbstractDataset` - this allows the catalog to register it also through a "catalog entry" (catch-all pattern) but without initialising the underlying `shared_memory_dataset` 
- In the code for `ParallelRunner` -> it initialises the `shared_memory_dataset` attribute of the `SharedMemoryDataset` with the (`ParallelRunner`'s)`manager.MemoryDataset()` object if a dataset is a `SharedMemoryDataset`
- The way i've implemented it right now is first the runner checks for the existence of all pipeline datasets with `catalog.exists(dataset)` which calls `catalog._get_dataset(dataset)` -> the dataset factory datasets are registered to the Catalog. And then for the `SharedMemoryDataset`, initialise the underlying dataset. (This could be improved in the final implementation) 
