### PR TITLE
Update telemetry docs include example_pipeline data collection

### DIFF
--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -19,13 +19,13 @@ which will prompt you for your consent the first time.
 ## Collected data fields:
 
 - **Hashed Username:** An anonymized representation of the user's computer username.
-- **CLI Command (Masked Arguments):** The command used, with sensitive arguments masked for privacy.
+- **CLI Command (Masked Arguments):** The command used, with sensitive arguments masked for privacy. Example Input: `kedro run --pipeline=ds --env=test` What we receive: `kedro run --pipeline ***** --env *****`
 - **Hashed Package Name:** An anonymized identifier of the project.
 - **Kedro Project Version:** The version of Kedro being used.
 - **Kedro-Telemetry Version:** The version of the Kedro-Telemetry plugin.
 - **Python Version:** The version of Python in use.
 - **Operating System:** The operating system on which Kedro is running.
-- **Tools Selected:** The tools chosen during the `kedro new` command execution, if applicable.
+- **Tools Selected and Example Pipeline:** The tools chosen and example pipeline inclusion during the `kedro new` command execution, if applicable.
 - **Number of Datasets, Nodes, and Pipelines:** Quantitative data about the project structure.
 
 For technical information on how the telemetry collection works, you can browse


### PR DESCRIPTION
## Description
This PR updates the Kedro documentation, specifically the telemetry section, to include information on the addition of example_pipeline to the telemetry data collection.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
