### PR TITLE
Lazy load commands from plugins

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -105,7 +105,7 @@ class KedroCLI(CommandCollection):
         super().__init__(
             ("Global commands", self.global_groups),
             ("Project specific commands", self.project_groups),
-            plugin_groups=self.plugin_groups,
+            plugin_entry_points=self.plugin_groups,
         )
 
     def main(

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -105,7 +105,7 @@ class KedroCLI(CommandCollection):
         super().__init__(
             ("Global commands", self.global_groups),
             ("Project specific commands", self.project_groups),
-            lazy_groups=list(self.lazy_global_groups) + list(self.lazy_project_groups),
+            plugin_groups=self.plugin_groups,
         )
 
     def main(
@@ -174,13 +174,8 @@ class KedroCLI(CommandCollection):
             sys.exit(exc.code)
 
     @property
-    def lazy_global_groups(self):
-        eps = _get_entry_points("global")
-        return eps
-
-    @property
-    def lazy_project_groups(self):
-        eps = _get_entry_points("project")
+    def plugin_groups(self):
+        eps = list(_get_entry_points("global")) + list(_get_entry_points("project"))
         return eps
 
     @property
@@ -211,8 +206,6 @@ class KedroCLI(CommandCollection):
             project_group,
             registry_cli,
         ]
-
-        # plugins = load_entry_points("project")
 
         try:
             project_cli = importlib.import_module(f"{self._metadata.package_name}.cli")

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import Any, Sequence
 
 import click
+from importlib_metadata import EntryPoint
 
 from kedro import __version__ as version
 from kedro.framework.cli import BRIGHT_BLACK, ORANGE
@@ -174,7 +175,7 @@ class KedroCLI(CommandCollection):
             sys.exit(exc.code)
 
     @property
-    def plugin_groups(self):
+    def plugin_groups(self) -> dict[str, EntryPoint]:
         eps = list(_get_entry_points("global")) + list(_get_entry_points("project"))
         entry_point_dict = {ep.name: ep for ep in eps}
         return entry_point_dict

--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -176,7 +176,8 @@ class KedroCLI(CommandCollection):
     @property
     def plugin_groups(self):
         eps = list(_get_entry_points("global")) + list(_get_entry_points("project"))
-        return eps
+        entry_point_dict = {ep.name: ep for ep in eps}
+        return entry_point_dict
 
     @property
     def global_groups(self) -> Sequence[click.MultiCommand]:

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -90,7 +90,7 @@ def forward_command(
     return wrapit
 
 
-def _partial_match(plugin_names: str, command_name: str):
+def _partial_match(plugin_names: list[str], command_name: str) -> str | None:
     for plugin_name in plugin_names:
         if command_name in plugin_name:
             return plugin_name
@@ -121,7 +121,7 @@ class CommandCollection(click.CommandCollection):
     def __init__(
         self,
         *groups: tuple[str, Sequence[click.MultiCommand]],
-        plugin_entry_points={},
+        plugin_entry_points: dict[str, importlib_metadata.EntryPoint] = {},
     ):
         self.groups = [
             (title, self._merge_same_name_collections(cli_list))
@@ -197,9 +197,9 @@ class CommandCollection(click.CommandCollection):
         complete_var: Any | None = None,
         standalone_mode: bool = True,
         **extra: Any,
-    ):
+    ) -> Any:
         # Load plugins if the command is not found in the current sources
-        if args is not None and args[0] not in self.list_commands(None):
+        if args and args[0] not in self.list_commands(None):
             self._load_plugins(args[0])
 
         return super().main(
@@ -218,11 +218,11 @@ class CommandCollection(click.CommandCollection):
             # Try to smartly load the plugin if there is partial match
             loaded_ep = _safe_load_entry_point(self.lazy_groups[part_match])
             self.add_source(loaded_ep)
-            if command_name in self.list_commands(None):
+            if command_name in self.list_commands(None):  # type: ignore[arg-type]
                 return
         # Load all plugins
         for ep in self.lazy_groups.values():
-            if command_name in self.list_commands(None):
+            if command_name in self.list_commands(None):  # type: ignore[arg-type]
                 return
             loaded_ep = _safe_load_entry_point(ep)
             self.add_source(loaded_ep)

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -112,13 +112,15 @@ class CommandCollection(click.CommandCollection):
     """Modified from the Click one to still run the source groups function."""
 
     def __init__(
-        self, *groups: tuple[str, Sequence[click.MultiCommand]], plugin_groups=None
+        self,
+        *groups: tuple[str, Sequence[click.MultiCommand]],
+        plugin_entry_points=[],
     ):
         self.groups = [
             (title, self._merge_same_name_collections(cli_list))
             for title, cli_list in groups
         ]
-        self.plugin_groups = plugin_groups
+        self.lazy_groups = plugin_entry_points
         sources = list(chain.from_iterable(cli_list for _, cli_list in self.groups))
         help_texts = [
             cli.help
@@ -190,8 +192,12 @@ class CommandCollection(click.CommandCollection):
         **extra: Any,
     ):
         i = 0
-        while args[0] not in self.list_commands(None) and i < len(self.plugin_groups):
-            loaded_ep = _safe_load_entry_point(self.plugin_groups[i])
+        while (
+            args
+            and i < len(self.lazy_groups)
+            and args[0] not in self.list_commands(None)
+        ):
+            loaded_ep = _safe_load_entry_point(self.lazy_groups[i])
             self.add_source(loaded_ep)
             i += 1
 

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -112,14 +112,13 @@ class CommandCollection(click.CommandCollection):
     """Modified from the Click one to still run the source groups function."""
 
     def __init__(
-        self, *groups: tuple[str, Sequence[click.MultiCommand]], lazy_groups=None
+        self, *groups: tuple[str, Sequence[click.MultiCommand]], plugin_groups=None
     ):
-        # print("GROUPS", groups)
         self.groups = [
             (title, self._merge_same_name_collections(cli_list))
             for title, cli_list in groups
         ]
-        self.lazy_group = lazy_groups
+        self.plugin_groups = plugin_groups
         sources = list(chain.from_iterable(cli_list for _, cli_list in self.groups))
         help_texts = [
             cli.help
@@ -184,15 +183,15 @@ class CommandCollection(click.CommandCollection):
 
     def main(
         self,
-        args,
-        prog_name,
-        complete_var,
-        standalone_mode,
-        **extra,
+        args: Any | None = None,
+        prog_name: Any | None = None,
+        complete_var: Any | None = None,
+        standalone_mode: bool = True,
+        **extra: Any,
     ):
         i = 0
-        while args[0] not in self.list_commands(None) and i < len(self.lazy_group):
-            loaded_ep = _safe_load_entry_point(self.lazy_group[i])
+        while args[0] not in self.list_commands(None) and i < len(self.plugin_groups):
+            loaded_ep = _safe_load_entry_point(self.plugin_groups[i])
             self.add_source(loaded_ep)
             i += 1
 

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -199,7 +199,7 @@ class CommandCollection(click.CommandCollection):
         **extra: Any,
     ) -> Any:
         # Load plugins if the command is not found in the current sources
-        if args and args[0] not in self.list_commands(None):
+        if args and args[0] not in self.list_commands(None):  # type: ignore[arg-type]
             self._load_plugins(args[0])
 
         return super().main(

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1,5 +1,4 @@
 from collections import namedtuple
-from itertools import cycle
 from os import rename
 from pathlib import Path
 
@@ -319,12 +318,7 @@ class TestKedroCLI:
         mocker.patch(
             "kedro.framework.cli.cli.bootstrap_project", return_value=fake_metadata
         )
-        mocker.patch(
-            "kedro.framework.cli.cli.importlib.import_module",
-            side_effect=cycle([ModuleNotFoundError()]),
-        )
         kedro_cli = KedroCLI(fake_metadata.project_path)
-        print(kedro_cli.project_groups)
         assert len(kedro_cli.project_groups) == 6
         assert kedro_cli.project_groups == [
             catalog_cli,
@@ -381,6 +375,8 @@ class TestKedroCLI:
         assert kedro_cli.global_groups == [cli, create_cli]
 
         result = CliRunner().invoke(kedro_cli, [])
+
+        print(result)
 
         assert result.exit_code == 0
         assert "Global commands from Kedro" in result.output


### PR DESCRIPTION
## Description
Partly resolve #1476 

As discussed in #1476, the initialisation of `KedroCLI` takes up a significant chunk of time. This is especially evident if you have a lot of kedro plugins installed in the environment as `KedroCLI` which is a `CommandCollection`, loads up all the commands from the plugins before the command is processed. This PR is to add a lazy way to load the commands from the plugins.

## Development notes

- Add a property called `plugin_groups` which returns a `dict` of `entry_point_name` to the `EntryPoint` object.
- This group is passed to the super class `CommandCollection` which is a custom version of `click.CommandCollection` used by Kedro and defined in `kedro/framework/cli/utils.py`

Update to custom `CommandCollection`:
- Add a new `main` function which receives the command to be run as `args`, eg `[ "catalog", "list"]` or `["airflow", "create"]`
- if the first element of the `args` is not in the command, then load commands from plugins
- run the command by passing to `super().main()`

Loading of plugins:

I tried to implement a sort of "smart" loading where if the command arg, i.e. `airflow` or `mlflow` or `viz` partially matches the entry point names in the `lazy_group` dict keys, load the plugin, check if the command now exists and exit.
Note: The entry point names are decided by the plugins, eg. `kedro-airflow`'s ep name is `airflow` which fully matches the command name too but for `kedro-viz` and `kedro-mlflow` the entry point names don't match the commands. eg. Command: `viz` Entry point name: `kedro-viz`


Otherwise, load all plugins one by one, exit if the command exists after loading plugins.

### TODO
- Fix code coverage on unit tests, which is tricky since this code is only used when a plugin is installed but we don't have tests like these in our unit tests. 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
