### PR TITLE
docs: replace kedro.io by kedro_datasets.partitions for PartitionedDataset

### DIFF
--- a/docs/source/data/partitioned_and_incremental_datasets.md
+++ b/docs/source/data/partitioned_and_incremental_datasets.md
@@ -38,7 +38,7 @@ Like any other dataset, `PartitionedDataset` can also be instantiated programmat
 
 ```python
 from kedro_datasets.pandas import CSVDataset
-from kedro.io import PartitionedDataset
+from kedro_datasets.partitions import PartitionedDataset
 
 my_credentials = {...}  # credentials dictionary
 


### PR DESCRIPTION
## Description

I think that the documentation about the import of `PartitionedDataset` in the code was not updated like the rest.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
