### PR TITLE
[Ready] Tweak docs search ranking to bump API docs down the listings

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -32,24 +32,3 @@ search:
   ranking:
     # Match API docs (files prefixed "kedro.") and push them down the ranking
     '*/kedro.*.html': -5
-
-    # Match all files under the markdown directories
-    configuration/*: 5
-    course/*: 5
-    data/*: 5
-    development/*: 5
-    deployment/*: 5
-    extend_kedro/*: 5
-    faq/*: 5
-    get_started/*: 5
-    hooks/*: 5
-    integrations/*: 5
-    introduction/*: 5
-    kedro_project_setup/*: 5
-    logging/*: 5
-    nodes_and_pipelines/*: 5
-    notebooks_and_ipython/*: 5
-    resources/*: 5
-    starters/*: 5
-    tutorial/*: 10
-    visualisation/*: 5

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -27,3 +27,29 @@ python:
       path: .
       extra_requirements:
         - docs
+
+search:
+  ranking:
+    # Match API docs (files prefixed "kedro.") and push them down the ranking
+    '*/kedro.*.html': -5
+
+    # Match all files under the markdown directories
+    configuration/*: 5
+    course/*: 5
+    data/*: 5
+    development/*: 5
+    deployment/*: 5
+    extend_kedro/*: 5
+    faq/*: 5
+    get_started/*: 5
+    hooks/*: 5
+    integrations/*: 5
+    introduction/*: 5
+    kedro_project_setup/*: 5
+    logging/*: 5
+    nodes_and_pipelines/*: 5
+    notebooks_and_ipython/*: 5
+    resources/*: 5
+    starters/*: 5
+    tutorial/*: 10
+    visualisation/*: 5


### PR DESCRIPTION
## Description
Closes #3445 

## Development notes
Initially just dropped the ranking of the API docs by globbing all files that start `kedro.*.html` but I have also committed (and overwritten) a version that pushes the narrative docs up the ranks by directory, if the initial change is insufficient. Let's see...keeping this as draft for now.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
