### PR TITLE
Make kedro commands work from inside subdirectories in project

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release 0.19.4
 
 ## Major features and improvements
+* Kedro commands now work from any subdirectory within a Kedro project.
 
 ## Bug fixes and other changes
 * Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 * Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.
 
 ## Breaking changes to the API
+* Methods `_is_project` and `_find_kedro_project` have been moved to `kedro.utils`. We recommend not using private methods in your code, but if you do, please update your code to use the new location.
 
 ## Documentation changes
 

--- a/features/run.feature
+++ b/features/run.feature
@@ -60,3 +60,11 @@ Feature: Run Project
     When I execute the kedro command "run --params extra1=1,extra2=value2"
     Then I should get a successful exit code
     And the logs should show that 4 nodes were run
+
+  Scenario: Run kedro run from within a sub-directory
+    Given I have prepared a config file
+    And I have run a non-interactive kedro new with starter "default"
+    And I have changed the current working directory to "data"
+    When I execute the kedro command "run"
+    Then I should get a successful exit code
+    And the logs should show that 4 nodes were run

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -737,5 +737,4 @@ def add_micropkg_to_pyproject_toml(context: behave.runner.Context):
 @given('I have changed the current working directory to "{dir}"')
 def change_dir(context, dir):
     """Execute Kedro target."""
-    cmd = "cd " + dir
-    context.result = run(cmd, env=context.env, cwd=str(context.root_project_dir))
+    util.chdir(dir)

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -732,3 +732,10 @@ def add_micropkg_to_pyproject_toml(context: behave.runner.Context):
     )
     with pyproject_toml_path.open(mode="a") as file:
         file.write(project_toml_str)
+
+
+@given('I have changed the current working directory to "{dir}"')
+def change_dir(context, dir):
+    """Execute Kedro target."""
+    cmd = "cd " + dir
+    context.result = run(cmd, env=context.env, cwd=str(context.root_project_dir))

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -30,7 +30,8 @@ from kedro.framework.cli.utils import (
     load_entry_points,
 )
 from kedro.framework.project import LOGGING  # noqa: F401
-from kedro.framework.startup import _is_project, bootstrap_project
+from kedro.framework.startup import bootstrap_project
+from kedro.utils import _is_project
 
 LOGO = rf"""
  _            _

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -31,7 +31,7 @@ from kedro.framework.cli.utils import (
 )
 from kedro.framework.project import LOGGING  # noqa: F401
 from kedro.framework.startup import bootstrap_project
-from kedro.utils import _is_project
+from kedro.utils import _find_kedro_project, _is_project
 
 LOGO = rf"""
  _            _
@@ -195,5 +195,7 @@ def main() -> None:  # pragma: no cover
     commands to `kedro`'s before invoking the CLI.
     """
     _init_plugins()
-    cli_collection = KedroCLI(project_path=Path.cwd())
+    cli_collection = KedroCLI(
+        project_path=_find_kedro_project(Path.cwd()) or Path.cwd()
+    )
     cli_collection()

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -27,6 +27,7 @@ from kedro.framework.project import (
 from kedro.framework.session.store import BaseSessionStore
 from kedro.io.core import generate_timestamp
 from kedro.runner import AbstractRunner, SequentialRunner
+from kedro.utils import _find_kedro_project
 
 
 def _describe_git(project_path: Path) -> dict[str, dict[str, Any]]:
@@ -104,7 +105,9 @@ class KedroSession:
         save_on_close: bool = False,
         conf_source: str | None = None,
     ):
-        self._project_path = Path(project_path or Path.cwd()).resolve()
+        self._project_path = Path(
+            project_path or _find_kedro_project(Path.cwd()).resolve() or Path.cwd()
+        )
         self.session_id = session_id
         self.save_on_close = save_on_close
         self._package_name = package_name

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -106,8 +106,8 @@ class KedroSession:
         conf_source: str | None = None,
     ):
         self._project_path = Path(
-            project_path or _find_kedro_project(Path.cwd()).resolve() or Path.cwd()
-        )
+            project_path or _find_kedro_project(Path.cwd()) or Path.cwd()
+        ).resolve()
         self.session_id = session_id
         self.save_on_close = save_on_close
         self._package_name = package_name

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -34,17 +34,6 @@ def _version_mismatch_error(kedro_init_version: str) -> str:
     )
 
 
-def _is_project(project_path: Union[str, Path]) -> bool:
-    metadata_file = Path(project_path).expanduser().resolve() / _PYPROJECT
-    if not metadata_file.is_file():
-        return False
-
-    try:
-        return "[tool.kedro]" in metadata_file.read_text(encoding="utf-8")
-    except Exception:  # noqa: broad-except
-        return False
-
-
 def _get_project_metadata(project_path: Union[str, Path]) -> ProjectMetadata:
     """Read project metadata from `<project_root>/pyproject.toml` config file,
     under the `[tool.kedro]` section.

