### PR TITLE
minor tech debts

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -560,6 +560,7 @@ def _get_extra_context(  # noqa: PLR0913
         extra_context["example_pipeline"] = str(_parse_yes_no_to_bool(example_pipeline))
 
     # set defaults for required fields, will be used mostly for starters
+    # project_name defaut value will be taken from cookiecutter.json file
     extra_context.setdefault("kedro_version", version)
     extra_context.setdefault("tools", str(["None"]))
     extra_context.setdefault("example_pipeline", "False")


### PR DESCRIPTION
## Description
Last issues from #3264 :

5. It appears that all file and directory operations are encapsulated within try-except blocks. @SajidAlamQB, have you identified any cases that are not covered?

7. The issue has been addressed in #3499. A default values section was introduced for tools and the example_pipeline. Here, I have inserted a comment in that section stating that the default value for the project name will be sourced from the cookiecutter.json file located in the project's directory.

8. The possibility of integrating flag_inputs into the _get_extra_context() function exists, but such a change would require code modifications. I am not convinced that this alteration would simplify the maintenance of _get_extra_context(). Therefore, I suggest keeping it as is for now.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
