### PR TITLE
Change path to starters test

### DIFF
--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -149,7 +149,7 @@ def _remove_pyspark_viz_starter_files(is_viz: bool, python_package_name: str) ->
         _remove_dir(pipelines_path / pipeline_subdir)
 
     # Remove all test files from tests/pipelines/
-    test_pipeline_path = current_dir / "tests/pipelines/test_data_science.py"
+    test_pipeline_path = current_dir / "tests/pipelines/data_science/test_pipeline.py"
     _remove_file(test_pipeline_path)
 
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Updates the path to the test pipelines generated by starters to match with the directory structure changes made on https://github.com/kedro-org/kedro-starters/pull/215

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
