### PR TITLE
Update error message when catalog entry is invalid

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 
 ## Bug fixes and other changes
+* Updated error message for invalid catalog entries.
 
 ## Breaking changes to the API
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -156,8 +156,6 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             raise DatasetError(
                 f"An exception occurred when parsing config "
                 f"for dataset '{name}':\n{str(exc)}."
-                f"\nHint: If this catalog entry is intended for variable interpolation, "
-                f"make sure that the top level key is preceded by an underscore."
             ) from exc
 
         try:
@@ -386,7 +384,11 @@ def parse_dataset_definition(
     config = copy.deepcopy(config)
 
     if "type" not in config:
-        raise DatasetError("'type' is missing from dataset catalog configuration")
+        raise DatasetError(
+            "'type' is missing from dataset catalog configuration."
+            "\nHint: If this catalog entry is intended for variable interpolation, "
+            "make sure that the top level key is preceded by an underscore."
+        )
 
     dataset_type = config.pop("type")
     class_obj = None

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -155,7 +155,9 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         except Exception as exc:
             raise DatasetError(
                 f"An exception occurred when parsing config "
-                f"for dataset '{name}':\n{str(exc)}"
+                f"for dataset '{name}':\n{str(exc)}."
+                f"\nHint: If this catalog entry is intended for variable interpolation, "
+                f"make sure that the top level key is preceded by an underscore."
             ) from exc
 
         try:

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -291,7 +291,8 @@ class DataCatalog:
             if not isinstance(ds_config, dict):
                 raise DatasetError(
                     f"Catalog entry '{ds_name}' is not a valid dataset configuration. "
-                    "If this is a variable intended for interpolation, make sure it is preceded by an underscore."
+                    "\nHint: If this catalog entry is intended for variable interpolation, "
+                    "make sure that the key is preceded by an underscore."
                 )
 
             ds_config = _resolve_credentials(  # noqa: PLW2901

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -288,6 +288,12 @@ class DataCatalog:
         user_default = {}
 
         for ds_name, ds_config in catalog.items():
+            if not isinstance(ds_config, dict):
+                raise DatasetError(
+                    f"Catalog entry '{ds_name}' is not a valid dataset configuration. "
+                    "If this is a variable intended for interpolation, make sure it is preceded by an underscore."
+                )
+
             ds_config = _resolve_credentials(  # noqa: PLW2901
                 ds_config, credentials
             )

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -519,6 +519,15 @@ class TestDataCatalogFromConfig:
         with pytest.raises(DatasetError, match=pattern):
             DataCatalog.from_config(**sane_config)
 
+    def test_config_invalid_dataset_config(self, sane_config):
+        sane_config["catalog"]["invalid_entry"] = "some string"
+        pattern = (
+            r"Catalog entry 'invalid_entry' is not a valid dataset configuration. "
+            r"If this is a variable intended for interpolation, make sure it is preceded by an underscore."
+        )
+        with pytest.raises(DatasetError, match=pattern):
+            DataCatalog.from_config(**sane_config)
+
     def test_empty_config(self):
         """Test empty config"""
         assert DataCatalog.from_config(None)

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -522,8 +522,9 @@ class TestDataCatalogFromConfig:
     def test_config_invalid_dataset_config(self, sane_config):
         sane_config["catalog"]["invalid_entry"] = "some string"
         pattern = (
-            r"Catalog entry 'invalid_entry' is not a valid dataset configuration. "
-            r"If this is a variable intended for interpolation, make sure it is preceded by an underscore."
+            "Catalog entry 'invalid_entry' is not a valid dataset configuration. "
+            "\nHint: If this catalog entry is intended for variable interpolation, "
+            "make sure that the key is preceded by an underscore."
         )
         with pytest.raises(DatasetError, match=pattern):
             DataCatalog.from_config(**sane_config)


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro/issues/3910

## Development notes
<!-- What have you changed, and how has this been tested? -->
Add an error message if the catalog entry is not a dictionary - eg
```yaml
invalid_entry: whatever
```
Also, when the catalog entry is a dict but `type:` is missing.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
