### PR TITLE
Fix e2e tests by distinguishing `kedro-datasets` dependency for different python versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ package: clean install
 
 install-test-requirements:
 	python -m pip install -U "pip>=21.2"
-	pip install .[test]
+	pip install -U .[test]
 
 install-pre-commit:
 	pre-commit install --install-hooks

--- a/features/environment.py
+++ b/features/environment.py
@@ -15,6 +15,7 @@ from features.steps.sh_run import run
 _PATHS_TO_REMOVE: set[Path] = set()
 
 FRESH_VENV_TAG = "fresh_venv"
+MINOR_PYTHON_38_VERSION = 8
 
 
 def call(cmd, env):
@@ -132,7 +133,7 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     # For Python versions 3.9 and above we use the new dataset dependency format introduced in `kedro-datasets` 3.0.0
-    if sys.version_info.minor > 8:  # noqa: PLR2004
+    if sys.version_info.minor > MINOR_PYTHON_38_VERSION:
         install_reqs.append("kedro-datasets[pandas-csvdataset]")
     # For Python 3.8 we use the older `kedro-datasets` dependency format
     else:

--- a/features/environment.py
+++ b/features/environment.py
@@ -131,8 +131,10 @@ def _install_project_requirements(context):
         .splitlines()
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
-    if sys.version_info > (3, 8):
+    # For Python versions 3.9 and above we use the new dataset dependency format introduced in `kedro-datasets` 3.0.0
+    if sys.version_info.minor > 8:
         install_reqs.append("kedro-datasets[pandas-csvdataset]")
+    # For Python 3.8 we use the older `kedro-datasets` dependency format
     else:
         install_reqs.append("kedro-datasets[pandas.CSVDataset]")
     call([context.pip, "install", *install_reqs], env=context.env)

--- a/features/environment.py
+++ b/features/environment.py
@@ -132,7 +132,7 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     # For Python versions 3.9 and above we use the new dataset dependency format introduced in `kedro-datasets` 3.0.0
-    if sys.version_info.minor > 8:
+    if sys.version_info.minor > 8:  # noqa: PLR2004
         install_reqs.append("kedro-datasets[pandas-csvdataset]")
     # For Python 3.8 we use the older `kedro-datasets` dependency format
     else:

--- a/features/environment.py
+++ b/features/environment.py
@@ -131,5 +131,5 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     install_reqs.append("kedro-datasets[pandas-csvdataset]")
-    call([context.pip, "install", *install_reqs], env=context.env)
+    call([context.pip, "install", "-U", *install_reqs], env=context.env)
     return context

--- a/features/environment.py
+++ b/features/environment.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import shutil
 import subprocess
+import sys
 import tempfile
 import venv
 from pathlib import Path
@@ -130,6 +131,9 @@ def _install_project_requirements(context):
         .splitlines()
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
-    install_reqs.append("kedro-datasets[pandas-csvdataset]")
-    call([context.pip, "install", "-U", *install_reqs], env=context.env)
+    if sys.version_info > (3, 8):
+        install_reqs.append("kedro-datasets[pandas-csvdataset]")
+    else:
+        install_reqs.append("kedro-datasets[pandas.CSVDataset]")
+    call([context.pip, "install", *install_reqs], env=context.env)
     return context

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/requirements.txt
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/requirements.txt
@@ -3,7 +3,8 @@ ipython>=8.10
 jupyterlab>=3.0
 notebook
 kedro~={{ cookiecutter.kedro_version}}
-kedro-datasets[pandas-csvdataset]
+kedro-datasets[pandas-csvdataset]; python_version >= "3.9"
+kedro-datasets[pandas.CSVDataset]<2.0.0; python_version < '3.9'
 kedro-telemetry>=0.3.1
 pytest-cov~=3.0
 pytest-mock>=1.7.1, <2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ test = [
     "jupyterlab_server>=2.11.1",
     "jupyterlab>=3,<5",
     "jupyter~=1.0",
-    "kedro-datasets",
+    "kedro-datasets; python_version >= '3.9'",
+    "kedro-datasets<2.0.0; python_version < '3.9'",
     "mypy~=1.0",
     "pandas~=2.0",
     "pluggy>=1.0, <1.4", # pluggy 1.4 hide imports inside function and causing mocking issue


### PR DESCRIPTION
## Description
@lrcouto I've gone ahead and added different dependency handling for python 3.8 with the `kedro-datasets` to unblock https://github.com/kedro-org/kedro/pull/3664

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
