### PR TITLE
Use user defined default dataset factory pattern over the one from the runner 

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* User defined catch-all dataset factory patterns now override the default pattern provided by the runner.
 
 ## Breaking changes to the API
 

--- a/docs/source/data/kedro_dataset_factories.md
+++ b/docs/source/data/kedro_dataset_factories.md
@@ -225,7 +225,7 @@ You can use dataset factories to define a catch-all pattern which will overwrite
 ```yaml
 "{default_dataset}":
   type: pandas.CSVDataset
-  filepath: data/{a_default_dataset}.csv
+  filepath: data/{default_dataset}.csv
 
 ```
 Kedro will now treat all the datasets mentioned in your project's pipelines that do not appear as specific patterns or explicit entries in your catalog
@@ -317,9 +317,9 @@ shuttles:
   type: pandas.ParquetDataset
   filepath: data/02_intermediate/preprocessed_{name}.pq
 
-"{a_default}":
+"{default}":
   type: pandas.ParquetDataset
-  filepath: data/03_primary/{a_default}.pq
+  filepath: data/03_primary/{default}.pq
 ```
 </details>
 

--- a/docs/source/data/kedro_dataset_factories.md
+++ b/docs/source/data/kedro_dataset_factories.md
@@ -223,18 +223,13 @@ The matches are ranked according to the following criteria:
 You can use dataset factories to define a catch-all pattern which will overwrite the default [`MemoryDataset`](/api/kedro.io.MemoryDataset) creation.
 
 ```yaml
