### PR TITLE
Remove interim 0.18.x versions from robots.txt

### DIFF
--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -5,14 +5,5 @@ Allow: /en/latest/
 Allow: /en/0.19.2/
 Allow: /en/0.19.1/
 Allow: /en/0.19.0/
-Allow: /en/0.18.5/
-Allow: /en/0.18.6/
-Allow: /en/0.18.7/
-Allow: /en/0.18.8/
-Allow: /en/0.18.9/
-Allow: /en/0.18.10/
-Allow: /en/0.18.11/
-Allow: /en/0.18.12/
-Allow: /en/0.18.13/
 Allow: /en/0.18.14/
 Allow: /en/0.17.7/


### PR DESCRIPTION
## Description
Created following user comment about following google SERP to invalid and unhelpful docs

## Development notes
Removed interim versions of 0.18.x docs leaving just 0.18.14 (plus all of 0.19.x and 0.17.7). Users can still access other versions in docs through the flyout menu, but it avoids cluttering up the google index with older versions of things.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
