### PR TITLE
Add ephemeral attribute to main branch

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 
 ## Bug fixes and other changes
 * Addressed arbitrary file write via archive extraction security vulnerability in micropackaging.
+* Added the `_EPHEMERAL` attribute to `AbstractDataset` and other Dataset classes that inherit from it.
 
 ## Breaking changes to the API
 
@@ -20,7 +21,6 @@
 * Added `source_dir` explicitly in `pyproject.toml` for non-src layout project.
 * `MemoryDataset` entries are now included in free outputs.
 * Removed black dependency and replaced it functionality with `ruff format`.
-* Added the `_EPHEMERAL` attribute to `AbstractDataset` and other Dataset classes that inherit from it.
 
 ## Breaking changes to the API
 * Added logging about not using async mode in `SequentiallRunner` and `ParallelRunner`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,6 +20,7 @@
 * Added `source_dir` explicitly in `pyproject.toml` for non-src layout project.
 * `MemoryDataset` entries are now included in free outputs.
 * Removed black dependency and replaced it functionality with `ruff format`.
+* Added the `_EPHEMERAL` attribute to `AbstractDataset` and other Dataset classes that inherit from it.
 
 ## Breaking changes to the API
 * Added logging about not using async mode in `SequentiallRunner` and `ParallelRunner`.

