### PR TITLE
Release 0.19.5

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -49,5 +49,5 @@ authors:
   given-names: Simon
 title: Kedro
 version: 0.19.5
-date-released: 2024-04-19
+date-released: 2024-04-22
 url: https://github.com/kedro-org/kedro

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -48,6 +48,6 @@ authors:
 - family-names: Brugman
   given-names: Simon
 title: Kedro
-version: 0.19.4
-date-released: 2024-04-17
+version: 0.19.5
+date-released: 2024-04-19
 url: https://github.com/kedro-org/kedro

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-# Upcoming Release 0.19.5
+# Upcoming Release 0.19.6
 
 ## Major features and improvements
 
@@ -7,9 +7,18 @@
 ## Breaking changes to the API
 
 ## Documentation changes
-* Updated the documentation for deploying a Kedro project with Astronomer Airflow.
 
 ## Community contributions
+
+
+# Release 0.19.5
+
+## Bug fixes and other changes
+* Fixed breaking import issue when working on a project with `kedro-viz` on python 3.8.
+
+## Documentation changes
+* Updated the documentation for deploying a Kedro project with Astronomer Airflow.
+* Used `kedro-sphinx-theme` for documentation.
 
 # Release 0.19.4
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -109,7 +109,7 @@ Returns output similar to the following, depending on the version of Kedro used 
 | |/ / _ \/ _` | '__/ _ \
 |   <  __/ (_| | | | (_) |
 |_|\_\___|\__,_|_|  \___/
-v0.19.4
+v0.19.5
 
 Kedro is a Python framework for
 creating reproducible, maintainable

--- a/docs/source/robots.txt
+++ b/docs/source/robots.txt
@@ -1,6 +1,7 @@
 User-agent: *
 Disallow: /
 Allow: /en/stable/
+Allow: /en/0.19.5/
 Allow: /en/0.19.4/
 Allow: /en/0.19.3/
 Allow: /en/0.19.2/

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -6,7 +6,7 @@ configuration and pipeline assembly.
 import sys
 import warnings
 
-__version__ = "0.19.4"
+__version__ = "0.19.5"
 
 
 class KedroDeprecationWarning(DeprecationWarning):


### PR DESCRIPTION
## Description
Patch release 0.19.5 for backwards compatibility on python 3.8 with `kedro-viz`

## Development notes
![image](https://github.com/kedro-org/kedro/assets/110245118/cd277ffc-fdfe-4bcd-9670-67b63e722898)


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
