### PR TITLE
Fix broken Markdown table in documentation

### DIFF
--- a/docs/source/notebooks_and_ipython/kedro_and_notebooks.md
+++ b/docs/source/notebooks_and_ipython/kedro_and_notebooks.md
@@ -199,8 +199,7 @@ You can also specify the following optional arguments for `session.run`:
 | `to_nodes`      | `Iterable[str]`  | A list of node names which should be used as an end point                                                                                            |
 | `from_inputs`   | `Iterable[str]`  | A list of dataset names which should be used as a starting point                                                                                     |
 | `to_outputs`    | `Iterable[str]`  | A list of dataset names which should be used as an end point                                                                                         |
-| `load_versions` | `Dict[str, str]` | A mapping of a dataset name to a specific dataset version (timestamp) for loading. Applies to versioned datasets
-                                |
+| `load_versions` | `Dict[str, str]` | A mapping of a dataset name to a specific dataset version (timestamp) for loading. Applies to versioned datasets                                     |
 | `pipeline_name` | `str`            | Name of the modular pipeline to run. Must be one of those returned by the `register_pipelines` function in `src/<package_name>/pipeline_registry.py` |
 
 You can execute one *successful* run per session, as there's a one-to-one mapping between a session and a run. If you wish to do more than one run, you'll have to run `%reload_kedro` line magic to get a new `session`.


### PR DESCRIPTION
## Description
A markdown table in the documentation is rendered incorrectly.

https://docs.kedro.org/en/stable/notebooks_and_ipython/kedro_and_notebooks.html

the last row of the table for session.run is shown incorrectly. 


## Development notes
Removed unnecessary line break

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
