### PR TITLE
Remove duplicate sections from the release notes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -51,50 +51,6 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 ## Documentation changes
 
-# Upcoming Release 0.19.3
-
-## Major features and improvements
-* Create the debugging line magic `%load_node` for Jupyter Notebook and Jupyter Lab.
-* Add better IPython, VSCode Notebook support for `%load_node` and minimal support for Databricks.
-* Add full Kedro Node input syntax for `%load_node`.
-
-## Bug fixes and other changes
-* Updated CLI Command `kedro catalog resolve` to work with dataset factories that use `PartitionedDataset`.
-* Addressed arbitrary file write via archive extraction security vulnerability in micropackaging.
-* Added the `_EPHEMERAL` attribute to `AbstractDataset` and other Dataset classes that inherit from it.
-* Enable read-the-docs search when user presses Command/Ctrl + K.
-* Added new JSON Schema that works with Kedro versions 0.19.*
-
-## Breaking changes to the API
-
-## Documentation changes
-
-## Community contributions
-Many thanks to the following Kedroids for contributing PRs to this release:
-* [MosaicMan](https://github.com/MosaicMan)
-
-
-# Release 0.19.2
-
-## Bug fixes and other changes
-* Removed example pipeline requirements when examples are not selected in `tools`.
-* Allowed modern versions of JupyterLab and Jupyter Notebooks.
-* Removed setuptools dependency
-* Added `source_dir` explicitly in `pyproject.toml` for non-src layout project.
-* `MemoryDataset` entries are now included in free outputs.
-* Removed black dependency and replaced it functionality with `ruff format`.
-
-## Breaking changes to the API
-* Added logging about not using async mode in `SequentiallRunner` and `ParallelRunner`.
-* Changed input format for tools option obtained from --config file from numbers to short names.
-
-## Documentation changes
-* Added documentation about `bootstrap_project` and `configure_project`.
-* Added documentation about `kedro run` and hook execution order.
-
-## Migration guide from Kedro 0.18.* to 0.19.*
-[See the migration guide for 0.19 in the Kedro documentation](https://docs.kedro.org/en/latest/resources/migration.html).
-
 # Release 0.19.1
 
 ## Bug fixes and other changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -34,7 +34,6 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 * [MosaicMan](https://github.com/MosaicMan)
 * [Fazil](https://github.com/lordsoffallen)
 
-
 # Release 0.19.2
 
 ## Bug fixes and other changes
@@ -50,6 +49,11 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 * Changed input format for tools option obtained from --config file from numbers to short names.
 
 ## Documentation changes
+* Added documentation about `bootstrap_project` and `configure_project`.
+* Added documentation about `kedro run` and hook execution order.
+
+## Migration guide from Kedro 0.18.* to 0.19.*
+[See the migration guide for 0.19 in the Kedro documentation](https://docs.kedro.org/en/latest/resources/migration.html).
 
 # Release 0.19.1
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #3660 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Removed the duplicated sections from the release notes, I think I messed them up in #3655 -_-

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
