### PR TITLE
Add removed CLI commands to release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,7 +25,14 @@
 * Removed `PartitionedDataset` and `IncrementalDataset` from `kedro.io`
 
 ### CLI
-* Removed deprecated `kedro docs` command.
+* Removed deprecated commands:
+   * `kedro docs`
+   * `kedro jupyter convert`
+   * `kedro activate-nbstripout`
+   * `kedro build-docs`
+   * `kedro build-reqs`
+   * `kedro lint`
+   * `kedro test`
 * Added the `--addons` flag to the `kedro new` command.
 * Added the `--name` flag to the `kedro new` command.
 


### PR DESCRIPTION
## Description
The CLI command removed in https://github.com/kedro-org/kedro/pull/3065 weren't mentioned yet in the release notes. 

## Development notes
-


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
