### PR TITLE
Minor dataset factories and config docs update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ install-test-requirements:
 	python -m pip install -U "pip>=21.2,<23.2"
 	pip install .[test]
 
-install-pre-commit: install-test-requirements
+install-pre-commit:
 	pre-commit install --install-hooks
 
 uninstall-pre-commit:

--- a/docs/source/configuration/parameters.md
+++ b/docs/source/configuration/parameters.md
@@ -128,8 +128,4 @@ If any extra parameter key or value contains spaces, wrap the whole option conte
 kedro run --params="key1=value with spaces,key2=value"
 ```
 
-Since key-value pairs are split on the first equals sign, values can contain equals signs, but keys cannot. This is the valid CLI command:
-
-```bash
-kedro run --params=endpoint_url=https://endpoint.example.com
-```
+Since key-value pairs are split on the first equals sign, values can contain equals signs, but keys cannot.

--- a/docs/source/data/kedro_dataset_factories.md
+++ b/docs/source/data/kedro_dataset_factories.md
@@ -151,7 +151,7 @@ You can now have one dataset factory pattern in your catalog instead of two sepa
 and `candidate_modelling_pipeline.regressor` as below:
 
 ```yaml
-"{namespace}."regressor":
+"{namespace}.regressor":
   type: pickle.PickleDataset
   filepath: data/06_models/regressor_{namespace}.pkl
   versioned: true

--- a/docs/source/data/kedro_dataset_factories.md
+++ b/docs/source/data/kedro_dataset_factories.md
@@ -151,7 +151,7 @@ You can now have one dataset factory pattern in your catalog instead of two sepa
 and `candidate_modelling_pipeline.regressor` as below:
 
 ```yaml
-{namespace}.regressor:
+"{namespace}."regressor":
   type: pickle.PickleDataset
   filepath: data/06_models/regressor_{namespace}.pkl
   versioned: true
@@ -253,11 +253,11 @@ Consider a catalog file with the following patterns:
   type: pandas.CSVDataset
   filepath: data/{layer}/{dataset_name}.csv
 
-preprocessed_{dataset_name}:
+"preprocessed_{dataset_name}":
   type: pandas.ParquetDataset
   filepath: data/02_intermediate/preprocessed_{dataset_name}.pq
 
-processed_{dataset_name}:
+"processed_{dataset_name}":
   type: pandas.ParquetDataset
   filepath: data/03_primary/processed_{dataset_name}.pq
 
@@ -278,8 +278,8 @@ processed_{dataset_name}:
 Running `kedro catalog rank` will result in the following output:
 
 ```
-- preprocessed_{dataset_name}
-- processed_{dataset_name}
+- 'preprocessed_{dataset_name}'
+- 'processed_{dataset_name}'
 - '{namespace}.{dataset_name}_pq'
 - '{dataset_name}_csv'
 - '{layer}.{dataset_name}'
@@ -312,7 +312,7 @@ shuttles:
   load_args:
     engine: openpyxl # Use modern Excel engine, it is the default since Kedro 0.18.0
 
-preprocessed_{name}:
+"preprocessed_{name}":
   type: pandas.ParquetDataset
   filepath: data/02_intermediate/preprocessed_{name}.pq
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
* Was just going through the `develop` docs and came across some missing quotes on dataset factory names in the docs. 
* An example in the configuration parameters is not relevant anymore since we moved the syntax for `--params` to use `=` instead of `:`
* `make install-pre-commit` installs all the test requirements too - I've removed it but can revert if this is intentional. The install test requirements step on GHA inadvertently calls `pip install .[test]` twice because of this.
## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
