### PR TITLE
Remove setuptools dependency

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 ## Bug fixes and other changes
 * Removed example pipeline requirements when examples are not selected in `tools`.
 * Allowed modern versions of JupyterLab and Jupyter Notebooks.
+* Removed setuptools dependency
 
 ## Breaking changes to the API
 * Added logging about not using async mode in `SequentiallRunner` and `ParallelRunner`.

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -21,7 +21,6 @@ from rope.base.project import Project
 from rope.contrib import generate
 from rope.refactor.move import MoveModule
 from rope.refactor.rename import Rename
-from setuptools.discovery import FlatLayoutPackageFinder
 
 from build.util import project_wheel_metadata
 from kedro.framework.cli.pipeline import (
@@ -227,9 +226,11 @@ def _pull_package(  # noqa: PLR0913
         # However, the rest of the code expects the non-normalized package name,
         # so we have to find it.
         packages = [
-            package
-            for package in FlatLayoutPackageFinder().find(project_root_dir)
-            if "." not in package
+            elem.name
+            for elem in project_root_dir.iterdir()
+            if elem.is_dir()
+            and elem.name != "tests"
+            and (elem / "__init__.py").exists()
         ]
         if len(packages) != 1:
             # Should not happen if user is calling `micropkg pull`

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -226,11 +226,11 @@ def _pull_package(  # noqa: PLR0913
         # However, the rest of the code expects the non-normalized package name,
         # so we have to find it.
         packages = [
-            elem.name
-            for elem in project_root_dir.iterdir()
-            if elem.is_dir()
-            and elem.name != "tests"
-            and (elem / "__init__.py").exists()
+            project_item.name
+            for project_item in project_root_dir.iterdir()
+            if project_item.is_dir()
+            and project_item.name != "tests"
+            and (project_item / "__init__.py").exists()
         ]
         if len(packages) != 1:
             # Should not happen if user is calling `micropkg pull`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
     "PyYAML>=4.2,<7.0",
     "rich>=12.0,<14.0",
     "rope>=0.21,<2.0",  # subject to LGPLv3 license
-    "setuptools>=65.5.1",
     "toml>=0.10.0",
     "toposort>=1.5",  # Needs to be at least 1.5 to be able to raise CircularDependencyError
 ]


### PR DESCRIPTION
## Description
Remove setuptools dependency as mentioned in #2350 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
