### PR TITLE
Add attribute to flag persistence in Dataset classes

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -113,6 +113,13 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             # param2 will be True by default
     """
 
+    """
+    Datasets are persistent by default. user-defined Datasets that
+    are not made to be persistent, such as instances o MemoryDataset,
+    need to change the `_EPHEMERAL` attribute to 'True'.
+    """
+    _EPHEMERAL = False
+
     @classmethod
     def from_config(
         cls: type,

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -12,7 +12,8 @@ _EMPTY = object()
 
 class MemoryDataset(AbstractDataset):
     """``MemoryDataset`` loads and saves data from/to an in-memory
-    Python object.
+    Python object. The `_EPHEMERAL` attribute is set to True to
+    indicate MemoryDataset's non-persistence.
 
     Example:
     ::
@@ -33,6 +34,8 @@ class MemoryDataset(AbstractDataset):
         >>> assert reloaded_data.equals(new_data)
 
     """
+
+    _EPHEMERAL = True
 
     def __init__(
         self,

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -54,6 +54,9 @@ class TestMemoryDataset:
         loaded_data = MemoryDataset(None).load()
         assert loaded_data is None
 
+    def test_ephemeral_attribute(self, memory_dataset):
+        assert memory_dataset._EPHEMERAL is True
+
     def test_load_infer_mode(
         self, memory_dataset, input_data, mocked_infer_mode, mocked_copy_with_mode
     ):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
