### PR TITLE
Add mlruns to gitignore to avoid pushing  mlflow local runs to github

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,11 +6,12 @@
 * Kedro commands now work from any subdirectory within a Kedro project.
 * Kedro CLI now provides a better error message when project commands are run outside of a project i.e. `kedro run`.
 * Dropped the dependency on `toposort` in favour of the built-in `graphlib` module.
-* Improve the performance of `Pipeline` object creation and summing.
+* Improved the performance of `Pipeline` object creation and summing.
 
 ## Bug fixes and other changes
 * Updated `kedro pipeline create` and `kedro pipeline delete` to read the base environment from the project settings.
 * Updated CLI command `kedro catalog resolve` to read credentials properly.
+* Updated ``.gitignore`` to prevent pushing Mlflow local runs folder to a remote forge when using mlflow and git.
 
 ## Breaking changes to the API
 * Methods `_is_project` and `_find_kedro_project` have been moved to `kedro.utils`. We recommend not using private methods in your code, but if you do, please update your code to use the new location.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/.gitignore
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/.gitignore
@@ -157,3 +157,6 @@ venv.bak/
 
 # mypy
 .mypy_cache/
+
+# mlflow local runs
+mlruns/*


### PR DESCRIPTION
## Description

I've noticed an increasing number of beginners facing some issues when using ``kedro`` and ``kedro-mlflow`` with the following workflow (see : https://github.com/Galileo-Galilei/kedro-mlflow/discussions/456): 
- They develop locally and start from a starer or the default template
- They develop locally and mlflow creates a ``mlruns`` folder the first time they run a kedro pipeline
- They push the local mlflow runs to a remote forge (Github / Gitlab)
- If someone else pull the code on another machine, mlflow completely messes up artifacts path and they got troubles running their pipelines. 

This all boils down to a misunderstanding of how mlflow and git works ; that said they are complex tools and beginners are often introduced to the whole tooling kedro / mlflow / git simultaneously, so it is understandable they do not get the point of not pushing data (their mlflow runs) to a remote forge. Besides, kedro-mlflow (and mlflow itself) do a lot of thing under the hood so some people do not even notice that a folder is created. 

I suggest we ignore ``mlruns/*`` by default in kedro's template to avoid pushing data remotely, because that's the right thing to do (even if people use mlflow without kedro-mlflow) and that's hard to fix by kedro-mlflow (see https://github.com/Galileo-Galilei/kedro-mlflow/issues/523). I think a beginner will think twice before removing something from ``.gitignore`` if they don't really understand what is at stake. 

Note: The change should also be done in starters. 

## Development notes

Add ``mlruns/*`` to gitgnore, to avoid pushing mlruns and all its subfolders in case it is created by ``kedro-mlflow``. We may document *why* this folder should not be pushed, but it is likely to be done in kedro-mlflow, or mlflow iteslef. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
