### PR TITLE
`kedro-telemetry`: Improve performance by switching to after_command_run

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -5,6 +5,7 @@ This module implements commands available from the kedro CLI.
 from __future__ import annotations
 
 import importlib
+import logging
 import sys
 import traceback
 from collections import defaultdict
@@ -37,6 +38,8 @@ LOGO = rf"""
 |_|\_\___|\__,_|_|  \___/
 v{version}
 """
+
+logger = logging.getLogger(__name__)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS, name="Kedro")
@@ -199,6 +202,13 @@ class KedroCLI(CommandCollection):
                 click.echo(message)
                 click.echo(hint)
             sys.exit(exc.code)
+        except Exception as error:
+            logger.error(f"An error has occurred: {error}")
+            pass
+        finally:
+            self._cli_hook_manager.hook.after_command_run(
+                project_metadata=self._metadata, command_args=args, exit_code=0
+            )
 
     @property
     def global_groups(self) -> Sequence[click.MultiCommand]:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
