### PR TITLE
Make all paths relative in `kedro catalog resolve`

### DIFF
--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -33,9 +33,29 @@ def fake_catalog_config():
     config = {
         "parquet_{factory_pattern}": {
             "type": "pandas.ParquetDataset",
-            "filepath": "test.pq",
+            "filepath": "data/01_raw/{factory_pattern}.pq",
         },
-        "csv_{factory_pattern}": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
+        "csv_{factory_pattern}": {
+            "type": "pandas.CSVDataset",
+            "filepath": "data/01_raw/{factory_pattern}.csv",
+        },
+        "csv_test": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
+    }
+    return config
+
+
+@pytest.fixture
+def fake_catalog_config_resolved():
+    config = {
+        "parquet_example": {
+            "type": "pandas.ParquetDataset",
+            "filepath": "data/01_raw/example.pq",
+        },
+        "csv_example": {
+            "type": "pandas.CSVDataset",
+            "filepath": "data/01_raw/example.csv",
+        },
+        "csv_test": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
     }
     return config
 
@@ -68,17 +88,62 @@ def fake_catalog_with_overlapping_factories():
 
 
 @pytest.fixture
-def fake_catalog_config_with_resolvable_dataset():
+def fake_catalog_config_with_factories(fake_metadata):
     config = {
         "parquet_{factory_pattern}": {
             "type": "pandas.ParquetDataset",
-            "filepath": "test.pq",
+            "filepath": str(fake_metadata.project_path)
+            + "/"
+            + "data/01_raw/{factory_pattern}.pq",
         },
-        "csv_{factory_pattern}": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
+        "csv_{factory_pattern}": {
+            "type": "pandas.CSVDataset",
+            "filepath": str(fake_metadata.project_path)
+            + "/"
+            + "data/01_raw/{factory_pattern}.csv",
+        },
         "explicit_ds": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
         "{factory_pattern}_ds": {
             "type": "pandas.ParquetDataset",
-            "filepath": "test.pq",
+            "filepath": str(fake_metadata.project_path)
+            + "/"
+            + "data/01_raw/{factory_pattern}_ds.pq",
+        },
+        "partitioned_{factory_pattern}": {
+            "type": "partitions.PartitionedDataset",
+            "path": str(fake_metadata.project_path) + "/" + "data/01_raw",
+            "dataset": "pandas.CSVDataset",
+            "metadata": {
+                "my-plugin": {
+                    "path": str(fake_metadata.project_path) + "/" + "data/01_raw",
+                }
+            },
+        },
+    }
+    return config
+
+
+@pytest.fixture
+def fake_catalog_config_with_factories_resolved():
+    config = {
+        "parquet_example": {
+            "type": "pandas.ParquetDataset",
+            "filepath": "data/01_raw/example.pq",
+        },
+        "csv_example": {
+            "type": "pandas.CSVDataset",
+            "filepath": "data/01_raw/example.csv",
+        },
+        "explicit_ds": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
+        "partitioned_example": {
+            "type": "partitions.PartitionedDataset",
+            "path": "data/01_raw",
+            "dataset": "pandas.CSVDataset",
+            "metadata": {
+                "my-plugin": {
+                    "path": "data/01_raw",
+                }
+            },
         },
     }
     return config
@@ -231,14 +296,16 @@ class TestCatalogListCommand:
             ["catalog", "list"],
             obj=fake_metadata,
         )
-
         assert not result.exit_code
         expected_dict = {
             f"Datasets in '{PIPELINE_NAME}' pipeline": {
                 "Datasets generated from factories": {
                     "pandas.CSVDataset": ["csv_example"],
                     "pandas.ParquetDataset": ["parquet_example"],
-                }
+                },
+                "Datasets mentioned in pipeline": {
+                    "CSVDataset": ["csv_test"],
+                },
             }
         }
         key = f"Datasets in '{PIPELINE_NAME}' pipeline"
@@ -419,7 +486,7 @@ class TestCatalogFactoryCommands:
         mocked_context.catalog = DataCatalog.from_config(
             fake_catalog_with_overlapping_factories
         )
-
+        print("!!!!", mocked_context.catalog._dataset_patterns)
         result = CliRunner().invoke(
             fake_project_cli, ["catalog", "rank"], obj=fake_metadata
         )
@@ -464,19 +531,19 @@ class TestCatalogFactoryCommands:
         mocker,
         mock_pipelines,
         fake_catalog_config,
+        fake_catalog_config_resolved,
     ):
         """Test that datasets factories are correctly resolved to the explicit datasets in the pipeline."""
-        yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
         mocked_context = fake_load_context.return_value
+        mocked_context.config_loader = {"catalog": fake_catalog_config}
         mocked_context.catalog = DataCatalog.from_config(fake_catalog_config)
-
-        placeholder_ds = mocked_context.catalog._datasets.keys()
-        explicit_ds = {"csv_example", "parquet_example"}
+        placeholder_ds = mocked_context.catalog._dataset_patterns.keys()
+        pipeline_datasets = {"csv_example", "parquet_example", "explicit_dataset"}
 
         mocker.patch.object(
             mock_pipelines[PIPELINE_NAME],
             "datasets",
-            return_value=explicit_ds,
+            return_value=pipeline_datasets,
         )
 
         result = CliRunner().invoke(
@@ -484,42 +551,37 @@ class TestCatalogFactoryCommands:
         )
 
         assert not result.exit_code
