### PR TITLE
Update UUID telemetry docs

### DIFF
--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -18,7 +18,7 @@ which will prompt you for your consent the first time.
 
 ## Collected data fields:
 
-- **Hashed Username:** An anonymized representation of the user's computer username.
+- **Unique user identifier(UUID):** The UUID is a randomly generated anonymous identifier, stored within an OS-specific configuration folder for Kedro, named 'telemetry.conf'. If a UUID does not already exist, the telemetry plugin generates a new one, stores it, and then uses this UUID in subsequent telemetry events.
 - **CLI Command (Masked Arguments):** The command used, with sensitive arguments masked for privacy. Example Input: `kedro run --pipeline=ds --env=test` What we receive: `kedro run --pipeline ***** --env *****`
 - **Hashed Package Name:** An anonymized identifier of the project.
 - **Kedro Project Version:** The version of Kedro being used.


### PR DESCRIPTION
## Description

Following the introduction of a [unique telemetry UUID](https://github.com/kedro-org/kedro-plugins/pull/596) and together with the [telemetry 0.4.0 release](https://github.com/kedro-org/kedro-plugins/issues/633), we need to update our telemetry docs to highlight the transition to a fully anonymous and unique user ID.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
