### PR TITLE
Ensure no nodes can depend on themselves even when transcoding is used

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,7 +18,7 @@
 * Changed the path of where pipeline tests generated with `kedro pipeline create` from `<project root>/src/tests/pipelines/<pipeline name>` to `<project root>/tests/pipelines/<pipeline name>`.
 * Updated ``.gitignore`` to prevent pushing Mlflow local runs folder to a remote forge when using mlflow and git.
 * Fixed error handling message for malformed yaml/json files in OmegaConfigLoader.
-* Fixed a bug in `node`-creation allowing self-dependencies when using transcoding, i.e. datasets named like `name@format`.
+* Fixed a bug in `node`-creation allowing self-dependencies when using transcoding, that is datasets named like `name@format`.
 
 ## Breaking changes to the API
 * Methods `_is_project` and `_find_kedro_project` have been moved to `kedro.utils`. We recommend not using private methods in your code, but if you do, please update your code to use the new location.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 * Changed the path of where pipeline tests generated with `kedro pipeline create` from `<project root>/src/tests/pipelines/<pipeline name>` to `<project root>/tests/pipelines/<pipeline name>`.
 * Updated ``.gitignore`` to prevent pushing Mlflow local runs folder to a remote forge when using mlflow and git.
 * Fixed error handling message for malformed yaml/json files in OmegaConfigLoader.
+* Fixed a bug in `node`-creation allowing self-dependencies when using transcoding, i.e. datasets named like `name@format`.
 
 ## Breaking changes to the API
 * Methods `_is_project` and `_find_kedro_project` have been moved to `kedro.utils`. We recommend not using private methods in your code, but if you do, please update your code to use the new location.

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -15,7 +15,7 @@ from pluggy import PluginManager
 from kedro.config import AbstractConfigLoader, MissingConfigException
 from kedro.framework.project import settings
 from kedro.io import DataCatalog
-from kedro.pipeline.pipeline import _transcode_split
+from kedro.pipeline._transcoding import _transcode_split
 
 
 def _is_relative_path(path_string: str) -> bool:

--- a/kedro/pipeline/_transcoding.py
+++ b/kedro/pipeline/_transcoding.py
@@ -1,0 +1,38 @@
+from typing import Tuple
+
+TRANSCODING_SEPARATOR = "@"
+
+
+def _transcode_split(element: str) -> Tuple[str, str]:
+    """Split the name by the transcoding separator.
+    If the transcoding part is missing, empty string will be put in.
+
+    Returns:
+        Node input/output name before the transcoding separator, if present.
+    Raises:
+        ValueError: Raised if more than one transcoding separator
+        is present in the name.
+    """
+    split_name = element.split(TRANSCODING_SEPARATOR)
+
+    if len(split_name) > 2:  # noqa: PLR2004
+        raise ValueError(
+            f"Expected maximum 1 transcoding separator, found {len(split_name) - 1} "
+            f"instead: '{element}'."
+        )
+    if len(split_name) == 1:
+        split_name.append("")
+
+    return tuple(split_name)  # type: ignore
+
+
+def _strip_transcoding(element: str) -> str:
+    """Strip out the transcoding separator and anything that follows.
+
+    Returns:
+        Node input/output name before the transcoding separator, if present.
+    Raises:
+        ValueError: Raised if more than one transcoding separator
+        is present in the name.
+    """
+    return _transcode_split(element)[0]

--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -6,12 +6,9 @@ import difflib
 from typing import AbstractSet, Iterable
 
 from kedro.pipeline.node import Node
-from kedro.pipeline.pipeline import (
-    TRANSCODING_SEPARATOR,
-    Pipeline,
-    _strip_transcoding,
-    _transcode_split,
-)
+from kedro.pipeline.pipeline import Pipeline
+
+from ._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding, _transcode_split
 
 
 class ModularPipelineError(Exception):

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -13,6 +13,8 @@ from warnings import warn
 
 from more_itertools import spy, unzip
 
