### PR TITLE
Added 'custom_args' attribute to AbstractDataset class

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -15,7 +15,7 @@ from functools import partial
 from glob import iglob
 from operator import attrgetter
 from pathlib import Path, PurePath, PurePosixPath
-from typing import Any, Callable, Generic, TypeVar
+from typing import Any, Callable, Generic, TypeVar, Optional
 from urllib.parse import urlsplit
 
 from cachetools import Cache, cachedmethod
@@ -119,6 +119,29 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
     need to change the `_EPHEMERAL` attribute to 'True'.
     """
     _EPHEMERAL = False
+
+    def __init__(
+        self,
+        *args,
+        custom_args: Optional[Any] = None,
+        **kwargs
+    ):
+        """
+        Initialize an instance of the AbstractDataset class.
+
+        Args:
+            *args: Positional arguments passed to the superclass's __init__ method.
+            custom_args: An optional argument that allows for passing custom
+                data or configurations specific to the instantiation of this
+                dataset instance. This can be any type of data structure or value
+                and its interpretation is left to the implementation of the
+                subclass. Defaults to None. Particularly useful for writing hooks,
+                such as a hook to save the dataset (i.e. predictions, visualizations)
+                in an experiment-specific directory (i.e. mlruns/<experiment_hash>)
+            **kwargs: Keyword arguments passed to the superclass's __init__ method.
+        """
+        super().__init__(*args, **kwargs)
+        self._custom_args = custom_args
 
     @classmethod
     def from_config(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

#### The Inspiration

- In my experience with Kedro, perhaps one of the most useful CI/CD methods is selecting which artifacts (datasets) to save to experiment-specific folders (and which to avoid saving repeatedly, such as large training datasets).
- The best method I have found to accomplish this is through the creation of an AbstractDataset, to accept 'custom_args'. 
    - For example, I could create `project_name.custom_datasets.csv.CustomCSVDataset` and write the following `catalog.yml`:
        ```
        predictions:
            type: project_name.custom_datasets.csv.CustomCSVDataset
            filepath: data/08_reporting/predictions.csv
            custom_args:
                save_to_mlruns: True
        ```
    - I could then configure my code to dynamically save this dataset to `mlruns/08_reporting/predictions.csv` (and, similarly, do so for all datasets with `save_to_mlruns: True` in the catalog).

Personally, this is my most frequent (and favorite) application of "dataset-specific" args. Unfortunately, I find myself creating a custom class for each type of artifact (i.e. CSV, plotly, pickle, etc.), and do so again each time I create a new kedro project.

#### Broader Usage

The above is a very specific use of the proposed 'custom_args' feature, though I believe many developers would find it useful to have access to custom args without having to rewrite numerous custom classes. I know it was a popular feature among my former team members (for the dynamic saving method detailed above)!

## Development notes
Given the minor extent of the change, I don't believe this merits an independent test. If I were to test it, however, I would test the instantiation of an AbstractDataset, a child of AbstractDataset (i.e. CSVDataSet), and ensure I could properly access the configured custom_args.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
