### PR TITLE
Add a test for transcoding loops of 1 or more nodes

### DIFF
--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -171,7 +171,8 @@ class Pipeline:
         try:
             self._toposorter.prepare()
         except CycleError as exc:
-            message = f"Circular dependencies exist among these items: {exc.args[1]}"
+            loop = list(set(exc.args[1]))
+            message = f"Circular dependencies exist among the following {len(loop)} item(s): {loop}"
             raise CircularDependencyError(message) from exc
 
         self._toposorted_nodes: list[Node] = []

--- a/tests/pipeline/test_pipeline_with_transcoding.py
+++ b/tests/pipeline/test_pipeline_with_transcoding.py
@@ -5,7 +5,11 @@ import pytest
 import kedro
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
-from kedro.pipeline.pipeline import OutputNotUniqueError, _strip_transcoding
+from kedro.pipeline.pipeline import (
+    CircularDependencyError,
+    OutputNotUniqueError,
+    _strip_transcoding,
+)
 
 
 # Different dummy func based on the number of arguments
@@ -174,6 +178,24 @@ class TestInvalidPipeline:
                 [
                     node(identity, "A", "B@pandas", name="node1"),
                     node(identity, "A", "B@spark", name="node2"),
+                ]
+            )
+
+    def test_transcoding_loop(self):
+        with pytest.raises(CircularDependencyError, match="node1"):
+            modular_pipeline(
+                [
+                    node(identity, "A@pandas", "B@pandas", name="node1"),
+                    node(identity, "B@spark", "C@spark", name="node2"),
+                    node(identity, "C@spark", "A@spark", name="node3"),
+                ]
+            )
+
+    def test_transcoding_self_reference(self):
+        with pytest.raises(CircularDependencyError, match="node1"):
+            modular_pipeline(
+                [
+                    node(identity, "A@pandas", "A@spark", name="node1"),
                 ]
             )
 


### PR DESCRIPTION
## Description

A recent change from `toposort` to `graphlib` accidentally revealed and fixed a bug, where 1 node loops were allowed through transcoding. For more information, read https://github.com/kedro-org/kedro/issues/3799

Here a regression test is added now in order to avoid reintroducing the same bug in the future.

## Development notes

This PR includes only tests and a slight modification of the error message to make it clearer how many nodes and what nodes exactly cause the loop.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
