### PR TITLE
Remove logic to define layer at the top level from DataCatalog

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -25,6 +25,7 @@
 * Remove deprecated `project_version` from `ProjectMetadata`.
 * Removed `package_name` argument from `KedroSession.create`.
 * Removed the `create_default_data_set()` method in the `Runner` in favour of using dataset factories to create default dataset instances.
+* Removed `layer` argument from the DataCatalog.
 
 ### Datasets
 * Removed `kedro.extras.datasets` and tests.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,7 @@
 * Added validation to node tags to be consistent with node names.
 * Removed `pip-tools` as a dependency.
 * Accepted path-like filepaths more broadly for datasets.
+* Removed support for defining the `layer` attribute at top-level within DataCatalog.
 
 ## Breaking changes to the API
 * Renamed the `data_sets` argument and the `_data_sets` attribute in `Catalog` and their references to `datasets` and `_datasets` respectively.

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -10,7 +10,6 @@ import copy
 import difflib
 import logging
 import re
-from collections import defaultdict
 from typing import Any, Dict
 
 from parse import parse
@@ -290,7 +289,6 @@ class DataCatalog:
         credentials = copy.deepcopy(credentials) or {}
         save_version = save_version or generate_timestamp()
         load_versions = copy.deepcopy(load_versions) or {}
