### PR TITLE
Add deprecation warning to get_pkg_version

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,9 @@
 
 ## Breaking changes to the API
 
+## Upcoming deprecations for Kedro 0.20.0
+* The utility method `get_pkg_version()` is deprecated and will be removed in Kedro 0.20.0.
+
 ## Documentation changes
 
 ## Community contributions

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -11,6 +11,7 @@ import sys
 import textwrap
 import traceback
 import typing
+import warnings
 from collections import defaultdict
 from importlib import import_module
 from itertools import chain
@@ -20,6 +21,8 @@ from typing import IO, Any, Iterable, Sequence
 import click
 import importlib_metadata
 from omegaconf import OmegaConf
+
+from kedro import KedroDeprecationWarning
 
 CONTEXT_SETTINGS = {"help_option_names": ["-h", "--help"]}
 MAX_SUGGESTIONS = 3
@@ -218,6 +221,10 @@ def get_pkg_version(reqs_path: (str | Path), package_name: str) -> str:
         KedroCliError: If the file specified in ``reqs_path`` does not exist
             or ``package_name`` was not found in that file.
     """
+    warnings.warn(
+        "`get_pkg_version()` has been deprecated and will be removed in Kedro 0.20.0",
+        KedroDeprecationWarning,
+    )
     reqs_path = Path(reqs_path).absolute()
     if not reqs_path.is_file():
         raise KedroCliError(f"Given path '{reqs_path}' is not a regular file.")

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -6,8 +6,9 @@ from pathlib import Path
 import click
 from click.testing import CliRunner
 from omegaconf import OmegaConf
-from pytest import fixture, mark, raises
+from pytest import fixture, mark, raises, warns
 
+from kedro import KedroDeprecationWarning
 from kedro import __version__ as version
 from kedro.framework.cli import load_entry_points
 from kedro.framework.cli.catalog import catalog_cli
@@ -244,6 +245,13 @@ class TestCliUtils:
         with raises(KedroCliError):
             non_existent_file = str(requirements_file) + "-nonexistent"
             get_pkg_version(non_existent_file, "pandas")
+
+    def test_get_pkg_version_deprecated(self, requirements_file):
+        with warns(
+            KedroDeprecationWarning,
+            match=r"\`get_pkg_version\(\)\` has been deprecated",
+        ):
+            _ = get_pkg_version(requirements_file, "pandas")
 
     def test_clean_pycache(self, tmp_path, mocker):
         """Test `clean_pycache` utility function"""


### PR DESCRIPTION
## Description
Closes #3789 

## Development notes

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
