### PR TITLE
Add logging about not using async for Sequential and Parallel runners

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
-
-## Breaking changes to the API
+* Added logging about not using async mode in `SequentiallRunner` and `ParallelRunner`.
 
 ## Documentation changes
 

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -256,6 +256,11 @@ class ParallelRunner(AbstractRunner):
 
         """
         # noqa: import-outside-toplevel,cyclic-import
+        if not self._is_async:
+            self._logger.info(
+                "Asynchronous mode is disabled for loading and saving data. Use the --async flag "
+                "for potential performance gains. https://docs.kedro.org/en/stable/nodes_and_pipelines/run_a_pipeline.html#load-and-save-asynchronously"
+            )
 
         nodes = pipeline.nodes
         self._validate_catalog(catalog, pipeline)

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -258,7 +258,7 @@ class ParallelRunner(AbstractRunner):
         # noqa: import-outside-toplevel,cyclic-import
         if not self._is_async:
             self._logger.info(
-                "Asynchronous mode is disabled for loading and saving data. Use the --async flag "
+                "Using synchronous mode for loading and saving data. Use the --async flag "
                 "for potential performance gains. https://docs.kedro.org/en/stable/nodes_and_pipelines/run_a_pipeline.html#load-and-save-asynchronously"
             )
 

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -62,7 +62,7 @@ class SequentialRunner(AbstractRunner):
         """
         if not self._is_async:
             self._logger.info(
-                "Asynchronous mode is disabled for loading and saving data. Use the --async flag "
+                "Using synchronous mode for loading and saving data. Use the --async flag "
                 "for potential performance gains. https://docs.kedro.org/en/stable/nodes_and_pipelines/run_a_pipeline.html#load-and-save-asynchronously"
             )
         nodes = pipeline.nodes

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -60,6 +60,11 @@ class SequentialRunner(AbstractRunner):
         Raises:
             Exception: in case of any downstream node failure.
         """
+        if not self._is_async:
+            self._logger.info(
+                "Asynchronous mode is disabled for loading and saving data. Use the --async flag "
+                "for potential performance gains. https://docs.kedro.org/en/stable/nodes_and_pipelines/run_a_pipeline.html#load-and-save-asynchronously"
+            )
         nodes = pipeline.nodes
         done_nodes = set()
 

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -77,7 +77,7 @@ class TestValidParallelRunner:
         catalog.add_feed_dict({"A": 42})
         ParallelRunner().run(fan_out_fan_in, catalog)
         assert (
-            "Asynchronous mode is disabled for loading and saving data." in caplog.text
+            "Using synchronous mode for loading and saving data." in caplog.text
         )
 
 

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -76,9 +76,7 @@ class TestValidParallelRunner:
     def test_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
         catalog.add_feed_dict({"A": 42})
         ParallelRunner().run(fan_out_fan_in, catalog)
-        assert (
-            "Using synchronous mode for loading and saving data." in caplog.text
-        )
+        assert "Using synchronous mode for loading and saving data." in caplog.text
 
 
 class TestMaxWorkers:

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -73,6 +73,13 @@ class TestValidParallelRunner:
         assert len(result["Z"]) == 3
         assert result["Z"] == ("42", "42", "42")
 
+    def test_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
+        catalog.add_feed_dict({"A": 42})
+        ParallelRunner().run(fan_out_fan_in, catalog)
+        assert (
+            "Asynchronous mode is disabled for loading and saving data." in caplog.text
+        )
+
 
 class TestMaxWorkers:
     @pytest.mark.parametrize("is_async", [False, True])

--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -33,7 +33,7 @@ class TestValidSequentialRunner:
         catalog.add_feed_dict({"A": 42})
         SequentialRunner().run(fan_out_fan_in, catalog)
         assert (
-            "Asynchronous mode is disabled for loading and saving data." in caplog.text
+            "Using synchronous mode for loading and saving data." in caplog.text
         )
 
 

--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -29,6 +29,13 @@ class TestValidSequentialRunner:
         assert "Z" in result
         assert result["Z"] == (42, 42, 42)
 
+    def test_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
+        catalog.add_feed_dict({"A": 42})
+        SequentialRunner().run(fan_out_fan_in, catalog)
+        assert (
+            "Asynchronous mode is disabled for loading and saving data." in caplog.text
+        )
+
 
 @pytest.mark.parametrize("is_async", [False, True])
 class TestSeqentialRunnerBranchlessPipeline:

--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -32,9 +32,7 @@ class TestValidSequentialRunner:
     def test_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
         catalog.add_feed_dict({"A": 42})
         SequentialRunner().run(fan_out_fan_in, catalog)
-        assert (
-            "Using synchronous mode for loading and saving data." in caplog.text
-        )
+        assert "Using synchronous mode for loading and saving data." in caplog.text
 
 
 @pytest.mark.parametrize("is_async", [False, True])

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -34,6 +34,14 @@ class TestValidThreadRunner:
         assert "Z" in result
         assert result["Z"] == ("42", "42", "42")
 
+    def test_does_not_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
+        catalog.add_feed_dict({"A": 42})
+        ThreadRunner().run(fan_out_fan_in, catalog)
+        assert (
+            "Asynchronous mode is disabled for loading and saving data."
+            not in caplog.text
+        )
+
 
 class TestMaxWorkers:
     @pytest.mark.parametrize(

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -38,7 +38,7 @@ class TestValidThreadRunner:
         catalog.add_feed_dict({"A": 42})
         ThreadRunner().run(fan_out_fan_in, catalog)
         assert (
-            "Asynchronous mode is disabled for loading and saving data."
+            "Using synchronous mode for loading and saving data."
             not in caplog.text
         )
 

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -37,10 +37,7 @@ class TestValidThreadRunner:
     def test_does_not_log_not_using_async(self, fan_out_fan_in, catalog, caplog):
         catalog.add_feed_dict({"A": 42})
         ThreadRunner().run(fan_out_fan_in, catalog)
-        assert (
-            "Using synchronous mode for loading and saving data."
-            not in caplog.text
-        )
+        assert "Using synchronous mode for loading and saving data." not in caplog.text
 
 
 class TestMaxWorkers:


### PR DESCRIPTION
## Description
Closes #2405 

## Development notes
Added logging message only to `SequentialRunner` and `ParallelRunner` because async mode can't be used with `ThreadRunner`. Added tests to check the message is shown/not shown when expected.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
