### PR TITLE
Fix error handling for OmegaConfigLoader

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 * Updated CLI command `kedro catalog resolve` to read credentials properly.
 * Changed the path of where pipeline tests generated with `kedro pipeline create` from `<project root>/src/tests/pipelines/<pipeline name>` to `<project root>/tests/pipelines/<pipeline name>`.
 * Updated ``.gitignore`` to prevent pushing Mlflow local runs folder to a remote forge when using mlflow and git.
+* Fixed error handling message for malformed yaml/json files in OmegaConfigLoader.
 
 ## Breaking changes to the API
 * Methods `_is_project` and `_find_kedro_project` have been moved to `kedro.utils`. We recommend not using private methods in your code, but if you do, please update your code to use the new location.

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -317,7 +317,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
                 line = exc.problem_mark.line
                 cursor = exc.problem_mark.column
                 raise ParserError(
-                    f"Invalid YAML or JSON file {Path(conf_path, config_filepath.name).as_posix()},"
+                    f"Invalid YAML or JSON file {Path(config_filepath).as_posix()},"
                     f" unable to read line {line}, position {cursor}."
                 ) from exc
 

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -307,12 +307,15 @@ class TestOmegaConfigLoader:
         assert re.search(pattern_nested_local, str(exc.value))
 
     @use_config_dir
-    def test_bad_config_syntax(self, tmp_path):
-        conf_path = tmp_path / _BASE_ENV
-        conf_path.mkdir(parents=True, exist_ok=True)
-        (conf_path / "catalog.yml").write_text("bad:\nconfig")
+    @pytest.mark.parametrize("config_path", ["catalog.yml", "subfolder/catalog.yml"])
+    def test_bad_config_syntax(self, tmp_path: Path, config_path):
+        conf_env_path = tmp_path / _BASE_ENV
+        conf_env_path.mkdir(parents=True, exist_ok=True)
+        conf_path = conf_env_path / config_path
+        conf_path.parent.mkdir(parents=True, exist_ok=True)
+        (conf_env_path / config_path).write_text("bad:\nconfig")
 
-        pattern = f"Invalid YAML or JSON file {conf_path.as_posix()}"
+        pattern = f"Invalid YAML or JSON file {conf_env_path.as_posix()}"
         with pytest.raises(ParserError, match=re.escape(pattern)):
             OmegaConfigLoader(
                 str(tmp_path), base_env=_BASE_ENV, default_run_env=_DEFAULT_RUN_ENV


### PR DESCRIPTION
## Description
Error in OmegaConfigLoader error handling for malformed yaml files.

`.name` returns just the name of the file instead of its relative path to `conf_source`.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
