### PR TITLE
Clarify `load_node` usecases

### DIFF
--- a/docs/source/development/debugging.md
+++ b/docs/source/development/debugging.md
@@ -4,7 +4,7 @@
 Our debugging documentation has moved. Please see our existing guides:
 ```
 
-* [Debugging a Kedro project within a notebook](../notebooks_and_ipython/kedro_and_notebooks.md#debugging-a-kedro-project-within-a-notebook) for information on how to debug using the `%load_node` line magic and an interactive debugger.
+* [Debugging a Kedro project within a notebook or IPython shell](../notebooks_and_ipython/kedro_and_notebooks.md#debugging-a-kedro-project-within-a-notebook) for information on how to debug using the `%load_node` line magic and an interactive debugger.
 * [Debugging in VSCode](./set_up_vscode.md#debugging) for information on how to set up VSCode's built-in debugger.
 * [Debugging in PyCharm](./set_up_pycharm.md#debugging) for information on using PyCharm's debugging tool.
 * [Debugging in the CLI with Kedro Hooks](../hooks/common_use_cases.md#use-hooks-to-debug-your-pipeline) for information on how to automatically launch an interactive debugger in the CLI when an error occurs in your pipeline run.

--- a/docs/source/notebooks_and_ipython/kedro_and_notebooks.md
+++ b/docs/source/notebooks_and_ipython/kedro_and_notebooks.md
@@ -224,7 +224,7 @@ For more details, run `%reload_kedro?`.
 ### `%load_node` line magic
 
 ``` {note}
-This is still an experimental feature and is currently only available for Jupyter Notebook (>7.0) and Jupyter Lab. If you encounter unexpected behaviour or would like to suggest feature enhancements, add it under [this github issue](https://github.com/kedro-org/kedro/issues/3580).
+This is still an experimental feature and is currently only available for Jupyter Notebook (>7.0), Jupyter Lab, IPython, and VSCode Notebook. If you encounter unexpected behaviour or would like to suggest feature enhancements, add it under [this github issue](https://github.com/kedro-org/kedro/issues/3580).
 ```
 
 You can load the contents of a node in your project into a series of cells using the `%load_node` line magic.
@@ -242,11 +242,16 @@ Ensure you use the name of your node as defined in the pipeline, not the name of
 
 </details>
 
----
 
 To be able to access your node's inputs, make sure they are explicitly defined in your project's catalog.
 
 You can then run the generated cells to recreate how the node would run in your pipeline. You can use this to explore your node's inputs, behaviour, and outputs in isolation, or for [debugging](#debugging-a-kedro-project-within-a-notebook).
+
+When using this feature in Jupyter Notebook you will need to have the following requirements and minimum versions installed:
+```yaml
+ipylab>=1.0.0
+notebook>=7.0.0
+```
 
 ### `%run_viz` line magic
 

--- a/kedro/ipython/__init__.py
+++ b/kedro/ipython/__init__.py
@@ -217,7 +217,7 @@ def _guess_run_environment() -> str:  # pragma: no cover
 )
 def magic_load_node(args: str) -> None:
     """The line magic %load_node <node_name>.
-    Currently, this feature is only available for Jupyter Notebook (>7.0), Jupyter Lab
+    Currently, this feature is only available for Jupyter Notebook (>7.0), Jupyter Lab, IPython,
     and VSCode Notebook. This line magic will generate code in multiple cells to load
     datasets from `DataCatalog`, import relevant functions and modules, node function
     definition and a function call. If generating code is not possible, it will print
@@ -270,7 +270,7 @@ def _load_node(node_name: str, pipelines: _ProjectPipelines) -> list[str]:
         notebook cell.
     """
     warnings.warn(
-        "This is an experimental feature, only Jupyter Notebook (>7.0) & Jupyter Lab "
+        "This is an experimental feature, only Jupyter Notebook (>7.0), Jupyter Lab, IPython, and VSCode Notebook "
         "are supported. If you encounter unexpected behaviour or would like to suggest "
         "feature enhancements, add it under this github issue https://github.com/kedro-org/kedro/issues/3580"
     )


### PR DESCRIPTION
## Description
Addresses #3638 and docs part of #3643. 

## Development notes

- Added `IPython` to list of tools the `%load_node` line magic can be used with on all pages where this is mentioned.
- Added a comment to the `%load_node` line magic description specifying which requirements are needed when using the line magic in a Jupyter Notebook. A follow up task (https://github.com/kedro-org/kedro/issues/3643) is to actually add the requirement in a way that's easier installable without forcing it on users that don't use `%load_node`


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