--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -38,7 +38,7 @@ At the minimum, a valid Kedro dataset needs to subclass the base [AbstractDatase
 `AbstractDataset` is generically typed with an input data type for saving data, and an output data type for loading data.
 This typing is optional however, and defaults to `Any` type.
 
-The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of [MemoryDataset](/kedro.io.MemoryDataset), it is set to True. By default, `_EPHEMERAL` is set to False.
+The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of [MemoryDataset](/kedro.io.MemoryDataset), which is not persistent, it is set to True. By default, `_EPHEMERAL` is set to False.
 
 Here is an example skeleton for `ImageDataset`:
 

--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -38,7 +38,7 @@ At the minimum, a valid Kedro dataset needs to subclass the base [AbstractDatase
 `AbstractDataset` is generically typed with an input data type for saving data, and an output data type for loading data.
 This typing is optional however, and defaults to `Any` type.
 
-The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of [MemoryDataset](/kedro.io.MemoryDataset), which is not persistent, it is set to True. By default, `_EPHEMERAL` is set to False.
+The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of [MemoryDataset](/api/kedro.io.MemoryDataset), which is not persistent, it is set to True. By default, `_EPHEMERAL` is set to False.
 
 Here is an example skeleton for `ImageDataset`:
 

--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -38,7 +38,7 @@ At the minimum, a valid Kedro dataset needs to subclass the base [AbstractDatase
 `AbstractDataset` is generically typed with an input data type for saving data, and an output data type for loading data.
 This typing is optional however, and defaults to `Any` type.
 
-The `_EPHEMERAL` boolean attribute present in `AbstractDataset` is used to indicate whether a dataset is meant to be persistent or not, such as in the case of [MemoryDataset](/kedro.io.MemoryDataset). By default, `_EPHEMERAL` is set to False.
+The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of [MemoryDataset](/kedro.io.MemoryDataset), it is set to True. By default, `_EPHEMERAL` is set to False.
 
 Here is an example skeleton for `ImageDataset`:
 

--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -38,6 +38,8 @@ At the minimum, a valid Kedro dataset needs to subclass the base [AbstractDatase
 `AbstractDataset` is generically typed with an input data type for saving data, and an output data type for loading data.
 This typing is optional however, and defaults to `Any` type.
 
+The `_EPHEMERAL` boolean attribute present in `AbstractDataset` is used to indicate whether a dataset is meant to be persistent or not, such as in the case of [MemoryDataset](/kedro.io.MemoryDataset). By default, `_EPHEMERAL` is set to False.
+
 Here is an example skeleton for `ImageDataset`:
 
 <details>

--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -34,6 +34,8 @@ class CachedDataset(AbstractDataset):
     # for parallelism please consider ``ThreadRunner`` instead
     _SINGLE_PROCESS = True
 
+    _EPHEMERAL = True
+
     def __init__(
         self,
         dataset: AbstractDataset | dict,

--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -34,8 +34,6 @@ class CachedDataset(AbstractDataset):
     # for parallelism please consider ``ThreadRunner`` instead
     _SINGLE_PROCESS = True
 
-    _EPHEMERAL = True
-
     def __init__(
         self,
         dataset: AbstractDataset | dict,
@@ -62,6 +60,8 @@ class CachedDataset(AbstractDataset):
             ValueError: If the provided dataset is not a valid dict/YAML
                 representation of a dataset or an actual dataset.
         """
+        self._EPHEMERAL = True
+
         if isinstance(dataset, dict):
             self._dataset = self._from_config(dataset, version)
         elif isinstance(dataset, AbstractDataset):

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -114,8 +114,8 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
     """
 
     """
-    Datasets are persistent by default. user-defined Datasets that
-    are not made to be persistent, such as instances o MemoryDataset,
+    Datasets are persistent by default. User-defined datasets that
+    are not made to be persistent, such as instances of `MemoryDataset`,
     need to change the `_EPHEMERAL` attribute to 'True'.
     """
     _EPHEMERAL = False

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -113,6 +113,13 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             # param2 will be True by default
     """
 
+    """
+    Datasets are persistent by default. user-defined Datasets that
+    are not made to be persistent, such as instances o MemoryDataset,
+    need to change the `_EPHEMERAL` attribute to 'True'.
+    """
+    _EPHEMERAL = False
+
     @classmethod
     def from_config(
         cls: type,

--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -99,9 +99,6 @@ class LambdaDataset(AbstractDataset):
             DatasetError: If a method is specified, but is not a Callable.
 
         """
-
-        self._EPHEMERAL = False
-
         for name, value in [
             ("load", load),
             ("save", save),

--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -100,6 +100,8 @@ class LambdaDataset(AbstractDataset):
 
         """
 
+        self._EPHEMERAL = False
+
         for name, value in [
             ("load", load),
             ("save", save),

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -12,7 +12,8 @@ _EMPTY = object()
 
 class MemoryDataset(AbstractDataset):
     """``MemoryDataset`` loads and saves data from/to an in-memory
-    Python object.
+    Python object. The `_EPHEMERAL` attribute is set to True to
+    indicate MemoryDataset's non-persistence.
 
     Example:
     ::
@@ -33,6 +34,8 @@ class MemoryDataset(AbstractDataset):
         >>> assert reloaded_data.equals(new_data)
 
     """
+
+    _EPHEMERAL = True
 
     def __init__(
         self,

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -35,8 +35,6 @@ class MemoryDataset(AbstractDataset):
 
     """
 
-    _EPHEMERAL = True
-
     def __init__(
         self,
         data: Any = _EMPTY,
@@ -57,6 +55,7 @@ class MemoryDataset(AbstractDataset):
         self._data = _EMPTY
         self._copy_mode = copy_mode
         self.metadata = metadata
+        self._EPHEMERAL = True
         if data is not _EMPTY:
             self._save(data)
 

--- a/kedro/io/shared_memory_dataset.py
+++ b/kedro/io/shared_memory_dataset.py
@@ -20,6 +20,8 @@ class SharedMemoryDataset(AbstractDataset):
             manager: An instance of multiprocessing manager for shared objects.
 
         """
+        self._EPHEMERAL = True
+
         if manager:
             self.shared_memory_dataset = manager.MemoryDataset()  # type: ignore[attr-defined]
         else:

--- a/kedro/io/shared_memory_dataset.py
+++ b/kedro/io/shared_memory_dataset.py
@@ -10,8 +10,6 @@ from kedro.io.core import AbstractDataset, DatasetError
 class SharedMemoryDataset(AbstractDataset):
     """``SharedMemoryDataset`` is a wrapper class for a shared MemoryDataset in SyncManager."""
 
-    _EPHEMERAL = True
-
     def __init__(self, manager: SyncManager | None = None):
         """Creates a new instance of ``SharedMemoryDataset``,
         and creates shared MemoryDataset attribute.

--- a/kedro/io/shared_memory_dataset.py
+++ b/kedro/io/shared_memory_dataset.py
@@ -10,6 +10,8 @@ from kedro.io.core import AbstractDataset, DatasetError
 class SharedMemoryDataset(AbstractDataset):
     """``SharedMemoryDataset`` is a wrapper class for a shared MemoryDataset in SyncManager."""
 
+    _EPHEMERAL = True
+
     def __init__(self, manager: SyncManager | None = None):
         """Creates a new instance of ``SharedMemoryDataset``,
         and creates shared MemoryDataset attribute.

--- a/tests/io/test_cached_dataset.py
+++ b/tests/io/test_cached_dataset.py
@@ -45,6 +45,9 @@ class TestCachedDataset:
         with pytest.raises(DatasetError, match=r"has not been saved yet"):
             _ = cached_ds.load()
 
+    def test_ephemeral_attribute(self, cached_ds):
+        assert cached_ds._EPHEMERAL is True
+
     def test_save_load(self, cached_ds):
         cached_ds.save(42)
         assert cached_ds.load() == 42

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -233,9 +233,6 @@ def data_catalog_from_config(sane_config):
 
 
 class TestDataCatalog:
-    def test_ephemeral_attribute(self, data_catalog):
-        assert data_catalog._EPHEMERAL is False
-
     def test_save_and_load(self, data_catalog, dummy_dataframe):
         """Test saving and reloading the data set"""
         data_catalog.save("test", dummy_dataframe)

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -233,6 +233,9 @@ def data_catalog_from_config(sane_config):
 
 
 class TestDataCatalog:
+    def test_ephemeral_attribute(self, data_catalog):
+        assert data_catalog._EPHEMERAL is False
+
     def test_save_and_load(self, data_catalog, dummy_dataframe):
         """Test saving and reloading the data set"""
         data_catalog.save("test", dummy_dataframe)

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -52,7 +52,7 @@ def test_dataset_describe():
     assert actual == expected
 
 
-def test_ephemeral_attribute(self, mocked_dataset):
+def test_ephemeral_attribute(mocked_dataset):
     assert mocked_dataset._EPHEMERAL is False
 
 

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -52,10 +52,11 @@ def test_dataset_describe():
     assert actual == expected
 
 
-class TestLambdaDatasetLoad:
-    def test_ephemeral_attribute(self, mocker):
-        assert mocker._EPHEMERAL is False
+def test_ephemeral_attribute(self, mocked_dataset):
+    assert mocked_dataset._EPHEMERAL is False
 
+
+class TestLambdaDatasetLoad:
     def test_load_invocation(self, mocker):
         """Test the basic `load` method invocation"""
         mocked_load = mocker.Mock(return_value=42)

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -53,6 +53,9 @@ def test_dataset_describe():
 
 
 class TestLambdaDatasetLoad:
+    def test_ephemeral_attribute(self, mocker):
+        assert mocker._EPHEMERAL is False
+
     def test_load_invocation(self, mocker):
         """Test the basic `load` method invocation"""
         mocked_load = mocker.Mock(return_value=42)

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -54,6 +54,9 @@ class TestMemoryDataset:
         loaded_data = MemoryDataset(None).load()
         assert loaded_data is None
 
+    def test_ephemeral_attribute(self, memory_dataset):
+        assert memory_dataset._EPHEMERAL is True
+
     def test_load_infer_mode(
         self, memory_dataset, input_data, mocked_infer_mode, mocked_copy_with_mode
     ):

--- a/tests/io/test_shared_memory_dataset.py
+++ b/tests/io/test_shared_memory_dataset.py
@@ -13,6 +13,9 @@ def shared_memory_dataset():
 
 
 class TestSharedMemoryDataset:
+    def test_ephemeral_attribute(self, shared_memory_dataset):
+        assert shared_memory_dataset._EPHEMERAL is True
+
     def test_save_and_load(self, shared_memory_dataset, input_data):
         """Test basic load"""
         shared_memory_dataset.save(input_data)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Adds the `_EPHEMERAL` attribute to the `AbstractDataset` class. This attribute will serve to indicate if a `Dataset` object is persistent or not. It is set to be False by default, and should be changed to True in case a Dataset is not meant to be persistent, as seen, for example, in `MemoryDataset`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

Comments and discussion can be seen on https://github.com/kedro-org/kedro/pull/3520


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
