### PR TITLE
Tidying the starter 

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -360,6 +360,14 @@ def _fetch_config_from_user_prompts(
     return config
 
 
+def _make_cookiecutter_context_for_prompts(cookiecutter_dir: Path):
+    # noqa: import-outside-toplevel
+    from cookiecutter.generate import generate_context
+
+    cookiecutter_context = generate_context(cookiecutter_dir / "cookiecutter.json")
+    return cookiecutter_context.get("cookiecutter", {})
+
+
 def _make_cookiecutter_args(
     config: dict[str, str],
     checkout: str,
@@ -495,14 +503,6 @@ def _get_prompts_required(cookiecutter_dir: Path) -> dict[str, Any] | None:
         raise KedroCliError(
             "Failed to generate project: could not load prompts.yml."
         ) from exc
-
-
-def _make_cookiecutter_context_for_prompts(cookiecutter_dir: Path):
-    # noqa: import-outside-toplevel
-    from cookiecutter.generate import generate_context
-
-    cookiecutter_context = generate_context(cookiecutter_dir / "cookiecutter.json")
-    return cookiecutter_context.get("cookiecutter", {})
 
 
 class _Prompt:

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -99,78 +99,6 @@ for starter_spec in _OFFICIAL_STARTER_SPECS:
 _OFFICIAL_STARTER_SPECS = {spec.alias: spec for spec in _OFFICIAL_STARTER_SPECS}
 
 
-# noqa: unused-argument
-def _remove_readonly(func: Callable, path: Path, excinfo: tuple):  # pragma: no cover
-    """Remove readonly files on Windows
-    See: https://docs.python.org/3/library/shutil.html?highlight=shutil#rmtree-example
-    """
-    os.chmod(path, stat.S_IWRITE)
-    func(path)
-
-
-def _get_starters_dict() -> dict[str, KedroStarterSpec]:
-    """This function lists all the starter aliases declared in
-    the core repo and in plugins entry points.
-
-    For example, the output for official kedro starters looks like:
-    {"astro-airflow-iris":
-        KedroStarterSpec(
-            name="astro-airflow-iris",
-            template_path="git+https://github.com/kedro-org/kedro-starters.git",
-            directory="astro-airflow-iris",
-            origin="kedro"
-        ),
-    "astro-iris":
-        KedroStarterSpec(
-            name="astro-iris",
-            template_path="git+https://github.com/kedro-org/kedro-starters.git",
-            directory="astro-airflow-iris",
-            origin="kedro"
-        ),
-    }
-    """
-    starter_specs = _OFFICIAL_STARTER_SPECS
-
-    for starter_entry_point in _get_entry_points(name="starters"):
-        origin = starter_entry_point.module.split(".")[0]
-        specs = _safe_load_entry_point(starter_entry_point) or []
-        for spec in specs:
-            if not isinstance(spec, KedroStarterSpec):
-                click.secho(
-                    f"The starter configuration loaded from module {origin}"
-                    f"should be a 'KedroStarterSpec', got '{type(spec)}' instead",
-                    fg="red",
-                )
-            elif spec.alias in starter_specs:
-                click.secho(
-                    f"Starter alias `{spec.alias}` from `{origin}` "
-                    f"has been ignored as it is already defined by"
-                    f"`{starter_specs[spec.alias].origin}`",
-                    fg="red",
-                )
-            else:
-                spec.origin = origin
-                starter_specs[spec.alias] = spec
-    return starter_specs
-
-
-def _starter_spec_to_dict(
-    starter_specs: dict[str, KedroStarterSpec]
-) -> dict[str, dict[str, str]]:
-    """Convert a dictionary of starters spec to a nicely formatted dictionary"""
-    format_dict: dict[str, dict[str, str]] = {}
-    for alias, spec in starter_specs.items():
-        if alias in _DEPRECATED_STARTERS:
-            key = alias + " (deprecated)"
-        else:
-            key = alias
-        format_dict[key] = {}  # Each dictionary represent 1 starter
-        format_dict[key]["template_path"] = spec.template_path
-        if spec.directory:
-            format_dict[key]["directory"] = spec.directory
-    return format_dict
-
-
 # noqa: missing-function-docstring
 @click.group(context_settings=CONTEXT_SETTINGS, name="Kedro")
 def create_cli():  # pragma: no cover
@@ -579,3 +507,75 @@ def _validate_config_file(config: dict[str, str], prompts: dict[str, Any]):
             f"'{config['output_dir']}' is not a valid output directory. "
             "It must be a relative or absolute path to an existing directory."
         )
+
+
+# noqa: unused-argument
+def _remove_readonly(func: Callable, path: Path, excinfo: tuple):  # pragma: no cover
+    """Remove readonly files on Windows
+    See: https://docs.python.org/3/library/shutil.html?highlight=shutil#rmtree-example
+    """
+    os.chmod(path, stat.S_IWRITE)
+    func(path)
+
+
+def _get_starters_dict() -> dict[str, KedroStarterSpec]:
+    """This function lists all the starter aliases declared in
+    the core repo and in plugins entry points.
+
+    For example, the output for official kedro starters looks like:
+    {"astro-airflow-iris":
+        KedroStarterSpec(
+            name="astro-airflow-iris",
+            template_path="git+https://github.com/kedro-org/kedro-starters.git",
+            directory="astro-airflow-iris",
+            origin="kedro"
+        ),
+    "astro-iris":
+        KedroStarterSpec(
+            name="astro-iris",
+            template_path="git+https://github.com/kedro-org/kedro-starters.git",
+            directory="astro-airflow-iris",
+            origin="kedro"
+        ),
+    }
+    """
+    starter_specs = _OFFICIAL_STARTER_SPECS
+
+    for starter_entry_point in _get_entry_points(name="starters"):
+        origin = starter_entry_point.module.split(".")[0]
+        specs = _safe_load_entry_point(starter_entry_point) or []
+        for spec in specs:
+            if not isinstance(spec, KedroStarterSpec):
+                click.secho(
+                    f"The starter configuration loaded from module {origin}"
+                    f"should be a 'KedroStarterSpec', got '{type(spec)}' instead",
+                    fg="red",
+                )
+            elif spec.alias in starter_specs:
+                click.secho(
+                    f"Starter alias `{spec.alias}` from `{origin}` "
+                    f"has been ignored as it is already defined by"
+                    f"`{starter_specs[spec.alias].origin}`",
+                    fg="red",
+                )
+            else:
+                spec.origin = origin
+                starter_specs[spec.alias] = spec
+    return starter_specs
+
+
+def _starter_spec_to_dict(
+    starter_specs: dict[str, KedroStarterSpec]
+) -> dict[str, dict[str, str]]:
+    """Convert a dictionary of starters spec to a nicely formatted dictionary"""
+    format_dict: dict[str, dict[str, str]] = {}
+    for alias, spec in starter_specs.items():
+        if alias in _DEPRECATED_STARTERS:
+            key = alias + " (deprecated)"
+        else:
+            key = alias
+        format_dict[key] = {}  # Each dictionary represent 1 starter
+        format_dict[key]["template_path"] = spec.template_path
+        if spec.directory:
+            format_dict[key]["directory"] = spec.directory
+    return format_dict

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -32,16 +32,19 @@ from kedro.framework.cli.utils import (
     command_with_verbosity,
 )
 
-KEDRO_PATH = Path(kedro.__file__).parent
-TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
-_STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
-
-_DEPRECATED_STARTERS = [
-    "pandas-iris",
-    "pyspark-iris",
-    "pyspark",
-    "standalone-datacatalog",
-]
+CONFIG_ARG_HELP = """Non-interactive mode, using a configuration yaml file. This file
+must supply  the keys required by the template's prompts.yml. When not using a starter,
+these are `project_name`, `repo_name` and `python_package`."""
+STARTER_ARG_HELP = """Specify the starter template to use when creating the project.
+This can be the path to a local directory, a URL to a remote VCS repository supported
+by `cookiecutter` or one of the aliases listed in ``kedro starter list``.
+"""
+CHECKOUT_ARG_HELP = (
+    "An optional tag, branch or commit to checkout in the starter repository."
+)
+DIRECTORY_ARG_HELP = (
+    "An optional directory inside the repository where the starter resides."
+)
 
 
 @define(order=True)
@@ -63,6 +66,17 @@ class KedroStarterSpec:  # noqa: too-few-public-methods
     origin: str | None = field(init=False)
 
 
+_DEPRECATED_STARTERS = [
+    "pandas-iris",
+    "pyspark-iris",
+    "pyspark",
+    "standalone-datacatalog",
+]
+KEDRO_PATH = Path(kedro.__file__).parent
+TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
+
+
+_STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
 _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec("astro-airflow-iris", _STARTERS_REPO, "astro-airflow-iris"),
     # The `astro-iris` was renamed to `astro-airflow-iris`, but old (external)
@@ -83,21 +97,6 @@ _OFFICIAL_STARTER_SPECS = [
 for starter_spec in _OFFICIAL_STARTER_SPECS:
     starter_spec.origin = "kedro"
 _OFFICIAL_STARTER_SPECS = {spec.alias: spec for spec in _OFFICIAL_STARTER_SPECS}
-
-
-CONFIG_ARG_HELP = """Non-interactive mode, using a configuration yaml file. This file
-must supply  the keys required by the template's prompts.yml. When not using a starter,
-these are `project_name`, `repo_name` and `python_package`."""
-STARTER_ARG_HELP = """Specify the starter template to use when creating the project.
-This can be the path to a local directory, a URL to a remote VCS repository supported
-by `cookiecutter` or one of the aliases listed in ``kedro starter list``.
-"""
-CHECKOUT_ARG_HELP = (
-    "An optional tag, branch or commit to checkout in the starter repository."
-)
-DIRECTORY_ARG_HELP = (
-    "An optional directory inside the repository where the starter resides."
-)
 
 
 # noqa: unused-argument

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -333,6 +333,31 @@ def _make_cookiecutter_args(
     return cookiecutter_args
 
 
+def _validate_config_file(config: dict[str, str], prompts: dict[str, Any]):
+    """Checks that the configuration file contains all needed variables.
+
+    Args:
+        config: The config as a dictionary.
+        prompts: Prompts from prompts.yml.
+
+    Raises:
+        KedroCliError: If the config file is empty or does not contain all the keys
+            required in prompts, or if the output_dir specified does not exist.
+    """
+    if config is None:
+        raise KedroCliError("Config file is empty.")
+    missing_keys = set(prompts) - set(config)
+    if missing_keys:
+        click.echo(yaml.dump(config, default_flow_style=False))
+        raise KedroCliError(f"{', '.join(missing_keys)} not found in config file.")
+
+    if "output_dir" in config and not Path(config["output_dir"]).exists():
+        raise KedroCliError(
+            f"'{config['output_dir']}' is not a valid output directory. "
+            "It must be a relative or absolute path to an existing directory."
+        )
+
+
 def _create_project(template_path: str, cookiecutter_args: dict[str, Any]):
     """Creates a new kedro project using cookiecutter.
 
@@ -482,31 +507,6 @@ def _get_available_tags(template_path: str) -> list:
     except git.GitCommandError:
         return []
     return sorted(unique_tags)
-
-
-def _validate_config_file(config: dict[str, str], prompts: dict[str, Any]):
-    """Checks that the configuration file contains all needed variables.
-
-    Args:
-        config: The config as a dictionary.
-        prompts: Prompts from prompts.yml.
-
-    Raises:
-        KedroCliError: If the config file is empty or does not contain all the keys
-            required in prompts, or if the output_dir specified does not exist.
-    """
-    if config is None:
-        raise KedroCliError("Config file is empty.")
-    missing_keys = set(prompts) - set(config)
-    if missing_keys:
-        click.echo(yaml.dump(config, default_flow_style=False))
-        raise KedroCliError(f"{', '.join(missing_keys)} not found in config file.")
-
-    if "output_dir" in config and not Path(config["output_dir"]).exists():
-        raise KedroCliError(
-            f"'{config['output_dir']}' is not a valid output directory. "
-            "It must be a relative or absolute path to an existing directory."
-        )
 
 
 # noqa: unused-argument

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -75,7 +75,6 @@ _DEPRECATED_STARTERS = [
 KEDRO_PATH = Path(kedro.__file__).parent
 TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
 
-
 _STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
 _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec("astro-airflow-iris", _STARTERS_REPO, "astro-airflow-iris"),
@@ -96,6 +95,7 @@ _OFFICIAL_STARTER_SPECS = [
 # Set the origin for official starters
 for starter_spec in _OFFICIAL_STARTER_SPECS:
     starter_spec.origin = "kedro"
+
 _OFFICIAL_STARTER_SPECS = {spec.alias: spec for spec in _OFFICIAL_STARTER_SPECS}
 
 
@@ -103,6 +103,11 @@ _OFFICIAL_STARTER_SPECS = {spec.alias: spec for spec in _OFFICIAL_STARTER_SPECS}
 @click.group(context_settings=CONTEXT_SETTINGS, name="Kedro")
 def create_cli():  # pragma: no cover
     pass
+
+
+@create_cli.group()
+def starter():
+    """Commands for working with project starters."""
 
 
 @command_with_verbosity(create_cli, short_help="Create a new kedro project.")
@@ -186,11 +191,6 @@ def new(config_path, starter_alias, checkout, directory, **kwargs):
 
     cookiecutter_args = _make_cookiecutter_args(config, checkout, directory)
     _create_project(template_path, cookiecutter_args)
-
-
-@create_cli.group()
-def starter():
-    """Commands for working with project starters."""
 
 
 @starter.command("list")

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -66,15 +66,15 @@ class KedroStarterSpec:  # noqa: too-few-public-methods
     origin: str | None = field(init=False)
 
 
+KEDRO_PATH = Path(kedro.__file__).parent
+TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
+
 _DEPRECATED_STARTERS = [
     "pandas-iris",
     "pyspark-iris",
     "pyspark",
     "standalone-datacatalog",
 ]
-KEDRO_PATH = Path(kedro.__file__).parent
-TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
-
 _STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
 _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec("astro-airflow-iris", _STARTERS_REPO, "astro-airflow-iris"),


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
It is a very small PR in a sense that it doesn't change anything, it just move stuff around to make it easier to read. 

## Development notes
<!-- What have you changed, and how has this been tested? -->

There is no functional changes, it's purely tidying work by doing the following:
- Move constants up and group them in logical way
- The API is moved at the beginning of the file (the CLI)
- method are either grouped in terms of their nature. i.e. `_get_xxx` method, or they are following the execution order. (mostly `kedro new` because it's the most complicated piece here)

To reviewer:
To review this it's best to have a look at the[ commit messages](https://github.com/kedro-org/kedro/pull/3294/commits) and try to read through the file in an IDE because the diff is not meaningful. It make most sense to review this with an IDE, opening the file side by side. The way that I do it is to have `starter.py` duplicate in two panes and one using the, with one mostly freeze and the other with "Fold all", so I can expand the definition to read when needed. (see screenshot below)

![image](https://github.com/kedro-org/kedro/assets/18221871/3ee9b09d-4032-490a-9ea2-172aaa84a1e1)


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