+from ._transcoding import _strip_transcoding
+
 
 class Node:
     """``Node`` is an auxiliary class facilitating the operations required to
@@ -528,11 +530,13 @@ class Node:
             )
 
     def _validate_inputs_dif_than_outputs(self) -> None:
-        common_in_out = set(self.inputs).intersection(set(self.outputs))
+        common_in_out = set(map(_strip_transcoding, self.inputs)).intersection(
+            set(map(_strip_transcoding, self.outputs))
+        )
         if common_in_out:
             raise ValueError(
                 f"Failed to create node {self}.\n"
-                f"A node cannot have the same inputs and outputs: "
+                f"A node cannot have the same inputs and outputs even if they are transcoded: "
                 f"{common_in_out}"
             )
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -15,42 +15,7 @@ from graphlib import CycleError, TopologicalSorter
 import kedro
 from kedro.pipeline.node import Node, _to_list
 
-TRANSCODING_SEPARATOR = "@"
-
-
-def _transcode_split(element: str) -> tuple[str, str]:
-    """Split the name by the transcoding separator.
-    If the transcoding part is missing, empty string will be put in.
-
-    Returns:
-        Node input/output name before the transcoding separator, if present.
-    Raises:
-        ValueError: Raised if more than one transcoding separator
-        is present in the name.
-    """
-    split_name = element.split(TRANSCODING_SEPARATOR)
-
-    if len(split_name) > 2:  # noqa: PLR2004
-        raise ValueError(
-            f"Expected maximum 1 transcoding separator, found {len(split_name) - 1} "
-            f"instead: '{element}'."
-        )
-    if len(split_name) == 1:
-        split_name.append("")
-
-    return tuple(split_name)  # type: ignore
-
-
-def _strip_transcoding(element: str) -> str:
-    """Strip out the transcoding separator and anything that follows.
-
-    Returns:
-        Node input/output name before the transcoding separator, if present.
-    Raises:
-        ValueError: Raised if more than one transcoding separator
-        is present in the name.
-    """
-    return _transcode_split(element)[0]
+from ._transcoding import _strip_transcoding
 
 
 class OutputNotUniqueError(Exception):

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -244,6 +244,10 @@ def input_same_as_output_node():
     return biconcat, ["A", "B"], {"a": "A"}
 
 
+def transcoded_input_same_as_output_node():
+    return identity, "A@excel", {"a": "A@csv"}
+
+
 def duplicate_output_dict_node():
     return identity, "A", {"a": "A", "b": "A"}
 
@@ -269,7 +273,11 @@ def bad_output_variable_name():
         (no_input_or_output_node, r"it must have some 'inputs' or 'outputs'"),
         (
             input_same_as_output_node,
-            r"A node cannot have the same inputs and outputs: {\'A\'}",
+            r"A node cannot have the same inputs and outputs even if they are transcoded: {\'A\'}",
+        ),
+        (
+            transcoded_input_same_as_output_node,
+            r"A node cannot have the same inputs and outputs even if they are transcoded: {\'A\'}",
         ),
         (
             duplicate_output_dict_node,

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5,13 +5,12 @@ import pytest
 
 import kedro
 from kedro.pipeline import node
+from kedro.pipeline._transcoding import _strip_transcoding, _transcode_split
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 from kedro.pipeline.pipeline import (
     CircularDependencyError,
     ConfirmNotUniqueError,
     OutputNotUniqueError,
-    _strip_transcoding,
-    _transcode_split,
 )
 
 

--- a/tests/pipeline/test_pipeline_with_transcoding.py
+++ b/tests/pipeline/test_pipeline_with_transcoding.py
@@ -4,8 +4,9 @@ import pytest
 
 import kedro
 from kedro.pipeline import node
+from kedro.pipeline._transcoding import _strip_transcoding
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
-from kedro.pipeline.pipeline import OutputNotUniqueError, _strip_transcoding
+from kedro.pipeline.pipeline import OutputNotUniqueError
 
 
 # Different dummy func based on the number of arguments


### PR DESCRIPTION
## Description

We have figured out in https://github.com/kedro-org/kedro/issues/3799 that Kedro allows self-referencing nodes, as long as they use transcoding in their dataset names as follows:

```python
node(
        func=load_shuttles_to_csv,
        inputs="test_data@excel",
        outputs="test_data@csv",
        name="load_shuttles_to_csv_node",
)
```

This makes the transcoding feature inconsistent with basic Kedro invariants like "no loops allowed in the graph". This PR adds a change to the node validation code, which raises an error and makes the message mention transcoded dataset names.

It also adds a couple of tests and moves around a bit some of the transcoding helpers, so they can be accessible to all modules in `kedro.pipeline`.

While working on this, the PR also reveals a bit of weird place of using `_strip_transcoding` in `KedroContext` which should probably be addressed when `KedroSession` is redesigned.

## Development notes

See above.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
