### PR TITLE
Remove latest docs from Google indexing

### DIFF
--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,7 +1,6 @@
 User-agent: *
 Disallow: /
 Allow: /en/stable/
-Allow: /en/latest/
 Allow: /en/0.19.2/
 Allow: /en/0.19.1/
 Allow: /en/0.19.0/


### PR DESCRIPTION
## Description
As noted in #3562, we don't need Google and other search engines to be indexing our `latest` docs, since these could confuse users who land on them if they're presented in SERPs. Removing from `robots.txt`

## Development notes
single line change

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
