### PR TITLE
Update docstring about default base/run environments in OCL

### DIFF
--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -95,10 +95,14 @@ class OmegaConfigLoader(AbstractConfigLoader):
             config_patterns: Regex patterns that specify the naming convention for configuration
                 files so they can be loaded. Can be customised by supplying config_patterns as
                 in `CONFIG_LOADER_ARGS` in `settings.py`.
-            base_env: Name of the base environment. Defaults to `"base"`.
+            base_env: Name of the base environment. When the ``OmegaConfigLoader`` is used directly
+                this defaults to `None`. Otherwise, the value will come from the `CONFIG_LOADER_ARGS` in the project
+                settings, where base_env defaults to `"base"`.
                 This is used in the `conf_paths` property method to construct
                 the configuration paths.
-            default_run_env: Name of the default run environment. Defaults to `"local"`.
+            default_run_env: Name of the default run environment. When the ``OmegaConfigLoader`` is used directly
+                this defaults to `None`. Otherwise, the value will come from the `CONFIG_LOADER_ARGS` in the project
+                settings, where base_env defaults to `"local"`.
                 Can be overridden by supplying the `env` argument.
             custom_resolvers: A dictionary of custom resolvers to be registered. For more information,
              see here: https://omegaconf.readthedocs.io/en/2.3_branch/custom_resolvers.html#custom-resolvers


### PR DESCRIPTION
## Description
The docstrings weren't updated when we did https://github.com/kedro-org/kedro/pull/3311, which confused a user.

## Development notes
Updated the docstrings for `base_env` and `default_run_env` arguments, describing the difference between using `OmegaConfigLoader` directly or through the framework.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
