### PR TITLE
READY! [Docs] Remove image embed using rst notation

### DIFF
--- a/docs/source/deployment/databricks/index.md
+++ b/docs/source/deployment/databricks/index.md
@@ -24,9 +24,7 @@ The workflow documented in ["Use a Databricks job to deploy a Kedro project"](./
 ---
 Here's a flowchart to guide your choice of workflow:
 
-```{image} ../../meta/images/databricks-flow-chart.png
-:alt: mermaid-Decision making diagram for deploying Kedro projects to Databricks
-```
+![Decision making diagram for deploying Kedro projects to Databricks](../../meta/images/databricks-flow-chart.png)
 
 % Mermaid code, see https://github.com/kedro-org/kedro/wiki/Render-Mermaid-diagrams
 % flowchart TD

--- a/docs/source/deployment/index.md
+++ b/docs/source/deployment/index.md
@@ -10,9 +10,8 @@ If you decide to deploy your Kedro project onto a single machine, you should con
 
 If your pipeline is sizeable, you may want to run it across separate machines, so will need to consult our [guide to distributed deployment](distributed.md).
 
-```{image} ../meta/images/deployment-diagram.png
-:alt: mermaid-Decision making diagram for deploying Kedro projects
-```
+![Decision making diagram for deploying Kedro projects](../meta/images/deployment-diagram.png)
+
 
 % Mermaid code, see https://github.com/kedro-org/kedro/wiki/Render-Mermaid-diagrams
 % flowchart TD

--- a/docs/source/kedro_project_setup/session.md
+++ b/docs/source/kedro_project_setup/session.md
@@ -39,9 +39,8 @@ You can provide the following optional arguments in `KedroSession.create()`:
 for the underlying **`KedroContext`**; if specified, this will update (and therefore take precedence over) parameters retrieved from the project configuration
 
 ## `bootstrap_project` and `configure_project`
-```{image} ../meta/images/kedro-session-creation.png
-:alt: mermaid-General overview diagram for KedroSession creation
-```
+
+![General overview diagram for KedroSession creation](../meta/images/kedro-session-creation.png)
 
 % Mermaid code, see https://github.com/kedro-org/kedro/wiki/Render-Mermaid-diagrams
 % graph LR

--- a/docs/source/starters/new_project_tools.md
+++ b/docs/source/starters/new_project_tools.md
@@ -267,9 +267,7 @@ See the [Kedro-Viz documentation](https://docs.kedro.org/projects/kedro-viz/en/s
 
 Here is a flowchart to help illustrate some example choice of tools you can select:
 
-```{image} ../meta/images/project-tools-choices.png
-:alt: mermaid-Example diagram of specific tool choices
-```
+![Example diagram of specific tool choices](../meta/images/project-tools-choices.png)
 
 % Mermaid code, see https://github.com/kedro-org/kedro/wiki/Render-Mermaid-diagrams
 % flowchart TD


### PR DESCRIPTION
## Description
Consistency PR to remove ```{image}``` and replace with markdown inline embed.

## Development notes
Grepped, replaced, rebuilt, inspected. Docs build is here https://kedro--3496.org.readthedocs.build/en/3496/index.html

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