-        assert yaml_dump_mock.call_count == 1
-
-        output = yaml_dump_mock.call_args[0][0]
+        resolved_config = yaml.safe_load(result.output)
+        assert resolved_config == fake_catalog_config_resolved
 
         for ds in placeholder_ds:
-            assert ds not in output
-
-        for ds in explicit_ds:
-            assert ds in output
+            assert ds not in result.output
 
     @pytest.mark.usefixtures("mock_pipelines")
-    def test_no_overwrite(
+    def test_catalog_resolve_nested_config(
         self,
         fake_project_cli,
         fake_metadata,
         fake_load_context,
         mocker,
         mock_pipelines,
-        fake_catalog_config_with_resolvable_dataset,
+        fake_catalog_config_with_factories,
+        fake_catalog_config_with_factories_resolved,
     ):
         """Test that explicit catalog entries are not overwritten by factory config."""
-        yaml_dump_mock = mocker.patch("yaml.dump", return_value="Result YAML")
         mocked_context = fake_load_context.return_value
+        mocked_context.project_path = fake_metadata.project_path
 
-        mocked_context.config_loader = {
-            "catalog": fake_catalog_config_with_resolvable_dataset
-        }
+        mocked_context.config_loader = {"catalog": fake_catalog_config_with_factories}
         mocked_context.catalog = DataCatalog.from_config(
-            fake_catalog_config_with_resolvable_dataset
+            fake_catalog_config_with_factories
         )
 
         mocker.patch.object(
             mock_pipelines[PIPELINE_NAME],
             "datasets",
             return_value=mocked_context.catalog._datasets.keys()
-            | {"csv_example", "parquet_example"},
+            | {"csv_example", "parquet_example", "partitioned_example"},
         )
 
         result = CliRunner().invoke(
@@ -527,12 +589,9 @@ class TestCatalogFactoryCommands:
         )
 
         assert not result.exit_code
-        assert yaml_dump_mock.call_count == 1
+        resolved_config = yaml.safe_load(result.output)
 
-        assert (
-            yaml_dump_mock.call_args[0][0]["explicit_ds"]
-            == fake_catalog_config_with_resolvable_dataset["explicit_ds"]
-        )
+        assert resolved_config == fake_catalog_config_with_factories_resolved
 
     @pytest.mark.usefixtures("mock_pipelines")
     def test_no_param_datasets_in_resolve(

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -92,30 +92,24 @@ def fake_catalog_config_with_factories(fake_metadata):
     config = {
         "parquet_{factory_pattern}": {
             "type": "pandas.ParquetDataset",
-            "filepath": str(fake_metadata.project_path)
-            + "/"
-            + "data/01_raw/{factory_pattern}.pq",
+            "filepath": "data/01_raw/{factory_pattern}.pq",
         },
         "csv_{factory_pattern}": {
             "type": "pandas.CSVDataset",
-            "filepath": str(fake_metadata.project_path)
-            + "/"
-            + "data/01_raw/{factory_pattern}.csv",
+            "filepath": "data/01_raw/{factory_pattern}.csv",
         },
         "explicit_ds": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
         "{factory_pattern}_ds": {
             "type": "pandas.ParquetDataset",
-            "filepath": str(fake_metadata.project_path)
-            + "/"
-            + "data/01_raw/{factory_pattern}_ds.pq",
+            "filepath": "data/01_raw/{factory_pattern}_ds.pq",
         },
         "partitioned_{factory_pattern}": {
             "type": "partitions.PartitionedDataset",
-            "path": str(fake_metadata.project_path) + "/" + "data/01_raw",
+            "path": "data/01_raw",
             "dataset": "pandas.CSVDataset",
             "metadata": {
                 "my-plugin": {
-                    "path": str(fake_metadata.project_path) + "/" + "data/01_raw",
+                    "path": "data/01_raw",
                 }
             },
         },


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
This bug was my bad! 😅 
I'd suggested in #3561 to just remove the trimming of filepaths because we were only checking for `filepath` key in the catalog config but `PartitionedDataset` uses the key `path` which was causing an error.

But the filepaths in `context.catalog._dataset_patterns` are absolute paths (because of this https://github.com/kedro-org/kedro/blob/e8f1bfd72992336ec12591b49a5fa2654217472f/kedro/framework/context/context.py#L54) . So when running `kedro catalog resolve`, the  output for factory datasets had absolute paths but explicit datasets were all relative paths 

Eg - 
```yaml
"{pattern}":
  type: partitions.PartitionedDataset
  path: data/01_raw
  dataset: pandas.CSVDataset
  metadata:
    path:  data/01_raw/metadata.yml # just to see what happens with nested dicts
```
* `kedro catalog resolve`
```yaml
y_train: # resolved from factory
  dataset: pandas.CSVDataset
  metadata:
    path: /Users/ankita_katiyar/kedro_projects/space/data/01_raw/metadata.yml
  path: /Users/ankita_katiyar/kedro_projects/space/data/01_raw
  type: partitions.PartitionedDataset

reviews: # explicit dataset entry
  filepath: data/01_raw/reviews.csv
  type: pandas.CSVDataset
```

## Development notes
<!-- What have you changed, and how has this been tested? -->
- trimming of filepath now works for nested stuff also 
- refactored the tests a little bit, still haven't fully gotten rid of the mocking of the Context but it's testing the trimming .

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
