### PR TITLE
Take path-like filepaths more broadly for datasets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,8 @@
 
 ## Bug fixes and other changes
 * Reduced `spaceflights` data to minimise waiting times during tutorial execution.
+* Accepted path-like filepaths more broadly for datasets.
+
 ## Breaking changes to the API
 
 ## Migration guide from Kedro 0.18.* to 0.19.*

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import abc
 import copy
 import logging
+import os
 import re
 import warnings
 from collections import namedtuple
@@ -565,7 +566,7 @@ class AbstractVersionedDataset(AbstractDataset[_DI, _DO], abc.ABC):
     # 'key' is set to prevent cache key overlapping for load and save:
     # https://cachetools.readthedocs.io/en/stable/#cachetools.cachedmethod
     @cachedmethod(cache=attrgetter("_version_cache"), key=partial(hashkey, "save"))
-    def _fetch_latest_save_version(self) -> str:  # noqa: no-self-use
+    def _fetch_latest_save_version(self) -> str:
         """Generate and cache the current save version"""
         return generate_timestamp()
 
@@ -612,7 +613,7 @@ class AbstractVersionedDataset(AbstractDataset[_DI, _DO], abc.ABC):
     def _get_versioned_path(self, version: str) -> PurePosixPath:
         return self._filepath / version / self._filepath.name
 
-    def load(self) -> _DO:  # noqa: useless-parent-delegation
+    def load(self) -> _DO:
         return super().load()
 
     def save(self, data: _DI) -> None:
@@ -709,7 +710,9 @@ def _parse_filepath(filepath: str) -> dict[str, str]:
     return options
 
 
-def get_protocol_and_path(filepath: str, version: Version = None) -> tuple[str, str]:
+def get_protocol_and_path(
+    filepath: str | os.PathLike, version: Version = None
+) -> tuple[str, str]:
     """Parses filepath on protocol and path.
 
     .. warning::
@@ -725,7 +728,7 @@ def get_protocol_and_path(filepath: str, version: Version = None) -> tuple[str, 
     Raises:
         DatasetError: when protocol is http(s) and version is not None.
     """
-    options_dict = _parse_filepath(filepath)
+    options_dict = _parse_filepath(str(filepath))
     path = options_dict["path"]
     protocol = options_dict["protocol"]
 


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
Recreating #3345, [which was previously blocked by RTD build](https://github.com/kedro-org/kedro/pull/3345#issuecomment-1827857449). Turns out, this needs to be in `main`, to affect Kedro-Datasets build.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Should've just waited for #3353 the first time around. :)

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
