### PR TITLE
Make logging.yml read by default

### DIFF
--- a/docs/source/logging/index.md
+++ b/docs/source/logging/index.md
@@ -42,6 +42,17 @@ After setting the environment variable, any subsequent Kedro commands use the lo
 If the `KEDRO_LOGGING_CONFIG` environment variable is not set, Kedro will use the [default logging configuration](https://github.com/kedro-org/kedro/blob/main/kedro/framework/project/default_logging.yml).
 ```
 
+## How to use custom `CONF_SOURCE` with logging
+
+The path to the logging configuration file is impacted by the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project. This setting determines where Kedro looks for configuration files, including `logging.yml`. 
+
+By default, Kedro expects the logging configuration file to be located in the `conf` directory. If `CONF_SOURCE` is customized to a different directory, ensure that your `logging.yml` file is also relocated to this new directory, or update the `KEDRO_LOGGING_CONFIG` environment variable to point to the new location of your logging configuration.
+
+For example:
+```bash
+export KEDRO_LOGGING_CONFIG=<project_root>/custom_config_folder/logging.yml
+```
+
 ### How to show DEBUG level messages
 To see `DEBUG` level messages, change the level of logging in your project-specific logging configuration file (`logging.yml`). We provide a `logging.yml` template:
 

--- a/docs/source/logging/index.md
+++ b/docs/source/logging/index.md
@@ -42,16 +42,18 @@ After setting the environment variable, any subsequent Kedro commands use the lo
 If the `KEDRO_LOGGING_CONFIG` environment variable is not set, Kedro will use the [default logging configuration](https://github.com/kedro-org/kedro/blob/main/kedro/framework/project/default_logging.yml).
 ```
 
-## How to use custom `CONF_SOURCE` with logging
+## Custom `CONF_SOURCE` with logging
 
-The path to the logging configuration file is impacted by the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project. This setting determines where Kedro looks for configuration files, including `logging.yml`.
+When you customise the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project, it determines where Kedro looks for configuration files, it does not automatically affect where the `logging.yml` is searched for.
 
-By default, Kedro expects the logging configuration file to be located in the `conf` directory. If `CONF_SOURCE` is customized to a different directory, ensure that your `logging.yml` file is also relocated to this new directory, or update the `KEDRO_LOGGING_CONFIG` environment variable to point to the new location of your logging configuration.
+By default, Kedro expects the logging configuration file to be located in the `conf` directory. If you change `CONF_SOURCE` and want to use a different location for your `logging.yml`, you must update the `KEDRO_LOGGING_CONFIG` environment variable to point to the new location of your logging configuration.
 
 For example:
 ```bash
 export KEDRO_LOGGING_CONFIG=<project_root>/custom_config_folder/logging.yml
 ```
+
+Please note that adjusting `CONF_SOURCE` without updating the logging configuration accordingly can lead to Kedro not locating the `logging.yml` file, which will result in the default logging settings being used instead.
 
 ### How to show DEBUG level messages
 To see `DEBUG` level messages, change the level of logging in your project-specific logging configuration file (`logging.yml`). We provide a `logging.yml` template:

--- a/docs/source/logging/index.md
+++ b/docs/source/logging/index.md
@@ -44,7 +44,7 @@ If the `KEDRO_LOGGING_CONFIG` environment variable is not set, Kedro will use th
 
 ## How to use custom `CONF_SOURCE` with logging
 
-The path to the logging configuration file is impacted by the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project. This setting determines where Kedro looks for configuration files, including `logging.yml`. 
+The path to the logging configuration file is impacted by the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project. This setting determines where Kedro looks for configuration files, including `logging.yml`.
 
 By default, Kedro expects the logging configuration file to be located in the `conf` directory. If `CONF_SOURCE` is customized to a different directory, ensure that your `logging.yml` file is also relocated to this new directory, or update the `KEDRO_LOGGING_CONFIG` environment variable to point to the new location of your logging configuration.
 

--- a/docs/source/logging/index.md
+++ b/docs/source/logging/index.md
@@ -44,16 +44,14 @@ If the `KEDRO_LOGGING_CONFIG` environment variable is not set, Kedro will use th
 
 ## Custom `CONF_SOURCE` with logging
 
-When you customise the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project, it determines where Kedro looks for configuration files, it does not automatically affect where the `logging.yml` is searched for.
+When you customise the [`CONF_SOURCE`](../configuration/configuration_basics.md#how-to-change-the-configuration-source-folder-at-runtime) setting in your Kedro project, it determines where Kedro looks for configuration files, including the logging configuration file. However, changing `CONF_SOURCE` does not automatically update the path to `logging.yml`. To use a custom location or filename for the logging configuration, you must explicitly set the `KEDRO_LOGGING_CONFIG` environment variable.
 
-By default, Kedro expects the logging configuration file to be located in the `conf` directory. If you change `CONF_SOURCE` and want to use a different location for your `logging.yml`, you must update the `KEDRO_LOGGING_CONFIG` environment variable to point to the new location of your logging configuration.
-
-For example:
+By default, Kedro looks for a file named `logging.yml` in the `conf` directory. If you move or rename your logging configuration file after changing `CONF_SOURCE`, specify the new path using the `KEDRO_LOGGING_CONFIG` environment variable:
 ```bash
-export KEDRO_LOGGING_CONFIG=<project_root>/custom_config_folder/logging.yml
+export KEDRO_LOGGING_CONFIG=<project_root>/custom_config_folder/custom_logging_name.yml
 ```
 
-Please note that adjusting `CONF_SOURCE` without updating the logging configuration accordingly can lead to Kedro not locating the `logging.yml` file, which will result in the default logging settings being used instead.
+Please note that adjusting `CONF_SOURCE` or renaming `logging.yml` without updating the logging configuration accordingly can lead to Kedro not locating the file, which will result in the default logging settings being used instead.
 
 ### How to show DEBUG level messages
 To see `DEBUG` level messages, change the level of logging in your project-specific logging configuration file (`logging.yml`). We provide a `logging.yml` template:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -237,7 +237,9 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
 
         # Log info about the logging configuration
-        if not user_logging_path and path.resolve() == (Path("conf/logging.yml").resolve()):
+        if not user_logging_path and path.resolve() == (
+            Path("conf/logging.yml").resolve()
+        ):
             logger = logging.getLogger(__name__)
             logger.info(
                 "Using `conf/logging.yml` as logging configuration. "

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -231,6 +231,11 @@ class _ProjectLogging(UserDict):
             path = Path(user_logging_path)
         else:
             path = default_logging_path
+            logger = logging.getLogger(__name__)
+            logger.warning(
+                "Using `conf/logging.yml` as logging configuration. You can change this by setting the "
+                "KEDRO_LOGGING_CONFIG environment variable accordingly."
+            )
 
         # Load and apply the logging configuration
         logging_config = Path(path).read_text(encoding="utf-8")

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -217,7 +217,8 @@ class _ProjectLogging(UserDict):
     def __init__(self) -> None:
         """Initialize project logging. The path to logging configuration is given in
         environment variable KEDRO_LOGGING_CONFIG (defaults to conf/logging.yml)."""
-        # Check if a user-specified path is set in the environment variable
+
+        # Check if a user path is set in the environment variable
         user_logging_path = os.environ.get("KEDRO_LOGGING_CONFIG")
 
         # Check if the default logging configuration exists
@@ -225,7 +226,7 @@ class _ProjectLogging(UserDict):
         if not default_logging_path.exists():
             default_logging_path = Path(__file__).parent / "default_logging.yml"
 
-        # Use the user-specified path if available; otherwise, use the default path
+        # Use the user path if available, otherwise, use the default path
         if user_logging_path and Path(user_logging_path).exists():
             path = Path(user_logging_path)
         else:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -215,19 +215,26 @@ class _ProjectPipelines(MutableMapping):
 
 class _ProjectLogging(UserDict):
     def __init__(self) -> None:
-        """Initialise project logging. The path to logging configuration is given in
-        environment variable KEDRO_LOGGING_CONFIG (defaults to default_logging.yml)."""
-        path = os.environ.get(
-            "KEDRO_LOGGING_CONFIG", Path(__file__).parent / "default_logging.yml"
-        )
+        """Initialize project logging. The path to logging configuration is given in
+        environment variable KEDRO_LOGGING_CONFIG (defaults to conf/logging.yml)."""
+        # Check if a user-specified path is set in the environment variable
+        user_logging_path = os.environ.get("KEDRO_LOGGING_CONFIG")
+
+        # Check if the default logging configuration exists
+        default_logging_path = Path("conf/logging.yml")
+        if not default_logging_path.exists():
+            default_logging_path = Path(__file__).parent / "default_logging.yml"
+
+        # Use the user-specified path if available; otherwise, use the default path
+        path = user_logging_path if user_logging_path else default_logging_path
         logging_config = Path(path).read_text(encoding="utf-8")
+
+        # Load and apply the logging configuration
         self.configure(yaml.safe_load(logging_config))
 
     def configure(self, logging_config: dict[str, Any]) -> None:
-        """Configure project logging using ``logging_config`` (e.g. from project
-        logging.yml). We store this in the UserDict data so that it can be reconfigured
-        in _bootstrap_subprocess.
-        """
+        """Configure project logging using `logging_config` (e.g., from project logging.yml).
+        Store this in the UserDict data so that it can be reconfigured in _bootstrap_subprocess."""
         logging.config.dictConfig(logging_config)
         self.data = logging_config
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -231,8 +231,7 @@ class _ProjectLogging(UserDict):
             path = Path(user_logging_path)
         else:
             path = default_logging_path
-            logger = logging.getLogger(__name__)
-            logger.warning(
+            warnings.warn(
                 "Using `conf/logging.yml` as logging configuration. You can change this by setting the "
                 "KEDRO_LOGGING_CONFIG environment variable accordingly."
             )

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -236,8 +236,10 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
 
     def configure(self, logging_config: dict[str, Any]) -> None:
-        """Configure project logging using `logging_config` (e.g., from project logging.yml).
-        Store this in the UserDict data so that it can be reconfigured in _bootstrap_subprocess."""
+        """Configure project logging using ``logging_config`` (e.g. from project
+        logging.yml). We store this in the UserDict data so that it can be reconfigured
+        in _bootstrap_subprocess.
+        """
         logging.config.dictConfig(logging_config)
         self.data = logging_config
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -237,13 +237,11 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
 
         # Log info about the logging configuration
-        if not user_logging_path and path.resolve() == (
-            Path("conf/logging.yml").resolve()
-        ):
+        if not user_logging_path and default_logging_path == Path("conf/logging.yml"):
             logger = logging.getLogger(__name__)
             logger.info(
-                "Using `conf/logging.yml` as logging configuration. "
-                "You can change this by setting the KEDRO_LOGGING_CONFIG environment variable accordingly."
+                f"Using `{path}` as logging configuration. "
+                f"You can change this by setting the KEDRO_LOGGING_CONFIG environment variable accordingly."
             )
 
     def configure(self, logging_config: dict[str, Any]) -> None:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -215,7 +215,7 @@ class _ProjectPipelines(MutableMapping):
 
 class _ProjectLogging(UserDict):
     def __init__(self) -> None:
-        """Initialize project logging. The path to logging configuration is given in
+        """Initialise project logging. The path to logging configuration is given in
         environment variable KEDRO_LOGGING_CONFIG (defaults to conf/logging.yml)."""
 
         # Check if a user path is set in the environment variable

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -231,14 +231,18 @@ class _ProjectLogging(UserDict):
             path = Path(user_logging_path)
         else:
             path = default_logging_path
-            warnings.warn(
-                "Using `conf/logging.yml` as logging configuration. You can change this by setting the "
-                "KEDRO_LOGGING_CONFIG environment variable accordingly."
-            )
 
         # Load and apply the logging configuration
         logging_config = Path(path).read_text(encoding="utf-8")
         self.configure(yaml.safe_load(logging_config))
+
+        # Log info about the logging configuration
+        if not user_logging_path and path.resolve() == (Path("conf/logging.yml").resolve()):
+            logger = logging.getLogger(__name__)
+            logger.info(
+                "Using `conf/logging.yml` as logging configuration. "
+                "You can change this by setting the KEDRO_LOGGING_CONFIG environment variable accordingly."
+            )
 
     def configure(self, logging_config: dict[str, Any]) -> None:
         """Configure project logging using ``logging_config`` (e.g. from project

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -226,10 +226,13 @@ class _ProjectLogging(UserDict):
             default_logging_path = Path(__file__).parent / "default_logging.yml"
 
         # Use the user-specified path if available; otherwise, use the default path
-        path = user_logging_path if user_logging_path else default_logging_path
-        logging_config = Path(path).read_text(encoding="utf-8")
+        if user_logging_path and Path(user_logging_path).exists():
+            path = Path(user_logging_path)
+        else:
+            path = default_logging_path
 
         # Load and apply the logging configuration
+        logging_config = Path(path).read_text(encoding="utf-8")
         self.configure(yaml.safe_load(logging_config))
 
     def configure(self, logging_config: dict[str, Any]) -> None:

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -170,7 +170,7 @@ def test_default_logging_info_emission(monkeypatch, capsys):
 
     captured = capsys.readouterr()
 
-    expected_message = f"Using `{expected_path}` as logging"
+    expected_message = f"Using `{expected_path}`"
     assert (
         expected_message in captured.out
     ), f"Expected message not found in logs: {captured.out}"

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -153,10 +153,7 @@ def always_true_exists(path):
 
 def mock_read_text(path, encoding):
     """Returns dummy logging config."""
-    dummy_logging_config = {
-        "version": 1,
-        "loggers": {"kedro": {"level": "INFO"}}
-    }
+    dummy_logging_config = {"version": 1, "loggers": {"kedro": {"level": "INFO"}}}
     return yaml.dump(dummy_logging_config)
 
 
@@ -167,6 +164,7 @@ def test_default_logging_info_emission(capsys, monkeypatch):
     monkeypatch.setattr(Path, "read_text", mock_read_text)
 
     from kedro.framework.project import _ProjectLogging
+
     _ProjectLogging()
 
     captured = capsys.readouterr()

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -144,3 +144,36 @@ def test_rich_traceback_disabled_on_databricks(
 
     rich_traceback_install.assert_not_called()
     rich_pretty_install.assert_called()
+
+
+def always_true_exists(path):
+    """Returns True for the default logging config path."""
+    return str(path) == "conf/logging.yml"
+
+
+def mock_read_text(path, encoding):
+    """Returns dummy logging config."""
+    dummy_logging_config = {
+        "version": 1,
+        "loggers": {"kedro": {"level": "INFO"}}
+    }
+    return yaml.dump(dummy_logging_config)
+
+
+def test_default_logging_info_emission(capsys, monkeypatch):
+    # Unset environment variable for KEDRO_LOGGING_CONFIG and mock paths
+    monkeypatch.delenv("KEDRO_LOGGING_CONFIG", raising=False)
+    monkeypatch.setattr(Path, "exists", always_true_exists)
+    monkeypatch.setattr(Path, "read_text", mock_read_text)
+
+    from kedro.framework.project import _ProjectLogging
+    LOGGING = _ProjectLogging()
+
+    captured = capsys.readouterr()
+    expected_messages = [
+        "Using `conf/logging.yml` as logging",
+    ]
+
+    # Assert that all parts of the message are in the output
+    for message in expected_messages:
+        assert message in captured.out, f"Expected '{message}' to be in logs"

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -167,7 +167,7 @@ def test_default_logging_info_emission(capsys, monkeypatch):
     monkeypatch.setattr(Path, "read_text", mock_read_text)
 
     from kedro.framework.project import _ProjectLogging
-    LOGGING = _ProjectLogging()
+    _ProjectLogging()
 
     captured = capsys.readouterr()
     expected_messages = [

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -158,7 +158,7 @@ def mock_read_text(path, encoding):
 
 
 def test_default_logging_info_emission(capsys, monkeypatch):
-    # Unset environment variable for KEDRO_LOGGING_CONFIG and mock paths
+    # Setup environment and path mocks
     monkeypatch.delenv("KEDRO_LOGGING_CONFIG", raising=False)
     monkeypatch.setattr(Path, "exists", always_true_exists)
     monkeypatch.setattr(Path, "read_text", mock_read_text)
@@ -168,10 +168,7 @@ def test_default_logging_info_emission(capsys, monkeypatch):
     _ProjectLogging()
 
     captured = capsys.readouterr()
-    expected_messages = [
-        "Using `conf/logging.yml` as logging",
-    ]
-
-    # Assert that all parts of the message are in the output
-    for message in expected_messages:
-        assert message in captured.out, f"Expected '{message}' to be in logs"
+    expected_message = "Using `conf/logging.yml` as logging"
+    assert (
+        expected_message in captured.out
+    ), f"Expected '{expected_message}' to be in logs"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Related to: https://github.com/kedro-org/kedro/issues/3801

Implement a fix to make sure the default file is read. KEDRO_LOGGING_CONFIG will take priority when it is provided.

## Development notes
<!-- What have you changed, and how has this been tested? -->

- It will default to `conf/logging.yml` if `KEDRO_LOGGING_CONFIG` isn't set. 
- If `conf/logging.yml` does not exist, it falls back to `default_logging.yml`. 

### CONF_SOURCE

Investigated the possibility of adding custom `CONF_SOURCE` support during the logging setup, allowing the `logging.yml` to be dynamically set. Below are the results of this investigation:

#### Code changes:

```
class _ProjectLogging(UserDict):
    def __init__(self, settings: _ProjectSettings) -> None:
        """Initialise project logging. The path to logging configuration is given in
        environment variable KEDRO_LOGGING_CONFIG (defaults to conf/logging.yml)."""
        # Fetch CONF_SOURCE from settings
        conf_source = getattr(settings, 'CONF_SOURCE', 'conf')

        # Check if a user path is set in the environment variable
        user_logging_path = os.environ.get("KEDRO_LOGGING_CONFIG")

        # Check if the default logging configuration exists
        default_logging_path = Path(conf_source) / "logging.yml"
        if not default_logging_path.exists():
            default_logging_path = Path(__file__).parent / "default_logging.yml"

        # Use the user path if available, otherwise, use the default path
        if user_logging_path and Path(user_logging_path).exists():
            path = Path(user_logging_path)
        else:
            path = default_logging_path

        # Load and apply the logging configuration
        logging_config = Path(path).read_text(encoding="utf-8")
        self.configure(yaml.safe_load(logging_config))

PACKAGE_NAME = None

settings = _ProjectSettings()

LOGGING = _ProjectLogging(settings)

pipelines = _ProjectPipelines()
```

#### Explanation:
The above code attempted to fetch the `CONF_SOURCE` setting from the Kedro settings and use this setting to find the path of the logging config file, allowing the logging setup to change automatically depending on where the user specifies.

#### Issues:
During the implementation I ran into several problems mostly due to timings:

The dynamic fetching of settings led to circular imports because the logging module depended on settings, which in turn depended on other things that required logging. This dependency cycle caused runtime errors preventing the project from starting.

This approach also complicated the creation of the project. It was quite challengin to initialise logging before all configurations are loaded without causing import loops.

So for now the current approach of using the happy path for logging will only remain. For the users that need more dynamic logging they will have to manually configure logging. I've enhanced the documentation to outline this.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
