### PR TITLE
Improve error message for invalid example pipeline value

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -153,11 +153,11 @@ def _validate_input_with_regex_pattern(pattern_name: str, input: str) -> None:
     VALIDATION_PATTERNS = {
         "yes_no": {
             "regex": r"(?i)^\s*(y|yes|n|no)\s*$",
-            "error_message": "|It must contain only y, n, YES, NO, case insensitive.",
+            "error_message": f"'{input}' is an invalid value for example pipeline. It must contain only y, n, YES, or NO (case insensitive).",
         },
         "project_name": {
             "regex": r"^[\w -]{2,}$",
-            "error_message": f"{input}' is an invalid value for project name. It must contain only alphanumeric symbols, spaces, underscores and hyphens and be at least 2 characters long",
+            "error_message": f"'{input}' is an invalid value for project name. It must contain only alphanumeric symbols, spaces, underscores and hyphens and be at least 2 characters long",
         },
         "tools": {
             "regex": r"""^(

--- a/kedro/templates/project/prompts.yml
+++ b/kedro/templates/project/prompts.yml
@@ -40,4 +40,4 @@ example_pipeline:
     Would you like to include an example pipeline? [y/N]:
   regex_validator: "(?i)^(y|yes|n|no)$"
   error_message: |
-    It must contain only y, n, YES, NO, case insensitive.
+    It must contain only y, n, YES, or NO (case insensitive).

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -1133,7 +1133,9 @@ class TestToolsAndExampleFromUserPrompts:
         )
 
         assert result.exit_code != 0
-        assert "is an invalid value for example pipeline." in result.output
+        assert (
+            f"'{bad_input}' is an invalid value for example pipeline." in result.output
+        )
         assert (
             "It must contain only y, n, YES, or NO (case insensitive).\n"
             in result.output
@@ -1311,6 +1313,9 @@ class TestToolsAndExampleFromConfigFile:
         )
 
         assert result.exit_code != 0
+        assert (
+            f"'{bad_input}' is an invalid value for example pipeline." in result.output
+        )
         assert (
             "It must contain only y, n, YES, or NO (case insensitive).\n"
             in result.output

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -1135,7 +1135,8 @@ class TestToolsAndExampleFromUserPrompts:
         assert result.exit_code != 0
         assert "is an invalid value for example pipeline." in result.output
         assert (
-            "It must contain only y, n, YES, NO, case insensitive.\n" in result.output
+            "It must contain only y, n, YES, or NO (case insensitive).\n"
+            in result.output
         )
 
 
@@ -1311,7 +1312,8 @@ class TestToolsAndExampleFromConfigFile:
 
         assert result.exit_code != 0
         assert (
-            "It must contain only y, n, YES, NO, case insensitive.\n" in result.output
+            "It must contain only y, n, YES, or NO (case insensitive).\n"
+            in result.output
         )
 
 


### PR DESCRIPTION
## Description
I noticed that the error message on entering an invalid example pipeline value wasn't very descriptive:

<img width="875" alt="Screenshot 2024-01-22 at 16 19 37" src="https://github.com/kedro-org/kedro/assets/49397448/dbf38849-d60d-4bde-83c1-9b2c9dce9d11">

## Development notes
Updated the message to repeat the entered value to the user and mention that the value was invalid specifically for the example pipeline flag:

<img width="870" alt="Screenshot 2024-01-22 at 16 19 14" src="https://github.com/kedro-org/kedro/assets/49397448/350f5143-0094-4be7-8efa-8c510953e4ba">


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
