### PR TITLE
Remove renamed/archived starters

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       make sign-off
       pip install -e /workspace/kedro[test]
       cd /workspace
-      yes project | kedro new -s spaceflights-pandas --checkout main
+      kedro new --name project -s spaceflights-pandas --checkout main
       cd /workspace/kedro
       pre-commit install --install-hooks
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,7 +7,7 @@ tasks:
       make sign-off
       pip install -e /workspace/kedro[test]
       cd /workspace
-      yes project | kedro new -s pandas-iris --checkout main
+      yes project | kedro new -s spaceflights-pandas --checkout main
       cd /workspace/kedro
       pre-commit install --install-hooks
 

--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -65,12 +65,12 @@ starters = [
     KedroStarterSpec(
         alias="test_plugin_starter",
         template_path="https://github.com/kedro-org/kedro-starters/",
-        directory="pandas-iris",
+        directory="spaceflights-pandas",
     )
 ]
 ```
 
-The `directory` argument is optional and should be used when you have multiple templates in one repository as for the [official kedro-starters](https://github.com/kedro-org/kedro-starters). If you only have one template, your top-level directory will be treated as the template. For an example, see the [pandas-iris starter](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris).
+The `directory` argument is optional and should be used when you have multiple templates in one repository as for the [official kedro-starters](https://github.com/kedro-org/kedro-starters). If you only have one template, your top-level directory will be treated as the template. For an example, see the [spaceflights-pandas starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas).
 
 In your `pyproject.toml`, you need to register the specifications to `kedro.starters`:
 

--- a/docs/source/kedro_project_setup/starters.md
+++ b/docs/source/kedro_project_setup/starters.md
@@ -47,10 +47,6 @@ kedro starter list
 The Kedro team maintains the following starters for a range of Kedro projects:
 
 * [`astro-airflow-iris`](https://github.com/kedro-org/kedro-starters/tree/main/astro-airflow-iris): The [Kedro Iris dataset example project](../get_started/new_project.md) with a minimal setup for deploying the pipeline on Airflow with [Astronomer](https://www.astronomer.io/).
-* [`standalone-datacatalog`](https://github.com/kedro-org/kedro-starters/tree/main/standalone-datacatalog): A minimum setup to use the traditional [Iris dataset](https://www.kaggle.com/uciml/iris) with Kedro's [`DataCatalog`](../data/data_catalog.md), which is a core component of Kedro. This starter is of use in the exploratory phase of a project. It was formerly known as `mini-kedro`.
-* [`pandas-iris`](https://github.com/kedro-org/kedro-starters/tree/main/pandas-iris): The [Kedro Iris dataset example project](../get_started/new_project.md)
-* [`pyspark-iris`](https://github.com/kedro-org/kedro-starters/tree/main/pyspark-iris): An alternative Kedro Iris dataset example, using [PySpark](../integrations/pyspark_integration.md)
-* [`pyspark`](https://github.com/kedro-org/kedro-starters/tree/main/pyspark): The configuration and initialisation code for a [Kedro pipeline using PySpark](../integrations/pyspark_integration.md)
 * [`spaceflights-pandas`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pandas` datasets.
 * [`spaceflights-pandas-viz`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas-viz): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pandas` datasets and visualisation and experiment tracking `kedro-viz` features.
 * [`spaceflights-pyspark`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pyspark): The [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) example code with `pyspark` datasets.

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -87,26 +87,9 @@ class KedroStarterSpec:  # noqa: too-few-public-methods
 KEDRO_PATH = Path(kedro.__file__).parent
 TEMPLATE_PATH = KEDRO_PATH / "templates" / "project"
 
-_DEPRECATED_STARTERS = [
-    "pandas-iris",
-    "pyspark-iris",
-    "pyspark",
-    "standalone-datacatalog",
-]
 _STARTERS_REPO = "git+https://github.com/kedro-org/kedro-starters.git"
 _OFFICIAL_STARTER_SPECS = [
     KedroStarterSpec("astro-airflow-iris", _STARTERS_REPO, "astro-airflow-iris"),
-    # The `astro-iris` was renamed to `astro-airflow-iris`, but old (external)
-    # documentation and tutorials still refer to `astro-iris`. We create an alias to
-    # check if a user has entered old `astro-iris` as the starter name and changes it
-    # to `astro-airflow-iris`.
-    KedroStarterSpec("astro-iris", _STARTERS_REPO, "astro-airflow-iris"),
-    KedroStarterSpec(
-        "standalone-datacatalog", _STARTERS_REPO, "standalone-datacatalog"
-    ),
-    KedroStarterSpec("pandas-iris", _STARTERS_REPO, "pandas-iris"),
-    KedroStarterSpec("pyspark", _STARTERS_REPO, "pyspark"),
-    KedroStarterSpec("pyspark-iris", _STARTERS_REPO, "pyspark-iris"),
     KedroStarterSpec("spaceflights-pandas", _STARTERS_REPO, "spaceflights-pandas"),
     KedroStarterSpec(
         "spaceflights-pandas-viz", _STARTERS_REPO, "spaceflights-pandas-viz"
@@ -122,7 +105,6 @@ for starter_spec in _OFFICIAL_STARTER_SPECS:
     starter_spec.origin = "kedro"
 
 _OFFICIAL_STARTER_SPECS = {spec.alias: spec for spec in _OFFICIAL_STARTER_SPECS}
-
 
 ADD_ONS_SHORTNAME_TO_NUMBER = {
     "lint": "1",

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -343,13 +343,6 @@ def _get_starters_dict() -> dict[str, KedroStarterSpec]:
             directory="astro-airflow-iris",
             origin="kedro"
         ),
-    "astro-iris":
-        KedroStarterSpec(
-            name="astro-iris",
-            template_path="git+https://github.com/kedro-org/kedro-starters.git",
-            directory="astro-airflow-iris",
-            origin="kedro"
-        ),
     }
     """
     starter_specs = _OFFICIAL_STARTER_SPECS

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -866,7 +866,7 @@ class TestFlagsNotAllowed:
     def test_directory_flag_with_starter_alias(self, fake_kedro_cli):
         result = CliRunner().invoke(
             fake_kedro_cli,
-            ["new", "--starter", "pyspark-iris", "--directory", "some-dir"],
+            ["new", "--starter", "spaceflights-pandas", "--directory", "some-dir"],
             input=_make_cli_prompt_input(),
         )
         assert result.exit_code != 0


### PR DESCRIPTION
## Description
Part of #3113 

## Development notes
- I also removed the mention to `astro-iris`. This starter was renamed about 2 years ago, so I think it's fair to remove this mention now. 
- I already updated some docs where it was easy to replace the mention of `pandas-iris` with `spaceflights-pandas`, but as noted in #3160 and #3161 more doc updates need to be done. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
