### PR TITLE
Remove redundant hint when already used

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -267,12 +267,12 @@ def new(  # noqa: PLR0913
 
     _create_project(project_template, cookiecutter_args)
 
-    # if flag and flag and flag:
-    click.secho(
-        "\nTo skip the interactive flow you can run `kedro new` with"
-        "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",
-        fg="green",
-    )
+    if prompts_required:
+        click.secho(
+            "\nTo skip the interactive flow you can run `kedro new` with"
+            "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",
+            fg="green",
+        )
 
 
 @starter.command("list")

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -299,7 +299,7 @@ def new(  # noqa: PLR0913
 
     _create_project(project_template, cookiecutter_args)
 
-    if prompts_required and not config_path:
+    if prompts_required and not config_path and not starter_alias:
         click.secho(
             "\nTo skip the interactive flow you can run `kedro new` with"
             "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -267,6 +267,13 @@ def new(  # noqa: PLR0913
 
     _create_project(project_template, cookiecutter_args)
 
+    # if flag and flag and flag:
+    click.secho(
+        "\nTo skip the interactive flow you can run `kedro new` with"
+        "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",
+        fg="green",
+    )
+
 
 @starter.command("list")
 def list_starters():
@@ -897,12 +904,6 @@ def _create_project(template_path: str, cookiecutter_args: dict[str, Any]):
                 "It has been created with an example pipeline.",
                 fg="green",
             )
-
-    click.secho(
-        "\nTo skip the interactive flow you can run `kedro new` with"
-        "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",
-        fg="green",
-    )
 
 
 class _Prompt:

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -887,7 +887,7 @@ def _create_project(template_path: str, cookiecutter_args: dict[str, Any]):
 
     # we can use starters without tools:
     if tools is not None:
-        if tools == "[]":  # TODO: This should be a list
+        if tools in ("[]", ""):  # TODO: This should be a list
             click.secho(
                 "You have selected no project tools",
                 fg="green",

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -267,7 +267,7 @@ def new(  # noqa: PLR0913
 
     _create_project(project_template, cookiecutter_args)
 
-    if prompts_required:
+    if prompts_required and not config_path:
         click.secho(
             "\nTo skip the interactive flow you can run `kedro new` with"
             "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -1144,6 +1144,10 @@ class TestToolsAndExampleFromConfigFile:
 
         _assert_template_ok(result, **config)
         _assert_requirements_ok(result, tools=tools, repo_name="new-kedro-project")
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            not in result.output
+        )
         _clean_up_project(Path("./new-kedro-project"))
 
     @pytest.mark.parametrize(
@@ -1357,6 +1361,27 @@ class TestToolsAndExampleFromCLI:
             "Tools options 'all' and 'none' cannot be used with other options"
             in result.output
         )
+
+    def test_flags_skip_interactive_flow(self, fake_kedro_cli):
+        result = CliRunner().invoke(
+            fake_kedro_cli,
+            [
+                "new",
+                "--name",
+                "New Kedro Project",
+                "--tools",
+                "none",
+                "--example",
+                "no",
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            not in result.output
+        )
+        _clean_up_project(Path("./new-kedro-project"))
 
 
 @pytest.mark.usefixtures("chdir_to_tmp")

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -991,6 +991,10 @@ class TestToolsAndExampleFromUserPrompts:
         _assert_template_ok(result, tools=tools, example_pipeline=example_pipeline)
         _assert_requirements_ok(result, tools=tools)
         assert "You have selected the following project tools:" in result.output
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            in result.output
+        )
         _clean_up_project(Path("./new-kedro-project"))
 
     @pytest.mark.parametrize(
@@ -1013,6 +1017,10 @@ class TestToolsAndExampleFromUserPrompts:
         _assert_template_ok(result, tools=tools, example_pipeline=example_pipeline)
         _assert_requirements_ok(result, tools=tools)
         assert "You have selected no project tools" in result.output
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            in result.output
+        )
         _clean_up_project(Path("./new-kedro-project"))
 
     @pytest.mark.parametrize(
@@ -1314,6 +1322,10 @@ class TestToolsAndExampleFromCLI:
         tools = _convert_tool_names_to_numbers(selected_tools=tools)
         _assert_template_ok(result, tools=tools, example_pipeline=example_pipeline)
         _assert_requirements_ok(result, tools=tools, repo_name="new-kedro-project")
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            in result.output
+        )
         _clean_up_project(Path("./new-kedro-project"))
 
     def test_invalid_tools_flag(self, fake_kedro_cli):

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -965,8 +965,6 @@ class TestToolsAndExampleFromUserPrompts:
             "5",
             "6",
             "7",
-            "none",
-            "",
             "2,3,4",
             "3-5",
             "1,2,4-6",
@@ -992,6 +990,29 @@ class TestToolsAndExampleFromUserPrompts:
 
         _assert_template_ok(result, tools=tools, example_pipeline=example_pipeline)
         _assert_requirements_ok(result, tools=tools)
+        assert "You have selected the following project tools:" in result.output
+        _clean_up_project(Path("./new-kedro-project"))
+
+    @pytest.mark.parametrize(
+        "tools",
+        [
+            "none",
+            "",
+        ],
+    )
+    @pytest.mark.parametrize("example_pipeline", ["Yes", "No"])
+    def test_no_tools_and_example(self, fake_kedro_cli, tools, example_pipeline):
+        result = CliRunner().invoke(
+            fake_kedro_cli,
+            ["new"],
+            input=_make_cli_prompt_input(
+                tools=tools, example_pipeline=example_pipeline
+            ),
+        )
+
+        _assert_template_ok(result, tools=tools, example_pipeline=example_pipeline)
+        _assert_requirements_ok(result, tools=tools)
+        assert "You have selected no project tools" in result.output
         _clean_up_project(Path("./new-kedro-project"))
 
     @pytest.mark.parametrize(

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -854,6 +854,20 @@ class TestNewWithStarterValid:
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
 
+    def test_no_hint(self, fake_kedro_cli):
+        shutil.copytree(TEMPLATE_PATH, "template")
+        result = CliRunner().invoke(
+            fake_kedro_cli,
+            ["new", "-v", "--starter", str(Path("./template").resolve())],
+            input=_make_cli_prompt_input(),
+        )
+        assert (
+            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            not in result.output
+        )
+        _assert_template_ok(result)
+        _clean_up_project(Path("./new-kedro-project"))
+
 
 class TestNewWithStarterInvalid:
     def test_invalid_starter(self, fake_kedro_cli):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolves #3365 
Found that "You have selected no project tools" wasn't always shown when appropriate, included that fix in this PR

## Development notes
Instead of testing the negative case, the tests test that the hint is shown where relevant. Manual testing reveals the hint is no longer shown where already used. Unsure on best practice here - happy to include a unit test for the negative case as well.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
