### PR TITLE
(security) Fix tar slip in micropackaging

### DIFF
--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -390,12 +390,14 @@ def _is_within_directory(directory: Path, target: Path) -> bool:
 
 
 def safe_extract(tar: tarfile.TarFile, path: Path) -> None:
+    safe_members = []
     for member in tar.getmembers():
         member_path = path / member.name
         if not _is_within_directory(path, member_path):
             # noqa: broad-exception-raised
             raise Exception("Failed to safely extract tar file.")
-    tar.extractall(path)  # nosec B202
+        safe_members.append(member_path)
+    tar.extractall(path, members=safe_members)  # nosec B202
 
 
 def _unpack_sdist(location: str, destination: Path, fs_args: str | None) -> None:

--- a/tests/framework/cli/micropkg/test_micropkg_pull.py
+++ b/tests/framework/cli/micropkg/test_micropkg_pull.py
@@ -762,7 +762,7 @@ class TestMicropkgPullCommand:
         assert sdist_file.is_file()
 
         with tarfile.open(sdist_file, "r:gz") as tar:
-            tar.extractall(tmp_path)
+            safe_extract(tar, tmp_path)
 
         # Create extra project
         extra_project = tmp_path / f"{PIPELINE_NAME}-0.1_extra"
@@ -801,7 +801,7 @@ class TestMicropkgPullCommand:
         assert sdist_file.is_file()
 
         with tarfile.open(sdist_file, "r:gz") as tar:
-            tar.extractall(tmp_path)
+            safe_extract(tar, tmp_path)
 
         # Create extra package
         extra_package = tmp_path / f"{PIPELINE_NAME}-0.1" / f"{PIPELINE_NAME}_extra"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Fix https://github.com/kedro-org/kedro/issues/3473

While we had already addressed the vulnerability with #2180, this helps snyk not flag it. You can test it by setting up snyk locally and running `snyk code test`

`bandit` still flags this so I haven't removed the `# no sec B202`


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
