### PR TITLE
Fix catalog shallow copy changing class type

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -754,7 +754,7 @@ class DataCatalog:
             dataset_patterns = self._sort_patterns(unsorted_dataset_patterns)
         else:
             dataset_patterns = self._dataset_patterns
-        return DataCatalog(
+        return self.__class__(
             datasets=self._datasets,
             dataset_patterns=dataset_patterns,
             load_versions=self._load_versions,

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -426,10 +426,20 @@ class TestDataCatalog:
         ],
     )
     def test_bad_confirm(self, data_catalog, dataset_name, error_pattern):
-        """Test confirming a non existent dataset or one that
+        """Test confirming a non-existent dataset or one that
         does not have `confirm` method"""
         with pytest.raises(DatasetError, match=re.escape(error_pattern)):
             data_catalog.confirm(dataset_name)
+
+    def test_shallow_copy_returns_correct_class_type(
+        self,
+    ):
+        class MyDataCatalog(DataCatalog):
+            pass
+
+        data_catalog = MyDataCatalog()
+        copy = data_catalog.shallow_copy()
+        assert isinstance(copy, MyDataCatalog)
 
 
 class TestDataCatalogFromConfig:


### PR DESCRIPTION
## Description
Fixes #3857. Catalog `shallow_copy()` should use specified class type and not cast to `DataCatalog`. 

## Development notes
Initially I thought I needed to use `settings.DATA_CATALOG_CLASS` inside the `shallow_copy()` method, but that resulted in import contract errors enforced in https://github.com/kedro-org/kedro/blob/main/pyproject.toml#L175. Specifically:
```
----------------
Broken contracts
----------------

CLI > Context > Library, Runner > Extras > IO & Pipeline
--------------------------------------------------------

kedro.io is not allowed to import kedro.framework.project:

- kedro.io.data_catalog -> kedro.framework.project (l.17)


Pipeline and IO are independent
-------------------------------

kedro.io is not allowed to import kedro.pipeline:

- kedro.io.data_catalog -> kedro.framework.project (l.17)
  kedro.framework.project -> kedro.pipeline (l.23)
                             & kedro.pipeline.pipeline (l.23)

```

However, thinking about it a bit more I decided it's fine not to use `settings` here, because this is not about instantiating the datacatalog but copying it. It's already instantiated in the context: https://github.com/kedro-org/kedro/blob/main/kedro/framework/context/context.py#L231

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
