### PR TITLE
Format plugin name to fix CI

### DIFF
--- a/features/steps/test_plugin/pyproject.toml
+++ b/features/steps/test_plugin/pyproject.toml
@@ -1,10 +1,10 @@
 [project]
-name = "test_plugin"
+name = "test-plugin"
 description = "Dummy plugin with hook implementations and custom starters"
 version = "0.1"
 
 [project.entry-points."kedro.hooks"]
-test_plugin = "plugin:hooks"
+test-plugin = "plugin:hooks"
 
 [project.entry-points."kedro.starters"]
 starter = "plugin:starters"

--- a/features/steps/test_plugin/pyproject.toml
+++ b/features/steps/test_plugin/pyproject.toml
@@ -4,7 +4,7 @@ description = "Dummy plugin with hook implementations and custom starters"
 version = "0.1"
 
 [project.entry-points."kedro.hooks"]
-test-plugin = "plugin:hooks"
+test_plugin = "plugin:hooks"
 
 [project.entry-points."kedro.starters"]
 starter = "plugin:starters"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolves #3461 and #3464 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Tests were failing because they were attempting to disable `test-plugin`, however within #3329 the plugin name was changed to `test_plugin` and therefore was not being properly disabled. In this PR the name is change back, following package naming convention and fixing the e2e tests.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
