### PR TITLE
Update `kedro pipeline create/delete` to get base env from project settings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean:
 
 lint:
 	pre-commit run -a --hook-stage manual $(hook)
-	mypy kedro --strict --allow-any-generics
+	mypy kedro --strict --allow-any-generics --no-warn-unused-ignores
 test:
 	pytest --numprocesses 4 --dist loadfile
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.
 
 ## Breaking changes to the API
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -110,7 +110,7 @@ def create_pipeline(
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE
     project_conf_path = metadata.project_path / conf_source
-    base_env = settings.CONFIG_LOADER_ARGS["base_env"]
+    base_env = settings.CONFIG_LOADER_ARGS.get("base_env", "base")
     env = env or base_env
     if not skip_config and not (project_conf_path / env).exists():
         raise KedroCliError(
@@ -152,7 +152,7 @@ def delete_pipeline(
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE
     project_conf_path = metadata.project_path / conf_source
-    base_env = settings.CONFIG_LOADER_ARGS["base_env"]
+    base_env = settings.CONFIG_LOADER_ARGS.get("base_env", "base")
     env = env or base_env
     if not (project_conf_path / env).exists():
         raise KedroCliError(

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -110,8 +110,8 @@ def create_pipeline(
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE
     project_conf_path = metadata.project_path / conf_source
-
-    env = env or "base"
+    base_env = settings.CONFIG_LOADER_ARGS["base_env"]
+    env = env or base_env
     if not skip_config and not (project_conf_path / env).exists():
         raise KedroCliError(
             f"Unable to locate environment '{env}'. "
@@ -152,8 +152,8 @@ def delete_pipeline(
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE
     project_conf_path = metadata.project_path / conf_source
-
-    env = env or "base"
+    base_env = settings.CONFIG_LOADER_ARGS["base_env"]
+    env = env or base_env
     if not (project_conf_path / env).exists():
         raise KedroCliError(
             f"Unable to locate environment '{env}'. "


### PR DESCRIPTION

## Description
Fix #3667 

## Development notes
<!-- What have you changed, and how has this been tested? -->
I was trying to reproduce #3667 and the fix seemed simple enough -
- Get the `base_env` from settings instead of assuming `"base"` for `kedro pipeline create` and `kedro pipeline delete`


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
