### PR TITLE
ToDel: Add an option to get an example pipeline 2

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include LICENSE.md
 include kedro/framework/project/default_logging.yml
 include kedro/ipython/*.png
 include kedro/ipython/*.svg
-recursive-include templates *
+recursive-include kedro/templates *

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -153,6 +153,7 @@ def create_config_file(context):
     config = {
         "add_ons": "1-5",
         "project_name": context.project_name,
+        "example_pipeline": "No",
         "repo_name": context.project_name,
         "output_dir": str(context.temp_dir),
         "python_package": context.package_name,

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -144,8 +144,10 @@ NUMBER_TO_ADD_ONS_NAME = {
     "7": "Kedro Viz",
 }
 
+
 def _validate_yn(ctx, param, value):
     return value.lower() in ["y", "yes"] if value is not None else None
+
 
 # noqa: missing-function-docstring
 @click.group(context_settings=CONTEXT_SETTINGS, name="Kedro")

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -63,6 +63,7 @@ STARTER_ARG_HELP = """Specify the starter template to use when creating the proj
 This can be the path to a local directory, a URL to a remote VCS repository supported
 by `cookiecutter` or one of the aliases listed in ``kedro starter list``.
 """
+EXAMPLE_ARG_HELP = "Enter y to enable, n to disable the example pipeline."
 
 
 @define(order=True)
@@ -143,6 +144,8 @@ NUMBER_TO_ADD_ONS_NAME = {
     "7": "Kedro Viz",
 }
 
+def _validate_yn(ctx, param, value):
+    return value.lower() in ["y", "yes"] if value is not None else None
 
 # noqa: missing-function-docstring
 @click.group(context_settings=CONTEXT_SETTINGS, name="Kedro")
@@ -168,6 +171,14 @@ def starter():
 @click.option("--directory", help=DIRECTORY_ARG_HELP)
 @click.option("--addons", "-a", "selected_add_ons_flag", help=ADDON_ARG_HELP)
 @click.option("--name", "-n", "project_name", help=NAME_ARG_HELP)
+@click.option(
+    "--example",
+    "-e",
+    "example_pipeline",
+    type=click.Choice(["y", "n", "yes", "no"], case_sensitive=False),
+    callback=_validate_yn,
+    help=EXAMPLE_ARG_HELP,
+)
 def new(  # noqa: PLR0913
     config_path,
     starter_alias,
@@ -175,6 +186,7 @@ def new(  # noqa: PLR0913
     project_name,
     checkout,
     directory,
+    example_pipeline,  # This will be True or False
     **kwargs,
 ):
     """Create a new kedro project."""
@@ -216,7 +228,7 @@ def new(  # noqa: PLR0913
 
     # Select which prompts will be displayed to the user based on which flags were selected.
     prompts_required = _select_prompts_to_display(
-        prompts_required, selected_add_ons_flag, project_name
+        prompts_required, selected_add_ons_flag, project_name, example_pipeline
     )
 
     # We only need to make cookiecutter_context if interactive prompts are needed.
@@ -239,6 +251,7 @@ def new(  # noqa: PLR0913
         cookiecutter_context=cookiecutter_context,
         selected_add_ons_flag=selected_add_ons_flag,
         project_name=project_name,
+        example_pipeline=example_pipeline,
     )
 
     cookiecutter_args = _make_cookiecutter_args(
@@ -395,12 +408,13 @@ def _get_starters_dict() -> dict[str, KedroStarterSpec]:
     return starter_specs
 
 
-def _get_extra_context(
+def _get_extra_context(  # noqa: PLR0913
     prompts_required: dict,
     config_path: str,
     cookiecutter_context: OrderedDict,
     selected_add_ons_flag: str | None,
     project_name: str | None,
+    example_pipeline: bool,
 ) -> dict[str, str]:
     """Generates a config dictionary that will be passed to cookiecutter as `extra_context`, based
     on CLI flags, user prompts, or a configuration file.
@@ -454,6 +468,12 @@ def _get_extra_context(
         ]
         extra_context["add_ons"] = str(extra_context["add_ons"])
 
+    extra_context["example_pipeline"] = (
+        example_pipeline  # type: ignore
+        if example_pipeline is not None
+        else _validate_yn(None, None, extra_context.get("example_pipeline", None))
+    )
+
     return extra_context
 
 
@@ -482,7 +502,10 @@ def _convert_addon_names_to_numbers(selected_add_ons_flag: str | None) -> str | 
 
 
 def _select_prompts_to_display(
-    prompts_required: dict, selected_add_ons_flag: str, project_name: str
+    prompts_required: dict,
+    selected_add_ons_flag: str,
+    project_name: str,
+    example_pipeline: bool,
 ) -> dict:
     """Selects which prompts an user will receive when creating a new
     Kedro project, based on what information was already made available
@@ -494,6 +517,8 @@ def _select_prompts_to_display(
         selected_add_ons_flag: a string containing the value for the --addons flag,
             or None in case the flag wasn't used.
         project_name: a string containing the value for the --name flag, or
+            None in case the flag wasn't used.
+        example_pipeline: True or False for --example flag, or
             None in case the flag wasn't used.
 
     Returns:
@@ -529,6 +554,9 @@ def _select_prompts_to_display(
             )
             sys.exit(1)
         del prompts_required["project_name"]
+
+    if example_pipeline is not None:
+        del prompts_required["example_pipeline"]
 
     return prompts_required
 
@@ -602,23 +630,37 @@ def _fetch_config_from_user_prompts(
 
 def fetch_template_based_on_add_ons(template_path, cookiecutter_args: dict[str, Any]):
     extra_context = cookiecutter_args["extra_context"]
-    add_ons = extra_context.get("add_ons")
+    # If 'add_ons' or 'example_pipeline' are not specified in prompts.yml and not prompted in 'kedro new' options,
+    # default options will be used instead
+    add_ons = extra_context.get("add_ons", [])
+    example_pipeline = extra_context.get("example_pipeline", False)
     starter_path = "git+https://github.com/kedro-org/kedro-starters.git"
-    if add_ons:
-        if "Pyspark" in add_ons and "Kedro Viz" in add_ons:
-            # Use the spaceflights-pyspark-viz starter if both Pyspark and Kedro Viz are chosen.
-            cookiecutter_args["directory"] = "spaceflights-pyspark-viz"
-        elif "Pyspark" in add_ons:
-            # Use the spaceflights-pyspark starter if only Pyspark is chosen.
-            cookiecutter_args["directory"] = "spaceflights-pyspark"
-        elif "Kedro Viz" in add_ons:
-            # Use the spaceflights-pandas-viz starter if only Kedro Viz is chosen.
-            cookiecutter_args["directory"] = "spaceflights-pandas-viz"
-        else:
-            # Use the default template path for any other combinations or if "none" is chosen.
-            starter_path = template_path
+    if "Pyspark" in add_ons and "Kedro Viz" in add_ons:
+        # Use the spaceflights-pyspark-viz starter if both Pyspark and Kedro Viz are chosen.
+        cookiecutter_args["directory"] = "spaceflights-pyspark-viz"
+        cookiecutter_args[
+            "checkout"
+        ] = "3076-add-example-pipeline-to-hooks"  # ToDel: temporary for test
+    elif "Pyspark" in add_ons:
+        # Use the spaceflights-pyspark starter if only Pyspark is chosen.
+        cookiecutter_args["directory"] = "spaceflights-pyspark"
+        cookiecutter_args[
+            "checkout"
+        ] = "3076-add-example-pipeline-to-hooks"  # ToDel: temporary for test
+    elif "Kedro Viz" in add_ons:
+        # Use the spaceflights-pandas-viz starter if only Kedro Viz is chosen.
+        cookiecutter_args["directory"] = "spaceflights-pandas-viz"
+        cookiecutter_args[
+            "checkout"
+        ] = "3076-add-example-pipeline-to-hooks"  # ToDel: temporary for test
+    elif example_pipeline:
+        # Use spaceflights-pandas starter if example was selected, but PySpark or Viz wasn't
+        cookiecutter_args["directory"] = "spaceflights-pandas"  # pragma: no cover
+        cookiecutter_args[
+            "checkout"
+        ] = "3076-add-example-pipeline-to-hooks"  # pragma: no cover
     else:
-        # Use the default template path if add_ons is None, which can occur if there is no prompts.yml or its empty.
+        # Use the default template path for non Pyspark, Viz or example options:
         starter_path = template_path
     return starter_path
 

--- a/kedro/templates/project/cookiecutter.json
+++ b/kedro/templates/project/cookiecutter.json
@@ -3,5 +3,6 @@
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
     "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "add_ons": "none"
+    "add_ons": "none",
+    "example_pipeline": "No"
 }

--- a/kedro/templates/project/hooks/post_gen_project.py
+++ b/kedro/templates/project/hooks/post_gen_project.py
@@ -15,9 +15,10 @@ def main():
 
     # Get the selected add-ons from cookiecutter
     selected_add_ons = "{{ cookiecutter.add_ons }}"
+    example_pipeline = "{{ cookiecutter.example_pipeline }}"
 
     # Handle template directories and requirements according to selected add-ons
-    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name)
+    setup_template_add_ons(selected_add_ons, requirements_file_path, pyproject_file_path, python_package_name, example_pipeline)
 
     # Sort requirements.txt file in alphabetical order
     sort_requirements(requirements_file_path)

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -144,7 +144,7 @@ def _handle_starter_setup(selected_add_ons_list: str, python_package_name: str) 
     _remove_file(test_pipeline_path)
 
 
-def setup_template_add_ons(selected_add_ons_list: str, requirements_file_path: str, pyproject_file_path: str, python_package_name: str) -> None:
+def setup_template_add_ons(selected_add_ons_list: str, requirements_file_path: str, pyproject_file_path: str, python_package_name: str, example_pipeline: str) -> None:
     """Setup the templates according to the choice of add-ons.
 
     Args:
@@ -169,13 +169,13 @@ def setup_template_add_ons(selected_add_ons_list: str, requirements_file_path: s
         _remove_from_toml(pyproject_file_path, docs_pyproject_requirements)
         _remove_dir(current_dir / "docs")
 
-    if "Data Structure" not in selected_add_ons_list:
+    if "Data Structure" not in selected_add_ons_list and example_pipeline != "True":
         _remove_dir(current_dir / "data")
 
-    if "Pyspark" in selected_add_ons_list:
+    if "Pyspark" in selected_add_ons_list and example_pipeline != "True":
         _handle_starter_setup(selected_add_ons_list, python_package_name)
 
-    if "Kedro Viz" in selected_add_ons_list:
+    if "Kedro Viz" in selected_add_ons_list and example_pipeline != "True":
         _handle_starter_setup(selected_add_ons_list, python_package_name)
 
 

--- a/kedro/templates/project/prompts.yml
+++ b/kedro/templates/project/prompts.yml
@@ -35,6 +35,6 @@ example_pipeline:
     To skip this step in the future use --example=y/n
     To read more about how examples work visit: kedro.org/
     Would you like to include an example pipeline? \[y/N]:
-  regex_validator: "^(?i)(y|yes|n|no)$"
+  regex_validator: "(?i)^(y|yes|n|no)$"
   error_message: |
     It must contain only y, n, YES, NO, case insensitive.

--- a/kedro/templates/project/prompts.yml
+++ b/kedro/templates/project/prompts.yml
@@ -27,3 +27,14 @@ project_name:
   error_message: |
     It must contain only alphanumeric symbols, spaces, underscores and hyphens and
     be at least 2 characters long.
+
+example_pipeline:
+  title: "Example Pipeline"
+  text: |
+    Select whether you would like an example spaceflights pipeline included in your project.
+    To skip this step in the future use --example=y/n
+    To read more about how examples work visit: kedro.org/
+    Would you like to include an example pipeline? \[y/N]:
+  regex_validator: "^(?i)(y|yes|n|no)$"
+  error_message: |
+    It must contain only y, n, YES, NO, case insensitive.

--- a/tests/tools/test_cli.py
+++ b/tests/tools/test_cli.py
@@ -103,6 +103,8 @@ class TestCLITools:
                 "-c",
                 "--addons",
                 "-a",
+                "--example",
+                "-e",
                 "--starter",
                 "-s",
                 "--name",


### PR DESCRIPTION
## Description
This PR introduces an --example flag to the kedro new command. Users can specify --example y/n directly in the command line to indicate their preference. If not specified, users will be prompted interactively, with 'No' as the default selection. Should the user opt for Yes, a template from one of the four spaceflights starter projects will be provided, based on the tools selected.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
