### PR TITLE
Bump doc requirements for successful build

### DIFF
--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/conf.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/conf.py
@@ -76,7 +76,7 @@ master_doc = "index"
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -14,16 +14,17 @@ dynamic = ["dependencies", "version"]
 
 [project.optional-dependencies]
 docs = [
-    "docutils<0.18.0",
-    "sphinx~=3.4.3",
-    "sphinx_rtd_theme==0.5.1",
+    "docutils<0.21",
+    "sphinx>=5.3,<7.3",
+     "sphinx_rtd_theme==2.0.0",
     "nbsphinx==0.8.1",
-    "sphinx-autodoc-typehints==1.11.1",
-    "sphinx_copybutton==0.3.1",
+    "sphinx-autodoc-typehints==1.20.2",
+    "sphinx_copybutton==0.5.2",
     "ipykernel>=5.3, <7.0",
-    "Jinja2<3.1.0",
-    "myst-parser~=0.17.2",
+    "Jinja2<3.2.0",
+    "myst-parser>=1.0,<2.1"
 ]
+
 
 [tool.setuptools.dynamic]
 dependencies = {file = "requirements.txt"}

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -197,15 +197,15 @@ def _assert_requirements_ok(
         expected = {
             "optional-dependencies": {
                 "docs": [
-                    "docutils<0.18.0",
-                    "sphinx~=3.4.3",
-                    "sphinx_rtd_theme==0.5.1",
+                    "docutils<0.21",
+                    "sphinx>=5.3,<7.3",
+                    "sphinx_rtd_theme==2.0.0",
                     "nbsphinx==0.8.1",
-                    "sphinx-autodoc-typehints==1.11.1",
-                    "sphinx_copybutton==0.3.1",
+                    "sphinx-autodoc-typehints==1.20.2",
+                    "sphinx_copybutton==0.5.2",
                     "ipykernel>=5.3, <7.0",
-                    "Jinja2<3.1.0",
-                    "myst-parser~=0.17.2",
+                    "Jinja2<3.2.0",
+                    "myst-parser>=1.0,<2.1",
                 ]
             }
         }


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro/issues/3774

## Development notes
Updated doc requirements to make sure docs in a new project can be built successfully. Same fix done on the starter side: https://github.com/kedro-org/kedro-starters/pull/226 The starters PR will need to be merged first to make the tests here pass.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
