### PR TITLE
Add deprecation warnings to `micropkg` CLI + docs

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,9 @@
 
 ## Breaking changes to the API
 
+## Upcoming deprecations for Kedro 0.20.0
+* All micro-packaging commands (`kedro micropkg pull`, `kedro micropkg package`) are deprecated and will be removed in Kedro 0.20.0.
+
 ## Documentation changes
 * Improved documentation for custom starters
 

--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -64,8 +64,8 @@ Here is a list of Kedro CLI commands, as a shortcut to the descriptions below. P
   * [`kedro ipython`](#notebooks)
   * [`kedro jupyter lab`](#notebooks)
   * [`kedro jupyter notebook`](#notebooks)
-  * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package)
-  * [`kedro micropkg pull <package_name>`](#pull-a-micro-package)
+  * [`kedro micropkg package <pipeline_name>`](#package-a-micro-package) (deprecated from version 0.20.0)
+  * [`kedro micropkg pull <package_name>`](#pull-a-micro-package) (deprecated from version 0.20.0)
   * [`kedro package`](#deploy-the-project)
   * [`kedro pipeline create <pipeline_name>`](#create-a-new-modular-pipeline-in-your-project)
   * [`kedro pipeline delete <pipeline_name>`](#delete-a-modular-pipeline)
@@ -335,6 +335,10 @@ See [the Python documentation for further information about packaging](https://p
 ### Pull a micro-package
 Since Kedro 0.17.7 you can pull a micro-package into your Kedro project as follows:
 
+```{warning}
+_This command is deprecated and will be removed from Kedro in version 0.20.0._
+```
+
 ```bash
 kedro micropkg pull <link-to-micro-package-sdist-file>
 ```
@@ -366,6 +370,10 @@ kedro pipeline create <pipeline_name>
 ##### Package a micro-package
 The following command packages all the files related to a micro-package, e.g. a modular pipeline, into a [Python source distribution file](https://packaging.python.org/overview/#python-source-distributions):
 
+```{warning}
+_This command is deprecated and will be removed from Kedro in version 0.20.0._
+```
+
 ```bash
 kedro micropkg package <package_module_path>
 ```
@@ -374,6 +382,10 @@ Further information is available in the [micro-packaging documentation](../nodes
 
 ##### Pull a micro-package in your project
 The following command pulls all the files related to a micro-package, e.g. a modular pipeline, from either [PyPI](https://pypi.org/) or a storage location of a [Python source distribution file](https://packaging.python.org/overview/#python-source-distributions).
+
+```{warning}
+_This command is deprecated and will be removed from Kedro in version 0.20.0._
+```
 
 ```bash
 kedro micropkg pull <package_name> (or path to a sdist file)

--- a/docs/source/nodes_and_pipelines/micro_packaging.md
+++ b/docs/source/nodes_and_pipelines/micro_packaging.md
@@ -1,5 +1,9 @@
 # Micro-packaging
 
+```{warning}
+_Micro-packaging is deprecated and will be removed from Kedro version 0.20.0._
+```
+
 Micro-packaging allows users to share Kedro micro-packages across codebases, organisations and beyond. A micro-package can be any part of Python code in a Kedro project including pipelines and utility functions.
 
 ## Package a micro-package

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -124,7 +124,7 @@ def micropkg_cli() -> None:  # pragma: no cover
 
 @micropkg_cli.group()
 def micropkg() -> None:
-    """Commands for working with micro-packages. DeprecationWarning: micropackaging is deprecated
+    """(DEPRECATED) Commands for working with micro-packages. DeprecationWarning: micro-packaging is deprecated
     and will not be available from Kedro 0.20.0."""
 
 

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -124,7 +124,8 @@ def micropkg_cli() -> None:  # pragma: no cover
 
 @micropkg_cli.group()
 def micropkg() -> None:
-    """Commands for working with micro-packages."""
+    """Commands for working with micro-packages. DeprecationWarning: micropackaging is deprecated
+    and will not be available from Kedro 0.20.0."""
 
 
 @command_with_verbosity(micropkg, "pull")
@@ -167,7 +168,13 @@ def pull_package(  # noqa: PLR0913
     all_flag: str,
     **kwargs: Any,
 ) -> None:
-    """Pull and unpack a modular pipeline and other micro-packages in your project."""
+    """(DEPRECATED) Pull and unpack a modular pipeline and other micro-packages in your project."""
+    deprecation_message = (
+        "DeprecationWarning: Command 'kedro micropkg pull' is deprecated and "
+        "will not be available from Kedro 0.20.0."
+    )
+    click.secho(deprecation_message, fg="red")
+
     if not package_path and not all_flag:
         click.secho(
             "Please specify a package path or add '--all' to pull all micro-packages in the "
@@ -341,7 +348,13 @@ def package_micropkg(  # noqa: PLR0913
     all_flag: str,
     **kwargs: Any,
 ) -> None:
-    """Package up a modular pipeline or micro-package as a Python source distribution."""
+    """(DEPRECATED) Package up a modular pipeline or micro-package as a Python source distribution."""
+    deprecation_message = (
+        "DeprecationWarning: Command 'kedro micropkg package' is deprecated and "
+        "will not be available from Kedro 0.20.0."
+    )
+    click.secho(deprecation_message, fg="red")
+
     if not module_path and not all_flag:
         click.secho(
             "Please specify a micro-package name or add '--all' to package all micro-packages in "


### PR DESCRIPTION
## Description
Closes #3854 

## Development notes

- Added deprecation notice to all `micropkg` CLI commands and at top-level when running `kedro`
- Added deprecation notice to `micropkg` docs + CLI docs
- Did not add a deprecation notice at import level of `kedro.framework.cli.micropkg`, since the only public method `safe_extract`: https://github.com/kedro-org/kedro/blob/main/kedro/framework/cli/micropkg.py#L393 is a utility method that doesn't contain any kedro specific info.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
