### PR TITLE
Move Nero to past maintainers

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -30,8 +30,6 @@ authors:
   given-names: Ravi Kumar
 - family-names: Nguyen
   given-names: Huong
-- family-names: Okwa
-  given-names: Nero
 - family-names: Cano Rodríguez
   given-names: Juan Luis
   orcid: https://orcid.org/0000-0002-2187-161X

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -66,7 +66,6 @@ We look for commitment markers who can do the following:
 | [Laura Couto](https://github.com/lrcouto)                | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Marcin Zabłocki](https://github.com/marrrcin)           | [Printify, Inc.](https://printify.com/)  |
 | [Merel Theisen](https://github.com/merelcht)             | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
-| [Nero Okwa](https://github.com/NeroOkwa)                 | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Nok Lam Chan](https://github.com/noklam)                | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Rashida Kanchwala](https://github.com/rashidakanchwala) | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Ravi Kumar Pilla](https://github.com/ravi-kumar-pilla)  | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
@@ -104,6 +103,7 @@ Former core team members with significant contributions include
 [Lorena Bălan](https://github.com/lorenabalan),
 [Mehdi Naderi Varandi](https://github.com/MehdiNV),
 [Nasef Khan](https://github.com/nakhan98),
+[Nero Okwa](https://github.com/NeroOkwa),
 [Richard Westenra](https://github.com/richardwestenra),
 [Susanna Wong](https://github.com/studioswong),
 [Vladimir Nikolic](https://github.com/vladimir-mck) and


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Nero is no longer working in the Kedro team at QB. He is more than welcome to keep contributing to the project, and stand for re-nomination to the TSC, as per https://docs.kedro.org/en/0.19.5/contribution/technical_steering_committee.html#requirements-to-become-a-maintainer

🗳️ This requires a vote from the TSC, please cast it by leaving an approval review on the PR 🗳️

## Development notes
<!-- What have you changed, and how has this been tested? -->
See https://github.com/kedro-org/kedro/issues/3793 for ongoing discussion about the current TSC process. This update does not try to amend any of that.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
