### PR TITLE
provide better error message outside of a kedro project

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release 0.19.4
 
 ## Major features and improvements
+* Kedro CLI now provides a better error message when project commands are run outside of a project i.e. `kedro run`
 
 ## Bug fixes and other changes
 * Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.

--- a/kedro/framework/cli/__init__.py
+++ b/kedro/framework/cli/__init__.py
@@ -1,10 +1,11 @@
 """``kedro.framework.cli`` implements commands available from Kedro's CLI.
 """
 
-from .cli import main
-from .utils import command_with_verbosity, load_entry_points
-
-__all__ = ["main", "command_with_verbosity", "load_entry_points"]
-
+# The constant need to be defined first otherwise it causes circular depdencies
 ORANGE = (255, 175, 0)
 BRIGHT_BLACK = (128, 128, 128)
+
+from .cli import main  # noqa: E402
+from .utils import command_with_verbosity, load_entry_points  # noqa: E402
+
+__all__ = ["main", "command_with_verbosity", "load_entry_points"]

--- a/kedro/framework/cli/__init__.py
+++ b/kedro/framework/cli/__init__.py
@@ -5,3 +5,6 @@ from .cli import main
 from .utils import command_with_verbosity, load_entry_points
 
 __all__ = ["main", "command_with_verbosity", "load_entry_points"]
+
+ORANGE = (255, 175, 0)
+BRIGHT_BLACK = (128, 128, 128)

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -14,6 +14,7 @@ from typing import Any, Sequence
 import click
 
 from kedro import __version__ as version
+from kedro.framework.cli import BRIGHT_BLACK, ORANGE
 from kedro.framework.cli.catalog import catalog_cli
 from kedro.framework.cli.hooks import get_cli_hook_manager
 from kedro.framework.cli.jupyter import jupyter_cli
@@ -139,12 +140,10 @@ class KedroCLI(CommandCollection):
             self._cli_hook_manager.hook.after_command_run(
                 project_metadata=self._metadata, command_args=args, exit_code=exc.code
             )
-            # When the CLI is run outside of a project, project_groups are not registered
+            # When CLI is run outside of a project, project_groups are not registered
             catch_exception = "click.exceptions.UsageError: No such command"
             # click convert exception handles to error message
             if catch_exception in traceback.format_exc() and not self.project_groups:
