### PR TITLE
[Draft] - logging

### DIFF
--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -196,6 +196,13 @@ def package(metadata: ProjectMetadata) -> None:
     help=PARAMS_ARG_HELP,
     callback=_split_params,
 )
+@click.option(
+    "-v",
+    "verbose",
+    type=click.UNPROCESSED,
+    is_flag=True,
+    default="",
+)
 def run(  # noqa: PLR0913
     tags: str,
     env: str,
@@ -212,8 +219,13 @@ def run(  # noqa: PLR0913
     conf_source: str,
     params: dict[str, Any],
     namespace: str,
+    verbose: bool,
 ) -> None:
     """Run the pipeline."""
+    if verbose:
+        from kedro.framework.project import LOGGING
+        LOGGING.data["root"]["level"] = "DEBUG"
+        LOGGING.configure(LOGGING.data)
 
     runner_obj = load_obj(runner or "SequentialRunner", "kedro.runner")
     tuple_tags = tuple(tags)

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -217,9 +217,14 @@ class _ProjectLogging(UserDict):
     def __init__(self) -> None:
         """Initialise project logging. The path to logging configuration is given in
         environment variable KEDRO_LOGGING_CONFIG (defaults to default_logging.yml)."""
-        path = os.environ.get(
-            "KEDRO_LOGGING_CONFIG", Path(__file__).parent / "default_logging.yml"
-        )
+        user_logging_path = os.environ.get("KEDRO_LOGGING_CONFIG")
+        if not user_logging_path and Path("conf/logging.yml").exists():
+            user_logging_path = Path("conf/logging.yml")
+
+        default_logging_path = Path(__file__).parent / "default_logging.yml"
+        path = user_logging_path if user_logging_path else default_logging_path
+        print(f"DEBUG: {path=}")
+
         logging_config = Path(path).read_text(encoding="utf-8")
         self.configure(yaml.safe_load(logging_config))
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -270,8 +270,8 @@ def configure_project(package_name: str) -> None:
     global PACKAGE_NAME  # noqa: PLW0603
     PACKAGE_NAME = package_name
 
-    if PACKAGE_NAME:
-        LOGGING.set_project_logging(PACKAGE_NAME)
+    # if PACKAGE_NAME:
+    #     LOGGING.set_project_logging(PACKAGE_NAME)
 
 
 def configure_logging(logging_config: dict[str, Any]) -> None:

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/conf/logging.yml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/conf/logging.yml
@@ -11,7 +11,6 @@ formatters:
 handlers:
   console:
     class: logging.StreamHandler
-    level: INFO
     formatter: simple
     stream: ext://sys.stdout
 
@@ -32,12 +31,13 @@ handlers:
     # See https://docs.kedro.org/en/stable/logging/logging.html#project-side-logging-configuration
     # tracebacks_show_locals: False
 
-loggers:
-  kedro:
-    level: INFO
+# loggers:
+#   kedro:
+#     level: INFO
 
-  {{ cookiecutter.python_package }}:
-    level: INFO
+#   {{ cookiecutter.python_package }}:
+#     level: INFO
 
 root:
   handlers: [rich, info_file_handler]
+  level: INFO


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
- https://github.com/kedro-org/kedro/issues/3591
- https://github.com/kedro-org/kedro/issues/3446

This draft PR is not ready for merge, but rather facilitate the discussion of the issues above.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Changes:
1. Read logging.yml automatically - be3d28d981ecf51d8fef96a256d9c0ef74d5d8c4
2. Change default of `logging.yml`- 65cf2a0b82afdf18a4f9e1f56af061b6a80f25ee . This challenge the idea of "project logging". Why is `logger` necessary? It's more common to have module level logger, which propagate log to the "root logger", and set the level for root logger only. The exception here is "info logger" because it should only filter `INFO` level. If anything `logger` should be optional, not default. I also think it's more likely you want to keep the level consistent for any `logger` you have manually configured, it's rare you want `kedro` at `INFO` but project at `DEBUG` (This become less important if we end up introduce `-v` or `-vv`
3. Add kedro run -v 2ec8bc1b218b608f094f1c81d2b1a37c44cceda8 . The main problem for this is CLI argument is slightly too late, there are chance that some log is produced before a "run" start. There is also question of extending this to all CLI command, because `logging.yml` affect any Kedro CLI. While this introduce a slight inconsistency, I don't think this is a big problem. As I envision this is mainly for debug use.

I imagine `-v`, `-vv` is a runtime config that used mostly for debugging. If users has sophisticated configuration, they can continue to use `logging.yml` to have different group of settings (I haven't seen much tbh)

Alternatlive, I found `pip` utilise something called a [VerboseLogger](https://github.com/pypa/pip/blob/0ad4c94be74cc24874c6feb5bb3c2152c398a18e/src/pip/_internal/utils/_log.py#L16) 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
