### PR TITLE
Spike to add support list for `--params` in CLI

### DIFF
--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -427,10 +427,12 @@ def _validate_config_file(key):
 
 
 def _split_params(ctx, param, value):
+    print(f"{param=}")
+    print(f"{value=}")
     if isinstance(value, dict):
         return value
     dot_list = []
-    for item in split_string(ctx, param, value):
+    for item in new_split_string(value):
         equals_idx = item.find("=")
         if equals_idx == -1:
             # If an equals sign is not found, fail with an error message.
@@ -483,3 +485,35 @@ def _split_load_versions(ctx, param, value):
         load_versions_dict[load_version_list[0]] = load_version_list[1]
 
     return load_versions_dict
+
+
+def new_split_string(string):
+    """Split string not enclosed by []"""
+    res = []
+    curr = 0
+    in_bracket = 0
+    print(f"{string=}")
+
+    for i, char in enumerate(string):
+        print(f"{curr=}", f"{i=}", f"{char=}", f"{in_bracket=}", f"{res=}")
+        if char == "[":
+            in_bracket += 1
+        if char == "]":
+            in_bracket -= 1
+        # Only split if the comma is not enclosed
+        if char == "," and in_bracket == 0:
+            item = string[curr : i + 1]
+            if item.strip():
+                res.append(item)
+            curr = i + 1  # Update the current index
+    if curr != i + 1:  # Last item
+        res.append(string[curr:])
+    print(f"{curr=}", f"{i=}", f"{char=}", f"{in_bracket=}", f"{res=}")
+    return res
+
+    # return [item.strip() for item in value.split(",") if item.strip()]
+
+
+# def split_string(ctx, param, value):  # noqa: unused-argument
+#     """Split string by comma."""
+#     return [item.strip() for item in value.split(",") if item.strip()]


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
A spike of #2552

test:
`kedro run --params x=1,y=[1,2,3]`

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
