### PR TITLE
Revise cookiecutter json

### DIFF
--- a/kedro/templates/project/cookiecutter.json
+++ b/kedro/templates/project/cookiecutter.json
@@ -2,7 +2,5 @@
     "project_name": "New Kedro Project",
     "repo_name": "{{ cookiecutter.project_name.strip().replace(' ', '-').replace('_', '-').lower() }}",
     "python_package": "{{ cookiecutter.project_name.strip().replace(' ', '_').replace('-', '_').lower() }}",
-    "kedro_version": "{{ cookiecutter.kedro_version }}",
-    "tools": "none",
-    "example_pipeline": "no"
+    "kedro_version": "{{ cookiecutter.kedro_version }}"
 }

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -182,6 +182,7 @@ def setup_template_tools(
     example_pipeline: str,
 ) -> None:
     """Set up the templates according to the choice of tools.
+    This code will be executed only if no starter is used
 
     Args:
         selected_tools_list (str): A string contains the selected tools.


### PR DESCRIPTION
## Description
Remove default values of 'tools' and 'example_pipeline' variables from cookiecutter.json, they never used.



## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
