### PR TITLE
Add documentation for how plugin CLI commands can be made lazy loaded

### DIFF
--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -84,7 +84,7 @@ We use the following command convention: `kedro <plugin-name> <command>`, with `
 If you are developing a plugin with a large set of CLI commands or with certain large libraries that are slow to import but are used by a small subset of commands, consider using lazy loading of these commands. This can significantly improve the performance of the plugin as well as the overall performance of Kedro CLI. To do this, you can follow [the instructions on the
 `click` documentation on lazy loading of commands](https://click.palletsprojects.com/en/8.1.x/complex/#lazily-loading-subcommands). From Kedro 0.19.7, the [Kedro commands are declared as lazy loaded command groups](https://github.com/kedro-org/kedro/blob/main/kedro/framework/cli/cli.py) that you can use as a reference for the implementation.
 
-Consider the previous example of the `kedrojson` plugin. Suppose the plugin has two commands, `kedro to_json pipeline` and `kedro to_json node`. The `to_json pipeline` command is used more frequently than the `to_json node` command and the `to_json node` command requires a large library to be imported. In this case, you can define your commands to be lazily loaded with delayed imports as follows:
+Consider the previous example of the `kedrojson` plugin. Suppose the plugin has two commands, `kedro to_json pipelines` and `kedro to_json nodes`. The `to_json pipelines` command is used more frequently than the `to_json nodes` command and the `to_json nodes` command requires a large library to be imported. In this case, you can define your commands to be lazily loaded with delayed imports as follows:
 
 In `kedrojson/plugin.py`:
 ```python

--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -81,8 +81,8 @@ We use the following command convention: `kedro <plugin-name> <command>`, with `
 
 ## Advanced: Lazy loading of plugin commands
 
-If you are developing a plugin with a large set of CLI commands or with certain large libraries that are slow to import for only a small subset of commands, you can consider using lazy loading of these commands to improve the performance of the plugin as well as the overall performance of Kedro CLI. To do this, you can follow [the instructions on the
-`click` documentation on lazy loading of commands](https://click.palletsprojects.com/en/8.1.x/complex/#lazily-loading-subcommands). From Kedro 0.19.7, the [Kedro commands themselves are declared as lazy loaded command groups](https://github.com/kedro-org/kedro/blob/main/kedro/framework/cli/cli.py) that you can use as a reference for the implementation.
+If you are developing a plugin with a large set of CLI commands or with certain large libraries that are slow to import but are used by a small subset of commands, consider using lazy loading of these commands. This can significantly improve the performance of the plugin as well as the overall performance of Kedro CLI. To do this, you can follow [the instructions on the
+`click` documentation on lazy loading of commands](https://click.palletsprojects.com/en/8.1.x/complex/#lazily-loading-subcommands). From Kedro 0.19.7, the [Kedro commands are declared as lazy loaded command groups](https://github.com/kedro-org/kedro/blob/main/kedro/framework/cli/cli.py) that you can use as a reference for the implementation.
 
 Consider the previous example of the `kedrojson` plugin. Suppose the plugin has two commands, `kedro to_json pipeline` and `kedro to_json node`. The `to_json pipeline` command is used more frequently than the `to_json node` command and the `to_json node` command requires a large library to be imported. In this case, you can define your commands to be lazily loaded with delayed imports as follows:
 
@@ -118,7 +118,6 @@ def nodes():
 @click.command("pipelines")
 def pipelines():
     """Convert Kedro pipelines to JSON"""
-    import another_large_library
     print("Converting pipelines to JSON")
     ...
 ```


### PR DESCRIPTION
## Description
To go with the changes in #3883 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Added some documentation with an example of how plugin developers can make their CLI commands lazy loaded.

I extended the "simple plugin" example from the docs above but let me know if it doesn't make a 100% sense.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