--- a/kedro/ipython/__init__.py
+++ b/kedro/ipython/__init__.py
@@ -31,9 +31,9 @@ from kedro.framework.project import (
     pipelines,
 )
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import _is_project, bootstrap_project
+from kedro.framework.startup import bootstrap_project
 from kedro.pipeline.node import Node
-from kedro.utils import _is_databricks
+from kedro.utils import _find_kedro_project, _is_databricks
 
 logger = logging.getLogger(__name__)
 
@@ -184,15 +184,6 @@ def _remove_cached_modules(package_name: str) -> None:  # pragma: no cover
     # define a name that was defined by the old version, the old definition remains.
     for module in to_remove:
         del sys.modules[module]
-
-
-def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
-    while current_dir != current_dir.parent:
-        if _is_project(current_dir):
-            return current_dir
-        current_dir = current_dir.parent
-
-    return None
 
 
 def _guess_run_environment() -> str:  # pragma: no cover

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -46,9 +46,8 @@ def _is_project(project_path: Union[str, Path]) -> bool:
 
 
 def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
-    while current_dir != current_dir.parent:
-        if _is_project(current_dir):
-            return current_dir
-        current_dir = current_dir.parent
+    for parent_dir in current_dir.parents:
+        if _is_project(parent_dir):
+            return parent_dir
 
     return None

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -3,7 +3,10 @@ of kedro package.
 """
 import importlib
 import os
-from typing import Any
+from pathlib import Path
+from typing import Any, Union
+
+_PYPROJECT = "pyproject.toml"
 
 
 def load_obj(obj_path: str, default_obj_path: str = "") -> Any:
@@ -29,3 +32,23 @@ def load_obj(obj_path: str, default_obj_path: str = "") -> Any:
 
 def _is_databricks() -> bool:
     return "DATABRICKS_RUNTIME_VERSION" in os.environ
+
+
+def _is_project(project_path: Union[str, Path]) -> bool:
+    metadata_file = Path(project_path).expanduser().resolve() / _PYPROJECT
+    if not metadata_file.is_file():
+        return False
+
+    try:
+        return "[tool.kedro]" in metadata_file.read_text(encoding="utf-8")
+    except Exception:  # noqa: broad-except
+        return False
+
+
+def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
+    while current_dir != current_dir.parent:
+        if _is_project(current_dir):
+            return current_dir
+        current_dir = current_dir.parent
+
+    return None

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -46,8 +46,8 @@ def _is_project(project_path: Union[str, Path]) -> bool:
 
 
 def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
-    for parent_dir in current_dir.parents:
+    paths_to_check = [current_dir] + list(current_dir.parents)
+    for parent_dir in paths_to_check:
         if _is_project(parent_dir):
             return parent_dir
-
     return None

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -10,10 +10,10 @@ from kedro import __version__ as kedro_version
 from kedro.framework.startup import (
     ProjectMetadata,
     _get_project_metadata,
-    _is_project,
     _validate_source_path,
     bootstrap_project,
 )
+from kedro.utils import _is_project
 
 
 class TestIsProject:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #1831 
## Development notes
<!-- What have you changed, and how has this been tested? -->
- Move `_find_kedro_project()` and `_is_project()` to `kedro.utils` so it can be used both by `KedroCLI` and `kedro.ipython` extension
- Update `_find_kedro_project()` to use `Path.parents` 
- Update `project_path` for `KedroCLI` and `KedroSession` to use `_find_kedro_project()`
- Added e2e test for this change

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
