### PR TITLE
Drop dependency on toposort in favour of built-in graphlib

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 * Cookiecutter errors are shown in short format without the `--verbose` flag.
 * Kedro commands now work from any subdirectory within a Kedro project.
 * Kedro CLI now provides a better error message when project commands are run outside of a project i.e. `kedro run`.
+* Dropped the dependency on `toposort` in favour of the built-in `graphlib` module.
 
 ## Bug fixes and other changes
 * Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -916,7 +916,9 @@ def _toposort(node_dependencies: dict[Node, set[Node]]) -> list[Node]:
     """
     try:
         sorter = TopologicalSorter(node_dependencies)
-        return list(sorter.static_order())
+        # Ensure stable toposort by sorting the nodes in a group
+        groups = _group_toposorted(sorter.static_order(), node_dependencies)
+        return [n for group in groups for n in group]
     except CycleError as exc:
         message = f"Circular dependencies exist among these items: {exc.args[1]}"
         raise CircularDependencyError(message) from exc

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -5,7 +5,6 @@ produced outputs and execution order.
 """
 from __future__ import annotations
 
-import copy
 import json
 from collections import Counter, defaultdict
 from itertools import chain
@@ -163,7 +162,7 @@ class Pipeline:
                 self._nodes_by_output[_strip_transcoding(output)] = node
 
         self._nodes = tagged_nodes
-        self._topo_sorted_nodes = _topologically_sorted(self.node_dependencies)
+        self._toposorted_nodes = _toposort(self.node_dependencies)
 
     def __repr__(self) -> str:  # pragma: no cover
         """Pipeline ([node1, ..., node10 ...], name='pipeline_name')"""
@@ -348,7 +347,7 @@ class Pipeline:
             The list of all pipeline nodes in topological order.
 
         """
-        return list(chain.from_iterable(self._topo_sorted_nodes))
+        return list(self._toposorted_nodes)
 
     @property
     def grouped_nodes(self) -> list[list[Node]]:
@@ -360,7 +359,8 @@ class Pipeline:
             The pipeline nodes in topologically ordered groups.
 
         """
-        return copy.copy(self._topo_sorted_nodes)
+
+        return _group_toposorted(self._toposorted_nodes, self.node_dependencies)
 
     def only_nodes(self, *node_names: str) -> Pipeline:
         """Create a new ``Pipeline`` which will contain only the specified
@@ -903,25 +903,20 @@ def _group_toposorted(
     return groups
 
 
-def _topologically_sorted(node_dependencies: dict[Node, set[Node]]) -> list[list[Node]]:
-    """Topologically group and sort (order) nodes such that no node depends on
-    a node that appears in the same or a later group.
+def _toposort(node_dependencies: dict[Node, set[Node]]) -> list[Node]:
+    """Topologically sort (order) nodes such that no node depends on
+    a node that appears earlier in the list.
 
     Raises:
         CircularDependencyError: When it is not possible to topologically order
             provided nodes.
 
     Returns:
-        The list of node sets in order of execution. First set is nodes that should
-        be executed first (no dependencies), second set are nodes that should be
-        executed on the second step, etc.
+        The list of nodes in order of execution.
     """
     try:
-        # Sort it so it has consistent order when run with SequentialRunner
         sorter = TopologicalSorter(node_dependencies)
-        toposorted = _group_toposorted(sorter.static_order(), node_dependencies)
-        result = [sorted(dependencies) for dependencies in toposorted]
-        return result
+        return list(sorter.static_order())
     except CycleError as exc:
         message = f"Circular dependencies exist among these items: {exc.args[1]}"
         raise CircularDependencyError(message) from exc

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rich>=12.0,<14.0",
     "rope>=0.21,<2.0",  # subject to LGPLv3 license
     "toml>=0.10.0",
-    "toposort>=1.5",  # Needs to be at least 1.5 to be able to raise CircularDependencyError
+    "graphlib_backport>=1.0.0,<8.0; python_version <= '3.9'",
 ]
 keywords = [
     "pipelines",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "rich>=12.0,<14.0",
     "rope>=0.21,<2.0",  # subject to LGPLv3 license
     "toml>=0.10.0",
-    "graphlib_backport>=1.0.0,<8.0; python_version <= '3.9'",
+    "graphlib_backport>=1.0.0; python_version < '3.9'",
 ]
 keywords = [
     "pipelines",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,8 +81,7 @@ test = [
     "pandas-stubs",
     "types-PyYAML",
     "types-cachetools",
-    "types-toml",
-    "types-toposort"
+    "types-toml"
 ]
 docs = [
     "docutils<0.21",

--- a/tests/runner/test_sequential_runner.py
+++ b/tests/runner/test_sequential_runner.py
@@ -255,7 +255,7 @@ class TestSequentialRunnerRelease:
 @pytest.mark.parametrize(
     "failing_node_names,expected_pattern",
     [
-        (["node1_A"], r"No nodes ran."),
+        (["node1_A", "node1_B"], r"No nodes ran."),
         (["node2"], r"(node1_A,node1_B|node1_B,node1_A)"),
         (["node3_A"], r"(node3_A,node3_B|node3_B,node3_A)"),
         (["node4_A"], r"(node3_A,node3_B|node3_B,node3_A)"),


### PR DESCRIPTION
## Description

From Python 3.9, there's a built-in toposort functionality and there's a backport for Python 3.8. This PR drops the dependency on a third-party library in favour of the built-in solution thus reducing Kedro's dependency footprint. This is fully backwards compatible change as no tests have failed with the change.

## Development notes

Current test coverage is sufficient.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