-                ORANGE = (255, 175, 0)
-                BRIGHT_BLACK = (128, 128, 128)
                 warn = click.style(
                     "\nKedro project not found in this directory. ",
                     fg=ORANGE,

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -144,6 +144,7 @@ class KedroCLI(CommandCollection):
             self._cli_hook_manager.hook.after_command_run(
                 project_metadata=self._metadata, command_args=args, exit_code=exc.code
             )
+            # When the CLI is run outside of a project, project_groups are not registered
             if not self.project_groups:
                 ORANGE = (255, 175, 0)
                 BRIGHT_BLACK = (128, 128, 128)

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -146,7 +146,9 @@ class KedroCLI(CommandCollection):
                 ORANGE = (255, 175, 0)
                 BRIGHT_BLACK = (128, 128, 128)
                 warn = click.style(
-                    "\nYou are not in a Kedro project! ", fg=ORANGE, bold=True
+                    "\nKedro project not found in this directory. ",
+                    fg=ORANGE,
+                    bold=True,
                 )
                 result = (
                     click.style("Project specific commands such as ")

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import importlib
 import sys
+import traceback
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Sequence
@@ -133,12 +134,15 @@ class KedroCLI(CommandCollection):
             )
         # click.core.main() method exits by default, we capture this and then
         # exit as originally intended
+
         except SystemExit as exc:
             self._cli_hook_manager.hook.after_command_run(
                 project_metadata=self._metadata, command_args=args, exit_code=exc.code
             )
             # When the CLI is run outside of a project, project_groups are not registered
-            if not self.project_groups:
+            catch_exception = "click.exceptions.UsageError: No such command"
+            # click convert exception handles to error message
+            if catch_exception in traceback.format_exc() and not self.project_groups:
                 ORANGE = (255, 175, 0)
                 BRIGHT_BLACK = (128, 128, 128)
                 warn = click.style(

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import click
-from black import find_project_root
 
 from kedro import __version__ as version
 from kedro.framework.cli.catalog import catalog_cli
@@ -96,20 +95,14 @@ class KedroCLI(CommandCollection):
 
     def __init__(self, project_path: Path):
         self._metadata = None  # running in package mode
-        self._guessed_project_root = None
         if _is_project(project_path):
             self._metadata = bootstrap_project(project_path)
-        else:
-            guessed_project_root, _ = find_project_root(None)
-            if _is_project(guessed_project_root):
-                self._guessed_project_root = guessed_project_root
         self._cli_hook_manager = get_cli_hook_manager()
 
         super().__init__(
             ("Global commands", self.global_groups),
             ("Project specific commands", self.project_groups),
         )
-        # print("KEDRO CLI************")
 
     def main(
         self,

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -385,6 +385,15 @@ class TestKedroCLI:
         assert result.exit_code == 0
         assert "Global commands from Kedro" in result.output
         assert "Project specific commands from Kedro" not in result.output
+        assert (
+            "You are not in a Kedro project! Project specific commands such as 'run' or "
+            "'jupyter' are only available within a project directory." in result.output
+        )
+
+        assert (
+            "Hint: Kedro is looking for a file called 'pyproject.toml, is one present in"
+            " your current working directory?" in result.output
+        )
 
     def test_kedro_cli_with_project(self, mocker, fake_metadata):
         Module = namedtuple("Module", ["cli"])

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -392,7 +392,7 @@ class TestKedroCLI:
 
         result = CliRunner().invoke(kedro_cli, ["run"])
         assert (
-            "You are not in a Kedro project! Project specific commands such as 'run' or "
+            "Kedro project not found in this directory. Project specific commands such as 'run' or "
             "'jupyter' are only available within a project directory." in result.output
         )
 

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -385,6 +385,12 @@ class TestKedroCLI:
         assert result.exit_code == 0
         assert "Global commands from Kedro" in result.output
         assert "Project specific commands from Kedro" not in result.output
+
+    def test_kedro_run_no_project(self, mocker, tmp_path):
+        mocker.patch("kedro.framework.cli.cli._is_project", return_value=False)
+        kedro_cli = KedroCLI(tmp_path)
+
+        result = CliRunner().invoke(kedro_cli, ["run"])
         assert (
             "You are not in a Kedro project! Project specific commands such as 'run' or "
             "'jupyter' are only available within a project directory." in result.output


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Close #1829 
To detect whether it is out of a kedro project is out of scope, it should be fixed in #1831 



## Development notes
<!-- What have you changed, and how has this been tested? -->

- `catch_exception = "click.exceptions.UsageError: No such command"` Note click's app by default convert all ExceptionHandles to error message. It's not possible to intercept the error class unless we implement #2682. The current workaround is catching the traceback which works reasonable well.
- I have considered to provide the exact command in the message, but it overcomplicates the problem. See screenshot below:

sub command:
![image](https://github.com/kedro-org/kedro/assets/18221871/3aa9354c-e747-4d50-ac08-f79b4687e174)

sub group command:
![image](https://github.com/kedro-org/kedro/assets/18221871/33c40458-1c13-4235-a404-9267bad816a3)

click propagate subcommand by forwarding the argument. Ideally in the 2nd screenshot, we want to see `No such command 'random command', but this is not possible. This is how click always behave and consistent with existing Kedro CLI. The solution is that the error message will always mention `run` or `jupyter` instead of showing the actual command user runs, I think this is clear enough and is an improvement.

I've also added a hint in the error message:
>  Hint: Kedro is looking for a file called 'pyproject.toml, is one present in your current working directory?

Technically Kedro is searching for a `pyproject.toml` which has `tool.kedro`(sometimes we see projects with multiple pyproject.toml, some are kedro project some are not).  I try to keep the hint simple and thus ignoring the details.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
