### PR TITLE
Add default for `env` in `KedroContext`

### DIFF
--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -167,12 +167,12 @@ class KedroContext:
 
     project_path: Path = field(init=True, converter=_expand_full_path)
     config_loader: AbstractConfigLoader = field(init=True)
-    _package_name: str = field(init=True)
-    _hook_manager: PluginManager = field(init=True)
+    env: str | None = field(init=True, default=None)
+    _package_name: str = field(init=True, default="")
+    _hook_manager: PluginManager | None = field(init=True, default=None)
     _extra_params: dict[str, Any] | None = field(
         init=True, default=None, converter=deepcopy
     )
-    env: str | None = field(init=True, default=None)
 
     @property
     def catalog(self) -> DataCatalog:

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -167,12 +167,12 @@ class KedroContext:
 
     project_path: Path = field(init=True, converter=_expand_full_path)
     config_loader: AbstractConfigLoader = field(init=True)
-    env: str | None = field(init=True)
     _package_name: str = field(init=True)
     _hook_manager: PluginManager = field(init=True)
     _extra_params: dict[str, Any] | None = field(
         init=True, default=None, converter=deepcopy
     )
+    env: str | None = field(init=True, default=None)
 
     @property
     def catalog(self) -> DataCatalog:


### PR DESCRIPTION
## Description
Fix #3954 

## Development notes
I checked the test with Kedro 0.18.14 and it was still working. The test breaks from 0.19 with this change - https://github.com/kedro-org/kedro/pull/3300

Add a default value `None` to `env`.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
