### PR TITLE
fix RTD build -  invalid toml in docs

### DIFF
--- a/docs/source/kedro_project_setup/settings.md
+++ b/docs/source/kedro_project_setup/settings.md
@@ -28,9 +28,9 @@ Every Kedro project comes with a default pre-populated `pyproject.toml` file in 
 
 ```toml
 [tool.kedro]
-package_name = package_name
-project_name = project_name
-kedro_init_version = kedro_version
+package_name = "package_name"
+project_name = "project_name"
+kedro_init_version = "kedro_version"
 ```
 
 The `package_name` should be a [valid Python package name](https://peps.python.org/pep-0423/) and the `project_name` should be a human-readable name. They are both mandatory keys for your project.


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->

> WARNING: Could not lex literal_block '[tool.kedro]\npackage_name = package_name\nproject_name = project_name\nkedro_init_version = kedro_version\n' as "toml". Highlighting skipped.
generating indices... genindex py-modindex done

We observed [some RTD build failure](https://readthedocs.org/projects/kedro/builds/22603260/) after pygments release 2.17.0. After some investigation, I think it actually caught a real error and we should fix our docs instead.

One way to check is try to parse this toml with
```python
import toml
toml.loads('[tool.kedro]\npackage_name = package_name\nproject_name = project_name\nkedro_init_version = kedro_version\n')
```
You get an error which indicate this is actually not a valid toml file.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
