### PR TITLE
Import `TRANSCODING_SEPARATOR` to pipeline to make Kedro backwards compatible with `kedro-viz` on python 3.8

### DIFF
--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -15,7 +15,8 @@ from graphlib import CycleError, TopologicalSorter
 import kedro
 from kedro.pipeline.node import Node, _to_list
 
-from ._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding  # noqa: F401
+from ._transcoding import _strip_transcoding
+from ._transcoding import TRANSCODING_SEPARATOR  # noqa: F401 for 0.19.x backward compatibility
 
 
 class OutputNotUniqueError(Exception):

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -15,8 +15,10 @@ from graphlib import CycleError, TopologicalSorter
 import kedro
 from kedro.pipeline.node import Node, _to_list
 
-from ._transcoding import _strip_transcoding
-from ._transcoding import TRANSCODING_SEPARATOR  # noqa: F401 for 0.19.x backward compatibility
+from ._transcoding import (
+    TRANSCODING_SEPARATOR,  # noqa: F401 for 0.19.x backward compatibility
+    _strip_transcoding,
+)
 
 
 class OutputNotUniqueError(Exception):

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -15,7 +15,7 @@ from graphlib import CycleError, TopologicalSorter
 import kedro
 from kedro.pipeline.node import Node, _to_list
 
-from ._transcoding import _strip_transcoding
+from ._transcoding import TRANSCODING_SEPARATOR, _strip_transcoding  # noqa: F401
 
 
 class OutputNotUniqueError(Exception):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Flagged by e2e test on `kedro-docker` this morning (but not related to `kedro-docker`) - https://github.com/kedro-org/kedro-plugins/actions/runs/8730295535/job/23953858295#step:8:1

### Context 
* `kedro-viz` dropped support for python 3.8 in `v.8.0.0`
* we recently moved `TRANSCODING_SEPARATOR` to `kedro.pipeline._transcoding.py` from `kedro.pipeline.pipeline.py`
* This variable is used by `kedro-viz` in https://github.com/kedro-org/kedro-viz/blob/main/package/kedro_viz/integrations/kedro/hooks.py
    * they did update the import statement to work with older versions of Kedro so Kedro-Viz remains backwards compatible.

### The problem
For python versions > 3.8, everything is okay ✅ 

For python version == 3.8:
If a user has a project that uses both Kedro and Viz, the project becomes completely unusable -
- The last version of viz that supports python 3.8 is 7.1.0
- Kedro still supports python 3.8, so if a user creates a new project with 0.19.4 or upgrades the project to 0.19.4 it becomes a problem:
```
ImportError: cannot import name 'TRANSCODING_SEPARATOR' from 
      'kedro.pipeline.pipeline' 
      (/usr/local/lib/python3.8/site-packages/kedro/pipeline/pipeline.py)
```
- User is then restricted to kedro versions < 0.19.4

## Development notes
<!-- What have you changed, and how has this been tested? -->
### Proposed Solution 1
- Do nothing, it's a very small subset of users (python == 3.8, kedro == 0.19.4 and using `kedro-viz` for their projects)
- Issue a statement that you can't update to kedro 0.19.4 if you're on python 3.8 AND want to use `kedro-viz` (Uninstalling viz solves the problem)
- Additionally -
    - We can fix this in 0.19.5 but **don't need to do an immediate** patch release

### Proposed Solution 2
- Add an import statement for `TRANSCODE_SEPARATOR` to `kedro.pipeline.pipeline` 
- **Do a patch release** to make Kedro backwards compatible with kedro-viz

### Other considerations (Bigger discussion)
- arrive at a consensus about which python versions should be supported by all Kedro/Viz/Plugins

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