-        layers: dict[str, set[str]] = defaultdict(set)
 
         for ds_name, ds_config in catalog.items():
             ds_config = _resolve_credentials(  # noqa: PLW2901
@@ -304,7 +302,6 @@ class DataCatalog:
                 datasets[ds_name] = AbstractDataset.from_config(
                     ds_name, ds_config, load_versions.get(ds_name), save_version
                 )
-        dataset_layers = layers or None
         sorted_patterns = cls._sort_patterns(dataset_patterns)
         missing_keys = [
             key
@@ -319,7 +316,6 @@ class DataCatalog:
 
         return cls(
             datasets=datasets,
-            layers=dataset_layers,
             dataset_patterns=sorted_patterns,
             load_versions=load_versions,
             save_version=save_version,

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -143,7 +143,6 @@ class DataCatalog:
         self,
         datasets: dict[str, AbstractDataset] = None,
         feed_dict: dict[str, Any] = None,
-        layers: dict[str, set[str]] = None,
         dataset_patterns: Patterns = None,
         load_versions: dict[str, str] = None,
         save_version: str = None,
@@ -158,10 +157,6 @@ class DataCatalog:
         Args:
             datasets: A dictionary of data set names and data set instances.
             feed_dict: A feed dict with data to be added in memory.
-            layers: A dictionary of data set layers. It maps a layer name
-                to a set of data set names, according to the
-                data engineering convention. For more details, see
-                https://docs.kedro.org/en/stable/resources/glossary.html#layers-data-engineering-convention
             dataset_patterns: A dictionary of data set factory patterns
                 and corresponding data set configuration. When fetched from catalog configuration
                 these patterns will be sorted by:
@@ -192,7 +187,6 @@ class DataCatalog:
         """
         self._datasets = dict(datasets or {})
         self.datasets = _FrozenDatasets(self._datasets)
-        self.layers = layers
         # Keep a record of all patterns in the catalog.
         # {dataset pattern name : dataset pattern body}
         self._dataset_patterns = dataset_patterns or {}
@@ -382,10 +376,6 @@ class DataCatalog:
             dataset_config = self._resolve_config(
                 dataset_name, matched_pattern, config_copy
             )
-            ds_layer = dataset_config.pop("layer", None)
-            if ds_layer:
-                self.layers = self.layers or {}
-                self.layers.setdefault(ds_layer, set()).add(dataset_name)
             dataset = AbstractDataset.from_config(
                 dataset_name,
                 dataset_config,
@@ -740,16 +730,14 @@ class DataCatalog:
             dataset_patterns = self._dataset_patterns
         return DataCatalog(
             datasets=self._datasets,
-            layers=self.layers,
             dataset_patterns=dataset_patterns,
             load_versions=self._load_versions,
             save_version=self._save_version,
         )
 
     def __eq__(self, other):
-        return (self._datasets, self.layers, self._dataset_patterns) == (
+        return (self._datasets, self._dataset_patterns) == (
             other._datasets,
-            other.layers,
             other._dataset_patterns,
         )
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -15,7 +15,6 @@ from typing import Any, Dict
 
 from parse import parse
 
-from kedro import KedroDeprecationWarning
 from kedro.io.core import (
     AbstractDataset,
     AbstractVersionedDataset,
@@ -302,20 +301,6 @@ class DataCatalog:
                 dataset_patterns[ds_name] = ds_config
 
             else:
-                # Check if 'layer' attribute is defined at the top level
-                if "layer" in ds_config:
-                    import warnings
-
-                    warnings.warn(
-                        "Defining the 'layer' attribute at the top level is deprecated "
-                        "and will be removed in Kedro 0.19.0. Please move 'layer' inside the 'metadata' -> "
-                        "'kedro-viz' attributes. See https://docs.kedro.org/en/latest/visualisation/kedro"
-                        "-viz_visualisation.html#visualise-layers for more information.",
-                        KedroDeprecationWarning,
-                    )
-                ds_layer = ds_config.pop("layer", None)
-                if ds_layer is not None:
-                    layers[ds_layer].add(ds_name)
                 datasets[ds_name] = AbstractDataset.from_config(
                     ds_name, ds_config, load_versions.get(ds_name), save_version
                 )

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -98,7 +98,6 @@ def local_config(tmp_path):
             "type": "pandas.CSVDataset",
             "filepath": boats_filepath,
             "versioned": True,
-            "layer": "raw",
         },
         "horses": {
             "type": "pandas.CSVDataset",
@@ -254,7 +253,6 @@ class TestKedroContext:
         mock_validate.assert_called_once_with(catalog)
 
     def test_catalog(self, dummy_context, dummy_dataframe):
-        assert dummy_context.catalog.layers == {"raw": {"boats"}}
         dummy_context.catalog.save("cars", dummy_dataframe)
         reloaded_df = dummy_context.catalog.load("cars")
         assert_frame_equal(reloaded_df, dummy_dataframe)

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -428,10 +428,6 @@ class TestDataCatalog:
         with pytest.raises(DatasetError, match=re.escape(error_pattern)):
             data_catalog.confirm(dataset_name)
 
-    def test_layers(self, data_catalog, data_catalog_from_config):
-        """Test dataset layers are correctly parsed"""
-        assert data_catalog.layers is None
-
 
 class TestDataCatalogFromConfig:
     def test_from_sane_config(self, data_catalog_from_config, dummy_dataframe):

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -184,8 +184,7 @@ def dataset(filepath):
 def multi_catalog():
     csv = CSVDataset(filepath="abc.csv")
     parq = ParquetDataset(filepath="xyz.parq")
-    layers = {"raw": {"abc.csv"}, "model": {"xyz.parq"}}
-    return DataCatalog({"abc": csv, "xyz": parq}, layers=layers)
+    return DataCatalog({"abc": csv, "xyz": parq})
 
 
 @pytest.fixture

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -958,13 +958,6 @@ class TestDataCatalogDatasetFactories:
         with pytest.raises(DatasetError, match=re.escape(pattern)):
             catalog._get_dataset("jet@planes")
 
-    def test_factory_layer(self, config_with_dataset_factories):
-        """Check that layer is correctly processed for patterned datasets"""
-        config_with_dataset_factories["catalog"]["{brand}_cars"]["layer"] = "raw"
-        catalog = DataCatalog.from_config(**config_with_dataset_factories)
-        _ = catalog._get_dataset("tesla_cars")
-        assert catalog.layers["raw"] == {"tesla_cars"}
-
     def test_factory_config_versioned(
         self, config_with_dataset_factories, filepath, dummy_dataframe
     ):

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -47,7 +47,6 @@ def sane_config(filepath):
                 "type": "pandas.CSVDataset",
                 "filepath": "s3://test_bucket/test_file.csv",
                 "credentials": "s3_credentials",
-                "layer": "raw",
             },
         },
         "credentials": {
@@ -432,8 +431,6 @@ class TestDataCatalog:
     def test_layers(self, data_catalog, data_catalog_from_config):
         """Test dataset layers are correctly parsed"""
         assert data_catalog.layers is None
-        # only one dataset is assigned a layer in the config
-        assert data_catalog_from_config.layers == {"raw": {"cars"}}
 
 
 class TestDataCatalogFromConfig:


### PR DESCRIPTION
> **NOTE:** Kedro datasets are moving from `kedro.extras.datasets` to a separate `kedro-datasets` package in
> [`kedro-plugins` repository](https://github.com/kedro-org/kedro-plugins). Any changes to the dataset implementations
> should be done by opening a pull request in that repository.
## Description
<!-- Why was this PR created? -->
 
Removes the logic used to to define the layer attribute at top-level within the DataCatalog class.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
