### PR TITLE
Catch error when `_describe()` is not implemented properly

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -258,6 +258,14 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         return f"{type(self).__name__}({_to_str(self._describe(), True)})"
 
     def _pretty_repr(self, object_description: dict[str, Any]) -> str:
+        if not isinstance(object_description, dict) or not all(
+            isinstance(key, str) for key in object_description.keys()
+        ):
+            self._logger.warning(
+                f"'{type(self).__module__}.{type(self).__name__}' is a subclass of AbstractDataset and it must "
+                f"implement the '_describe' method following the signature of AbstractDataset's '_describe'."
+            )
+            return f"{type(self).__module__}.{type(self).__name__}()"
         str_keys = []
         for arg_name, arg_descr in object_description.items():
             if arg_descr is not None:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -274,15 +274,16 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
 
     def __repr__(self) -> str:
         object_description = self._describe()
-        if not isinstance(object_description, dict) or not all(
-            isinstance(key, str) for key in object_description.keys()
+        if isinstance(object_description, dict) and all(
+            isinstance(key, str) for key in object_description
         ):
-            self._logger.warning(
-                f"'{type(self).__module__}.{type(self).__name__}' is a subclass of AbstractDataset and it must "
-                f"implement the '_describe' method following the signature of AbstractDataset's '_describe'."
-            )
-            return f"{type(self).__module__}.{type(self).__name__}()"
-        return self._pretty_repr(self._describe())
+            return self._pretty_repr(object_description)
+
+        self._logger.warning(
+            f"'{type(self).__module__}.{type(self).__name__}' is a subclass of AbstractDataset and it must "
+            f"implement the '_describe' method following the signature of AbstractDataset's '_describe'."
+        )
+        return f"{type(self).__module__}.{type(self).__name__}()"
 
     @abc.abstractmethod
     def _load(self) -> _DO:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -258,14 +258,6 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         return f"{type(self).__name__}({_to_str(self._describe(), True)})"
 
     def _pretty_repr(self, object_description: dict[str, Any]) -> str:
-        if not isinstance(object_description, dict) or not all(
-            isinstance(key, str) for key in object_description.keys()
-        ):
-            self._logger.warning(
-                f"'{type(self).__module__}.{type(self).__name__}' is a subclass of AbstractDataset and it must "
-                f"implement the '_describe' method following the signature of AbstractDataset's '_describe'."
-            )
-            return f"{type(self).__module__}.{type(self).__name__}()"
         str_keys = []
         for arg_name, arg_descr in object_description.items():
             if arg_descr is not None:
@@ -281,6 +273,15 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         return f"{type(self).__module__}.{type(self).__name__}({', '.join(str_keys)})"
 
     def __repr__(self) -> str:
+        object_description = self._describe()
+        if not isinstance(object_description, dict) or not all(
+            isinstance(key, str) for key in object_description.keys()
+        ):
+            self._logger.warning(
+                f"'{type(self).__module__}.{type(self).__name__}' is a subclass of AbstractDataset and it must "
+                f"implement the '_describe' method following the signature of AbstractDataset's '_describe'."
+            )
+            return f"{type(self).__module__}.{type(self).__name__}()"
         return self._pretty_repr(self._describe())
 
     @abc.abstractmethod

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import pprint
 import shutil
 from decimal import Decimal
@@ -222,6 +223,26 @@ class TestCoreFunctions:
             repr(MyDataset())
             == f"tests.io.test_core.MyDataset(filepath={filepath_str})"
         )
+
+    @pytest.mark.parametrize(
+        "describe_return",
+        [None, {"key_1": "val_1", 2: "val_2"}],
+    )
+    def test_repr_bad_describe(self, describe_return, caplog):
+        class BadDescribeDataset(MyDataset):
+            def _describe(self):
+                return describe_return
+
+        warning_message = (
+            "'tests.io.test_core.BadDescribeDataset' is a subclass of AbstractDataset and it must "
+            "implement the '_describe' method following the signature of AbstractDataset's '_describe'."
+        )
+
+        with caplog.at_level(logging.WARNING):
+            assert (
+                repr(BadDescribeDataset()) == "tests.io.test_core.BadDescribeDataset()"
+            )
+            assert warning_message in caplog.text
 
     def test_get_filepath_str(self):
         path = get_filepath_str(PurePosixPath("example.com/test.csv"), "http")


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4031

## Development notes
Implemented validation of describe output when calling it at `__repr__()`


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
