### PR TITLE
Prioritize venv with conda as secondary option in virtual env docs

### DIFF
--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -47,7 +47,7 @@ deactivate
 ```
 
 
-### How to create a new virtual environment without using `venv`
+### How to create a new virtual environment using `conda`
 
  [The second, less popular option is to install Conda.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) Than from your terminal:
 

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -49,7 +49,7 @@ deactivate
 
 ### How to create a new virtual environment using `conda`
 
- [Another popular option is to use Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/). After you install it, execute this from your terminal:
+[Another popular option is to use Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/). After you install it, execute this from your terminal:
 
 ```bash
 conda create --name kedro-environment python=3.10 -y

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -24,7 +24,7 @@ We strongly recommend utilizing `venv` as your virtual environment manager if yo
 The recommended approach. If you use Python 3, you should already have the `venv` module installed with the standard library. Create a directory for working with your project and navigate to it. For example:
 
 ```bash
-mkdir kedro-environment && cd kedro-environment
+mkdir your-kedro-project && cd your-kedro-project
 ```
 
 Next, create a new virtual environment in this directory with `venv`:

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -13,15 +13,43 @@
 
 ## Create a virtual environment for your Kedro project
 
-We strongly recommend [installing `conda` as your virtual environment manager](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) if you don't already use it.
+We strongly recommend utilizing `venv` as your virtual environment manager if you don't already use it.
 
 ``` {tip}
 [Read more about virtual environments for Python projects](https://realpython.com/python-virtual-environments-a-primer/) or [watch an explainer video about them](https://youtu.be/YKfAwIItO7M).
 ```
 
-### How to create a new virtual environment using `conda`
+### How to create a new virtual environment using `venv`
 
-The recommended approach. From your terminal:
+The recommended approach. If you use Python 3, you should already have the `venv` module installed with the standard library. Create a directory for working with your project and navigate to it. For example:
+
+```bash
+mkdir kedro-environment && cd kedro-environment
+```
+
+Next, create a new virtual environment in this directory with `venv`:
+
+```bash
+python -m venv .venv
+```
+
+Activate this virtual environment:
+
+```bash
+source .venv/bin/activate # macOS / Linux
+.\.venv\Scripts\activate  # Windows
+```
+
+To exit the environment:
+
+```bash
+deactivate
+```
+
+
+### How to create a new virtual environment without using `venv`
+
+ [The second, less popular option is to install Conda.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) Than from your terminal:
 
 ```bash
 conda create --name kedro-environment python=3.10 -y
@@ -52,68 +80,6 @@ To exit `kedro-environment`:
 ```bash
 conda deactivate
 ```
-
-### How to create a new virtual environment without using `conda`
-
-Depending on your preferred Python installation, you can create virtual environments to work with Kedro using `venv` or `pipenv` instead of `conda`.
-
-<details>
-<summary><b>Click to expand instructions for <code>venv</code></b></summary>
-
-If you use Python 3, you should already have the `venv` module installed with the standard library. Create a directory for working with your project and navigate to it. For example:
-
-```bash
-mkdir kedro-environment && cd kedro-environment
-```
-
-Next, create a new virtual environment in this directory with `venv`:
-
-```bash
-python -m venv .venv
-```
-
-Activate this virtual environment:
-
-```bash
-source .venv/bin/activate # macOS / Linux
-.\.venv\Scripts\activate  # Windows
-```
-
-To exit the environment:
-
-```bash
-deactivate
-```
-</details>
-
-<details>
-<summary><b>Click to expand instructions for <code>pipenv</code></b></summary>
-
-Install `pipenv` as follows:
-
-```bash
-pip install pipenv
-```
-
-Create a directory for working with your project and navigate to it. For example:
-
-```bash
-mkdir kedro-environment && cd kedro-environment
-```
-
-To start a session with the correct virtual environment activated:
-
-```bash
-pipenv shell
-```
-
-To exit the shell session:
-
-```bash
-exit
-```
-
-</details>
 
 
 ## How to install Kedro using `pip`

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -49,7 +49,7 @@ deactivate
 
 ### How to create a new virtual environment using `conda`
 
- [The second, less popular option is to install Conda.](https://docs.conda.io/projects/conda/en/latest/user-guide/install/) Than from your terminal:
+ [Another popular option is to use Conda](https://docs.conda.io/projects/conda/en/latest/user-guide/install/). After you install it, execute this from your terminal:
 
 ```bash
 conda create --name kedro-environment python=3.10 -y

--- a/docs/source/get_started/install.md
+++ b/docs/source/get_started/install.md
@@ -13,7 +13,7 @@
 
 ## Create a virtual environment for your Kedro project
 
-We strongly recommend utilizing `venv` as your virtual environment manager if you don't already use it.
+We strongly recommend using `venv` as your virtual environment manager if you don't already use it.
 
 ``` {tip}
 [Read more about virtual environments for Python projects](https://realpython.com/python-virtual-environments-a-primer/) or [watch an explainer video about them](https://youtu.be/YKfAwIItO7M).


### PR DESCRIPTION
## Description

This PR implements changes suggested by @astrojuanlu :

- Recommends `venv` as the primary solution for managing virtual environments, with `conda` as the secondary option.
- Removes collapsible menus from our documentation to simplify the process of finding commands for users.
- Removes all mentions of `pipenv` from our guide.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
