### PR TITLE
Replace `io` by `catalog` in docstrings of `DataCatalog`

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -203,7 +203,7 @@ class DataCatalog:
             >>> cars = CSVDataset(filepath="cars.csv",
             >>>                   load_args=None,
             >>>                   save_args={"index": False})
-            >>> io = DataCatalog(datasets={'cars': cars})
+            >>> catalog = DataCatalog(datasets={'cars': cars})
         """
         self._datasets = dict(datasets or {})
         self.datasets = _FrozenDatasets(self._datasets)
@@ -527,9 +527,9 @@ class DataCatalog:
             >>> cars = CSVDataset(filepath="cars.csv",
             >>>                   load_args=None,
             >>>                   save_args={"index": False})
-            >>> io = DataCatalog(datasets={'cars': cars})
+            >>> catalog = DataCatalog(datasets={'cars': cars})
             >>>
-            >>> df = io.load("cars")
+            >>> df = catalog.load("cars")
         """
         load_version = Version(version, None) if version else None
         dataset = self._get_dataset(name, version=load_version)
@@ -569,12 +569,12 @@ class DataCatalog:
             >>> cars = CSVDataset(filepath="cars.csv",
             >>>                   load_args=None,
             >>>                   save_args={"index": False})
-            >>> io = DataCatalog(datasets={'cars': cars})
+            >>> catalog = DataCatalog(datasets={'cars': cars})
             >>>
             >>> df = pd.DataFrame({'col1': [1, 2],
             >>>                    'col2': [4, 5],
             >>>                    'col3': [5, 6]})
-            >>> io.save("cars", df)
+            >>> catalog.save("cars", df)
         """
         dataset = self._get_dataset(name)
 
@@ -642,11 +642,11 @@ class DataCatalog:
 
             >>> from kedro_datasets.pandas import CSVDataset
             >>>
-            >>> io = DataCatalog(datasets={
+            >>> catalog = DataCatalog(datasets={
             >>>                   'cars': CSVDataset(filepath="cars.csv")
             >>>                  })
             >>>
-            >>> io.add("boats", CSVDataset(filepath="boats.csv"))
+            >>> catalog.add("boats", CSVDataset(filepath="boats.csv"))
         """
         if dataset_name in self._datasets:
             if replace:
@@ -678,7 +678,7 @@ class DataCatalog:
 
             >>> from kedro_datasets.pandas import CSVDataset, ParquetDataset
             >>>
-            >>> io = DataCatalog(datasets={
+            >>> catalog = DataCatalog(datasets={
             >>>                   "cars": CSVDataset(filepath="cars.csv")
             >>>                  })
             >>> additional = {
@@ -686,9 +686,9 @@ class DataCatalog:
             >>>     "boats": CSVDataset(filepath="boats.csv")
             >>> }
             >>>
-            >>> io.add_all(additional)
+            >>> catalog.add_all(additional)
             >>>
-            >>> assert io.list() == ["cars", "planes", "boats"]
+            >>> assert catalog.list() == ["cars", "planes", "boats"]
         """
         for name, dataset in datasets.items():
             self.add(name, dataset, replace)
@@ -756,13 +756,13 @@ class DataCatalog:
         Example:
         ::
 
-            >>> io = DataCatalog()
+            >>> catalog = DataCatalog()
             >>> # get data sets where the substring 'raw' is present
-            >>> raw_data = io.list(regex_search='raw')
+            >>> raw_data = catalog.list(regex_search='raw')
             >>> # get data sets which start with 'prm' or 'feat'
-            >>> feat_eng_data = io.list(regex_search='^(prm|feat)')
+            >>> feat_eng_data = catalog.list(regex_search='^(prm|feat)')
             >>> # get data sets which end with 'time_series'
-            >>> models = io.list(regex_search='.+time_series$')
+            >>> models = catalog.list(regex_search='.+time_series$')
         """
 
         if regex_search is None:


### PR DESCRIPTION
## Description
Closes #4033

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file - I guess no need?
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
