### PR TITLE
Update incremental and partitions dataset import paths

### DIFF
--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -277,7 +277,7 @@ To use `PartitionedDataset` with `ImageDataset` to load all Pokemon PNG images, 
 # in conf/base/catalog.yml
 
 pokemon:
-  type: PartitionedDataset
+  type: partitions.PartitionedDataset
   dataset: kedro_pokemon.datasets.image_dataset.ImageDataset
   path: data/01_raw/pokemon-images-and-types/images/images
   filename_suffix: ".png"

--- a/docs/source/data/partitioned_and_incremental_datasets.md
+++ b/docs/source/data/partitioned_and_incremental_datasets.md
@@ -23,7 +23,7 @@ You can use a `PartitionedDataset` in `catalog.yml` file like any other regular 
 # conf/base/catalog.yml
 
 my_partitioned_dataset:
-  type: PartitionedDataset
+  type: partitions.PartitionedDataset
   path: s3://my-bucket-name/path/to/folder  # path to the location of partitions
   dataset: pandas.CSVDataset  # shorthand notation for the dataset which will handle individual partitions
   credentials: my_credentials
@@ -56,7 +56,7 @@ Alternatively, if you need more granular configuration of the underlying dataset
 # conf/base/catalog.yml
 
 my_partitioned_dataset:
-  type: PartitionedDataset
+  type: partitions.PartitionedDataset
   path: s3://my-bucket-name/path/to/folder
   dataset:  # full dataset config notation
     type: pandas.CSVDataset
@@ -171,7 +171,7 @@ Partition ID _does not_ represent the whole partition path, but only a part of i
 # conf/base/catalog.yml
 
 new_partitioned_dataset:
-  type: PartitionedDataset
+  type: partitions.PartitionedDataset
   path: s3://my-bucket-name
   dataset: pandas.CSVDataset
   filename_suffix: ".csv"
@@ -319,7 +319,7 @@ Important notes about the confirmation operation:
 
 ```yaml
 my_partitioned_dataset:
-  type: IncrementalDataset
+  type: partitions.IncrementalDataset
   path: s3://my-bucket-name/path/to/folder
   dataset: pandas.CSVDataset
   checkpoint:
@@ -336,7 +336,7 @@ Along with the standard dataset attributes, `checkpoint` config also accepts two
 
 ```yaml
 my_partitioned_dataset:
-  type: IncrementalDataset
+  type: partitions.IncrementalDataset
   path: s3://my-bucket-name/path/to/folder
   dataset: pandas.CSVDataset
   checkpoint:
@@ -347,7 +347,7 @@ my_partitioned_dataset:
 
 ```yaml
 my_partitioned_dataset:
-  type: IncrementalDataset
+  type: partitions.IncrementalDataset
   path: s3://my-bucket-name/path/to/folder
   dataset: pandas.CSVDataset
   checkpoint:
@@ -360,7 +360,7 @@ Specification of `force_checkpoint` is also supported via the shorthand notation
 
 ```yaml
 my_partitioned_dataset:
-  type: IncrementalDataset
+  type: partitions.IncrementalDataset
   path: s3://my-bucket-name/path/to/folder
   dataset: pandas.CSVDataset
   checkpoint: 2020-01-01/data.csv
@@ -372,7 +372,7 @@ If you need to force the partitioned dataset to load all available partitions, s
 
 ```yaml
 my_partitioned_dataset:
-  type: IncrementalDataset
+  type: partitions.IncrementalDataset
   path: s3://my-bucket-name/path/to/folder
   dataset: pandas.CSVDataset
   checkpoint: ""


### PR DESCRIPTION
## Description
A user was facing problems trying to use the `PartitionedDataset` because the import has changed now the dataset has moved to `kedro-datasets`: https://github.com/kedro-org/kedro-plugins/issues/501

## Development notes
Updated docstring to new import path.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
