### PR TITLE
Release `0.19.1`

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -51,6 +51,6 @@ authors:
 - family-names: Theisen
   given-names: Merel
 title: Kedro
-version: 0.19.0
-date-released: 2023-12-12
+version: 0.19.1
+date-released: 2023-12-13
 url: https://github.com/kedro-org/kedro

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Upcoming Release 0.19.1
+# Upcoming Release 0.19.2
 
 ## Major features and improvements
 
@@ -9,6 +9,11 @@
 ## Documentation changes
 
 ## Community contributions
+
+# Release 0.19.1
+
+## Bug fixes and other changes
+* Loosened pin for `kedro-telemtry` to fix dependency issues in `0.19.0`.
 
 # Release 0.19.0
 

--- a/docs/source/configuration/config_loader_migration.md
+++ b/docs/source/configuration/config_loader_migration.md
@@ -69,7 +69,7 @@ install Kedro version `0.18.13` or later to properly replace the `TemplatedConfi
 You can install both this Kedro version and `omegaconf` using `pip`:
 
 ```bash
-pip install "kedro>=0.18.13, <0.19.0"
+pip install "kedro>=0.18.13"
 ```
 This would be the minimum required Kedro version which includes `omegaconf` as a dependency and the necessary functionality to replace `TemplatedConfigLoader`.
 Or you can run:

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -109,7 +109,7 @@ Returns output similar to the following, depending on the version of Kedro used 
 | |/ / _ \/ _` | '__/ _ \
 |   <  __/ (_| | | | (_) |
 |_|\_\___|\__,_|_|  \___/
-v0.19.0
+v0.19.1
 
 Kedro is a Python framework for
 creating reproducible, maintainable

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -2,6 +2,7 @@ User-agent: *
 Disallow: /
 Allow: /en/stable/
 Allow: /en/latest/
+Allow: /en/0.19.1/
 Allow: /en/0.19.0/
 Allow: /en/0.18.5/
 Allow: /en/0.18.6/

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -6,7 +6,7 @@ configuration and pipeline assembly.
 import sys
 import warnings
 
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 
 class KedroDeprecationWarning(DeprecationWarning):

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -1152,6 +1152,7 @@ class TestToolsAndExampleFromConfigFile:
             "python_package": "my_project",
         }
         _write_yaml(Path("config.yml"), config)
+        shutil.copytree(TEMPLATE_PATH, "template")
         result = CliRunner().invoke(
             fake_kedro_cli,
             [
@@ -1159,7 +1160,7 @@ class TestToolsAndExampleFromConfigFile:
                 "-v",
                 "--config",
                 "config.yml",
-                "--starter=spaceflights-pandas-viz",
+                "--starter=template",
             ],
         )
 


### PR DESCRIPTION
## Description
Minor release to solve dependency issue with `kedro-telemetry` and kedro `0.19.0`.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