-"{a_default_dataset}":
+"{default_dataset}":
   type: pandas.CSVDataset
   filepath: data/{a_default_dataset}.csv
 
 ```
 Kedro will now treat all the datasets mentioned in your project's pipelines that do not appear as specific patterns or explicit entries in your catalog
 as `pandas.CSVDataset`.
-
-```{note}
-Under the hood Kedro uses the pattern name "{default}" to generate the default datasets set in the runners. If you want to overwrite this pattern you should make sure you choose a name that comes
-before "default" in the alphabet for it to be resolved first.
-```
 
 ## CLI commands for dataset factories
 

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -92,6 +92,7 @@ def list_datasets(metadata: ProjectMetadata, pipeline: str, env: str) -> None:
                 ds_config_copy = copy.deepcopy(
                     data_catalog._dataset_patterns.get(matched_pattern)
                     or data_catalog._default_pattern.get(matched_pattern)
+                    or {}
                 )
 
                 ds_config = data_catalog._resolve_config(
@@ -268,6 +269,7 @@ def resolve_patterns(metadata: ProjectMetadata, env: str) -> None:
             ds_config_copy = copy.deepcopy(
                 data_catalog._dataset_patterns.get(matched_pattern)
                 or data_catalog._default_pattern.get(matched_pattern)
+                or {}
             )
 
             ds_config = data_catalog._resolve_config(

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -87,10 +87,11 @@ def list_datasets(metadata: ProjectMetadata, pipeline: str, env: str) -> None:
         for ds_name in default_ds:
             matched_pattern = data_catalog._match_pattern(
                 data_catalog._dataset_patterns, ds_name
-            )
+            ) or data_catalog._match_pattern(data_catalog._default_pattern, ds_name)
             if matched_pattern:
                 ds_config_copy = copy.deepcopy(
-                    data_catalog._dataset_patterns[matched_pattern]
+                    data_catalog._dataset_patterns.get(matched_pattern)
+                    or data_catalog._default_pattern.get(matched_pattern)
                 )
 
                 ds_config = data_catalog._resolve_config(
@@ -215,7 +216,10 @@ def rank_catalog_factories(metadata: ProjectMetadata, env: str) -> None:
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 
-    catalog_factories = context.catalog._dataset_patterns
+    catalog_factories = {
+        **context.catalog._dataset_patterns,
+        **context.catalog._default_pattern,
+    }
     if catalog_factories:
         click.echo(yaml.dump(list(catalog_factories.keys())))
     else:
@@ -259,10 +263,11 @@ def resolve_patterns(metadata: ProjectMetadata, env: str) -> None:
 
         matched_pattern = data_catalog._match_pattern(
             data_catalog._dataset_patterns, ds_name
-        )
+        ) or data_catalog._match_pattern(data_catalog._default_pattern, ds_name)
         if matched_pattern:
             ds_config_copy = copy.deepcopy(
-                data_catalog._dataset_patterns[matched_pattern]
+                data_catalog._dataset_patterns.get(matched_pattern)
+                or data_catalog._default_pattern.get(matched_pattern)
             )
 
             ds_config = data_catalog._resolve_config(

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -173,6 +173,8 @@ class DataCatalog:
                 case-insensitive string that conforms with operating system
                 filename limitations, b) always return the latest version when
                 sorted in lexicographical order.
+            default_pattern: A dictionary of the default catch-all pattern that overrides the default
+                pattern provided through the runners.
 
         Example:
         ::
@@ -361,7 +363,7 @@ class DataCatalog:
         ]
         if len(catch_all) > 1:
             raise DatasetError(
-                f"Multiple catch-all patterns found in the catalog: {', '.join(catch_all)}"
+                f"Multiple catch-all patterns found in the catalog: {', '.join(catch_all)}. Only one catch-all pattern is allowed, remove the extras."
             )
         return {key: dataset_patterns[key] for key in sorted_keys}
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -356,6 +356,13 @@ class DataCatalog:
                 pattern,
             ),
         )
+        catch_all = [
+            pattern for pattern in sorted_keys if cls._specificity(pattern) == 0
+        ]
+        if len(catch_all) > 1:
+            raise DatasetError(
+                f"Multiple catch-all patterns found in the catalog: {', '.join(catch_all)}"
+            )
         return {key: dataset_patterns[key] for key in sorted_keys}
 
     @staticmethod

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -144,7 +144,7 @@ class DataCatalog:
         dataset_patterns: Patterns | None = None,
         load_versions: dict[str, str] | None = None,
         save_version: str | None = None,
-        default_pattern=None,
+        default_pattern: Patterns | None = None,
     ) -> None:
         """``DataCatalog`` stores instances of ``AbstractDataset``
         implementations to provide ``load`` and ``save`` capabilities from
@@ -385,10 +385,10 @@ class DataCatalog:
         if dataset_name not in self._datasets and matched_pattern:
             # If the dataset is a patterned dataset, materialise it and add it to
             # the catalog
-            if matched_pattern in self._dataset_patterns:
-                config_copy = copy.deepcopy(self._dataset_patterns[matched_pattern])
-            else:
-                config_copy = copy.deepcopy(self._default_pattern[matched_pattern])
+            config_copy = copy.deepcopy(
+                self._dataset_patterns.get(matched_pattern)
+                or self._default_pattern.get(matched_pattern)
+            )
             dataset_config = self._resolve_config(
                 dataset_name, matched_pattern, config_copy
             )

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -144,6 +144,7 @@ class DataCatalog:
         dataset_patterns: Patterns | None = None,
         load_versions: dict[str, str] | None = None,
         save_version: str | None = None,
+        default_pattern=None,
     ) -> None:
         """``DataCatalog`` stores instances of ``AbstractDataset``
         implementations to provide ``load`` and ``save`` capabilities from
@@ -190,6 +191,7 @@ class DataCatalog:
         self._dataset_patterns = dataset_patterns or {}
         self._load_versions = load_versions or {}
         self._save_version = save_version
+        self._default_pattern = default_pattern or {}
 
         if feed_dict:
             self.add_feed_dict(feed_dict)
@@ -281,6 +283,7 @@ class DataCatalog:
         credentials = copy.deepcopy(credentials) or {}
         save_version = save_version or generate_timestamp()
         load_versions = copy.deepcopy(load_versions) or {}
+        user_default = {}
 
         for ds_name, ds_config in catalog.items():
             ds_config = _resolve_credentials(  # noqa: PLW2901
@@ -295,6 +298,12 @@ class DataCatalog:
                     ds_name, ds_config, load_versions.get(ds_name), save_version
                 )
         sorted_patterns = cls._sort_patterns(dataset_patterns)
+        if sorted_patterns:
+            # If the last pattern is a catch-all pattern, pop it and set it as the default
+            if cls._specificity(list(sorted_patterns.keys())[-1]) == 0:
+                last_pattern = sorted_patterns.popitem()
+                user_default = {last_pattern[0]: last_pattern[1]}
+
         missing_keys = [
             key
             for key in load_versions.keys()
@@ -311,6 +320,7 @@ class DataCatalog:
             dataset_patterns=sorted_patterns,
             load_versions=load_versions,
             save_version=save_version,
+            default_pattern=user_default,
         )
 
     @staticmethod
@@ -369,11 +379,16 @@ class DataCatalog:
         version: Version | None = None,
         suggest: bool = True,
     ) -> AbstractDataset:
-        matched_pattern = self._match_pattern(self._dataset_patterns, dataset_name)
+        matched_pattern = self._match_pattern(
+            self._dataset_patterns, dataset_name
+        ) or self._match_pattern(self._default_pattern, dataset_name)
         if dataset_name not in self._datasets and matched_pattern:
             # If the dataset is a patterned dataset, materialise it and add it to
             # the catalog
-            config_copy = copy.deepcopy(self._dataset_patterns[matched_pattern])
+            if matched_pattern in self._dataset_patterns:
+                config_copy = copy.deepcopy(self._dataset_patterns[matched_pattern])
+            else:
+                config_copy = copy.deepcopy(self._default_pattern[matched_pattern])
             dataset_config = self._resolve_config(
                 dataset_name, matched_pattern, config_copy
             )
@@ -385,7 +400,7 @@ class DataCatalog:
             )
             if (
                 self._specificity(matched_pattern) == 0
-                and matched_pattern != "{default}"
+                and matched_pattern in self._default_pattern
             ):
                 self._logger.warning(
                     "Config from the dataset factory pattern '%s' in the catalog will be used to "
@@ -721,7 +736,7 @@ class DataCatalog:
         Returns:
             Copy of the current object.
         """
-        if extra_dataset_patterns:
+        if not self._default_pattern and extra_dataset_patterns:
             unsorted_dataset_patterns = {
                 **self._dataset_patterns,
                 **extra_dataset_patterns,
@@ -734,6 +749,7 @@ class DataCatalog:
             dataset_patterns=dataset_patterns,
             load_versions=self._load_versions,
             save_version=self._save_version,
+            default_pattern=self._default_pattern,
         )
 
     def __eq__(self, other) -> bool:  # type: ignore[no-untyped-def]

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -388,6 +388,7 @@ class DataCatalog:
             config_copy = copy.deepcopy(
                 self._dataset_patterns.get(matched_pattern)
                 or self._default_pattern.get(matched_pattern)
+                or {}
             )
             dataset_config = self._resolve_config(
                 dataset_name, matched_pattern, config_copy


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #3720 
## Development notes
<!-- What have you changed, and how has this been tested? -->
### TODO:
- [x] Update DataCatalog code 
- [x] Update CLI commands code
- [x] Docs
- [x] Test
- [ ] Release notes

Wanted to get opinions on the proposed solution before proceeding with the pending tasks mentioned above^

### Proposed Solution

#### When `DataCatalog` is created (in `from_config`)
- If the last pattern in the sorted patterns list is a catch-all pattern i.e. has specificity == 0, it is popped out and stored separately as the `DataCatalog._default_pattern` (This would be the user-defined default pattern, not from the runner)
> [!NOTE]  
> This assumes that there is only one catch-all pattern in the user's catalog. If there are more, the last one will be popped which wouldn't ever be used anyway.**❓ [Question for reviewers]: We should probably error out if the user has more than one catch-all patterns in this case, does that make sense?**

#### When a dataset is being fetched 
- Try to match is against the patterns in `DataCatalog._dataset_patterns` OR `DataCatalog._default_pattern`
- Resolve config again first from `_dataset_patterns` OR `_default_pattern`

#### When runner.run() is called 
When `kedro run` is executed, the runner creates a shallow copy of the catalog object by calling the `DataCatalog.shallow_copy()`
- Here the runner inserts a default dataset pattern e.g. `extra_dataset_patterns = {'{default}': MemoryDataset}`
- IF there is already a `_default_pattern` - it's not needed to do anything
- IF there isn't a user defined catch-all pattern - add it to the `DataCatalog._dataset_patterns` (this will then not emit a warning about the catch-all pattern being used over the runner default dataset)

#### For the catalog CLI commands
Similar logic as above has been copied for the matching of datasets to patterns


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
