### PR TITLE
Apply Flake8 type checking and Ruff-specific rules

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -476,7 +476,7 @@ def autolink_classes_and_methods(lines):
             lines[i] = re.sub(existing, rf"{replacement}", lines[i])
 
 
-def autodoc_process_docstring(app, what, name, obj, options, lines):  # noqa: PLR0913
+def autodoc_process_docstring(app, what, name, obj, options, lines):
     try:
         # guarded method to make sure build never fails
         log_suggestions(lines, name)
@@ -486,7 +486,7 @@ def autodoc_process_docstring(app, what, name, obj, options, lines):  # noqa: PL
             style(
                 "Failed to check for class name mentions that can be "
                 f"converted to reStructuredText links in docstring of {name}. "
-                f"Error is: \n{str(e)}",
+                f"Error is: \n{e!s}",
                 fg="red",
             )
         )
@@ -515,7 +515,7 @@ except Exception as e:
         style(
             "Failed to create list of (regex, reStructuredText link "
             "replacement) for class names and method names in docstrings. "
-            f"Error is: \n{str(e)}",
+            f"Error is: \n{e!s}",
             fg="red",
         )
     )

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,5 +1,4 @@
 """Behave environment setup commands."""
-# noqa: unused-argument
 from __future__ import annotations
 
 import os
@@ -65,7 +64,7 @@ def _setup_context_with_venv(context, venv_dir):
     path = context.env["PATH"].split(os.pathsep)
     path = [p for p in path if not (Path(p).parent / "pyvenv.cfg").is_file()]
     path = [p for p in path if not (Path(p).parent / "conda-meta").is_dir()]
-    path = [str(bin_dir)] + path
+    path = [str(bin_dir), *path]
     context.env["PATH"] = os.pathsep.join(path)
 
     # Create an empty pip.conf file and point pip to it

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -342,7 +342,7 @@ def commit_changes_to_git(context):
 def exec_kedro_target(context, command):
     """Execute Kedro target."""
     split_command = command.split()
-    cmd = [context.kedro] + split_command
+    cmd = [context.kedro, *split_command]
     context.result = run(cmd, env=context.env, cwd=str(context.root_project_dir))
 
 
@@ -378,7 +378,7 @@ def get_kedro_version_python(context):
 def exec_notebook(context, command):
     """Execute Kedro Jupyter target."""
     split_command = command.split()
-    cmd = [context.kedro, "jupyter"] + split_command
+    cmd = [context.kedro, "jupyter", *split_command]
 
     # Jupyter notebook forks a child process from a parent process, and
     # only kills the parent process when it is terminated
@@ -706,7 +706,7 @@ def check_docs_generated(context: behave.runner.Context):
         context.root_project_dir / "docs" / "build" / "html" / "index.html"
     ).read_text("utf-8")
     project_repo = context.project_name.replace("-", "_")
-    assert f"Welcome to project {project_repo}’s API docs!" in index_html, index_html
+    assert f"Welcome to project {project_repo}'s API docs!" in index_html, index_html
 
 
 @then("requirements should be generated")

--- a/features/steps/sh_run.py
+++ b/features/steps/sh_run.py
@@ -90,7 +90,7 @@ class ChildTerminatingPopen(subprocess.Popen):
         """Terminate process and children."""
         try:
             proc = psutil.Process(self.pid)
-            procs = [proc] + proc.children(recursive=True)
+            procs = [proc, *proc.children(recursive=True)]
         except psutil.NoSuchProcess:
             pass
         else:

--- a/features/steps/util.py
+++ b/features/steps/util.py
@@ -5,9 +5,11 @@ from __future__ import annotations
 import os
 import re
 from contextlib import contextmanager
-from pathlib import Path
 from time import sleep, time
-from typing import Any, Callable, Iterator
+from typing import TYPE_CHECKING, Any, Callable, Iterator
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 @contextmanager

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -306,7 +306,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
         paths = []
         for pattern in patterns:
-            for each in self._fs.glob(Path(f"{str(conf_path)}/{pattern}").as_posix()):
+            for each in self._fs.glob(Path(f"{conf_path!s}/{pattern}").as_posix()):
                 if not self._is_hidden(each):
                     paths.append(Path(each))
 

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -296,7 +296,6 @@ class OmegaConfigLoader(AbstractConfigLoader):
             Resulting configuration dictionary.
 
         """
-        # noqa: too-many-locals
 
         if not self._fs.isdir(Path(conf_path).as_posix()):
             raise MissingConfigException(

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 import copy
 from collections import defaultdict
 from itertools import chain
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 import yaml
@@ -14,9 +13,13 @@ from click import secho
 from kedro.framework.cli.utils import KedroCliError, env_option, split_string
 from kedro.framework.project import pipelines, settings
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import ProjectMetadata
-from kedro.io import AbstractDataset
 from kedro.io.data_catalog import DataCatalog
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from kedro.framework.startup import ProjectMetadata
+    from kedro.io import AbstractDataset
 
 
 def _create_session(package_name: str, **kwargs: Any) -> KedroSession:

--- a/kedro/framework/cli/hooks/specs.py
+++ b/kedro/framework/cli/hooks/specs.py
@@ -4,9 +4,12 @@ For more information about these specifications, please visit
 """
 from __future__ import annotations
 
-from kedro.framework.startup import ProjectMetadata
+from typing import TYPE_CHECKING
 
 from .markers import cli_hook_spec
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
 
 
 class CLICommandSpecs:

--- a/kedro/framework/cli/jupyter.py
+++ b/kedro/framework/cli/jupyter.py
@@ -7,7 +7,7 @@ import json
 import os
 import shutil
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -19,7 +19,9 @@ from kedro.framework.cli.utils import (
     python_call,
 )
 from kedro.framework.project import validate_settings
-from kedro.framework.startup import ProjectMetadata
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
 
 
 @click.group(name="Kedro")
@@ -34,7 +36,7 @@ def jupyter() -> None:
 
 @forward_command(jupyter, "setup", forward_help=True)
 @click.pass_obj  # this will pass the metadata as first argument
-def setup(metadata: ProjectMetadata, /, args: Any, **kwargs: Any) -> None:  # noqa: unused-argument
+def setup(metadata: ProjectMetadata, /, args: Any, **kwargs: Any) -> None:
     """Initialise the Jupyter Kernel for a kedro project."""
     _check_module_importable("ipykernel")
     validate_settings()
@@ -53,7 +55,7 @@ def jupyter_notebook(
     env: str,
     args: Any,
     **kwargs: Any,
-) -> None:  # noqa: unused-argument
+) -> None:
     """Open Jupyter Notebook with project specific variables loaded."""
     _check_module_importable("notebook")
     validate_settings()
@@ -66,8 +68,11 @@ def jupyter_notebook(
 
     python_call(
         "jupyter",
-        ["notebook", f"--MultiKernelManager.default_kernel_name={kernel_name}"]
-        + list(args),
+        [
+            "notebook",
+            f"--MultiKernelManager.default_kernel_name={kernel_name}",
+            *list(args),
+        ],
     )
 
 
@@ -80,7 +85,7 @@ def jupyter_lab(
     env: str,
     args: Any,
     **kwargs: Any,
-) -> None:  # noqa: unused-argument
+) -> None:
     """Open Jupyter Lab with project specific variables loaded."""
     _check_module_importable("jupyterlab")
     validate_settings()
@@ -93,7 +98,7 @@ def jupyter_lab(
 
     python_call(
         "jupyter",
-        ["lab", f"--MultiKernelManager.default_kernel_name={kernel_name}"] + list(args),
+        ["lab", f"--MultiKernelManager.default_kernel_name={kernel_name}", *list(args)],
     )
 
 

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -11,10 +11,9 @@ import tempfile
 import toml
 from importlib import import_module
 from pathlib import Path
-from typing import Any, Iterable, Iterator
+from typing import Any, Iterable, Iterator, TYPE_CHECKING
 
 import click
-from importlib_metadata import PackageMetadata
 from omegaconf import OmegaConf
 from packaging.requirements import InvalidRequirement, Requirement
 from packaging.utils import canonicalize_name
@@ -38,7 +37,10 @@ from kedro.framework.cli.utils import (
     env_option,
     python_call,
 )
-from kedro.framework.startup import ProjectMetadata
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
+    from importlib_metadata import PackageMetadata
 
 _PYPROJECT_TOML_TEMPLATE = """
 [build-system]
@@ -107,7 +109,7 @@ class _EquivalentRequirement(Requirement):
         )
 
 
-def _check_module_path(ctx: click.core.Context, param: Any, value: str) -> str:  # noqa: unused-argument
+def _check_module_path(ctx: click.core.Context, param: Any, value: str) -> str:
     if value and not re.match(r"^[\w.]+$", value):
         message = (
             "The micro-package location you provided is not a valid Python module path"
@@ -116,7 +118,6 @@ def _check_module_path(ctx: click.core.Context, param: Any, value: str) -> str: 
     return value
 
 
-# noqa: missing-function-docstring
 @click.group(name="Kedro")
 def micropkg_cli() -> None:  # pragma: no cover
     pass
@@ -379,7 +380,6 @@ def package_micropkg(  # noqa: PLR0913
 
 
 def _get_fsspec_filesystem(location: str, fs_args: str | None) -> Any:
-    # noqa: import-outside-toplevel
     import fsspec
 
     from kedro.io.core import get_protocol_and_path
@@ -389,7 +389,7 @@ def _get_fsspec_filesystem(location: str, fs_args: str | None) -> Any:
 
     try:
         return fsspec.filesystem(protocol, **fs_args_config)
-    except Exception as exc:  # noqa: broad-except
+    except Exception as exc:
         # Specified protocol is not supported by `fsspec`
         # or requires extra dependencies
         click.secho(str(exc), fg="red")
@@ -408,7 +408,6 @@ def safe_extract(tar: tarfile.TarFile, path: Path) -> None:
     for member in tar.getmembers():
         member_path = path / member.name
         if not _is_within_directory(path, member_path):
-            # noqa: broad-exception-raised
             raise Exception("Failed to safely extract tar file.")
         safe_members.append(member)
     tar.extractall(path, members=safe_members)  # nosec B202

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -5,7 +5,7 @@ import re
 import shutil
 from pathlib import Path
 from textwrap import indent
-from typing import Any, NamedTuple
+from typing import TYPE_CHECKING, Any, NamedTuple
 
 import click
 
@@ -17,7 +17,9 @@ from kedro.framework.cli.utils import (
     env_option,
 )
 from kedro.framework.project import settings
-from kedro.framework.startup import ProjectMetadata
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
 
 _SETUP_PY_TEMPLATE = """# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
@@ -65,7 +67,7 @@ def _assert_pkg_name_ok(pkg_name: str) -> None:
         raise KedroCliError(message)
 
 
-def _check_pipeline_name(ctx: click.Context, param: Any, value: str) -> str:  # noqa: unused-argument
+def _check_pipeline_name(ctx: click.Context, param: Any, value: str) -> str:
     if value:
         _assert_pkg_name_ok(value)
     return value
@@ -105,7 +107,7 @@ def create_pipeline(
     skip_config: bool,
     env: str,
     **kwargs: Any,
-) -> None:  # noqa: unused-argument
+) -> None:
     """Create a new modular pipeline by providing a name."""
     package_dir = metadata.source_dir / metadata.package_name
     project_root = metadata.project_path / metadata.project_name
@@ -148,7 +150,7 @@ def create_pipeline(
 @click.pass_obj  # this will pass the metadata as first argument
 def delete_pipeline(
     metadata: ProjectMetadata, /, name: str, env: str, yes: bool, **kwargs: Any
-) -> None:  # noqa: unused-argument
+) -> None:
     """Delete a modular pipeline by providing a name."""
     package_dir = metadata.source_dir / metadata.package_name
     conf_source = settings.CONF_SOURCE

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
 
@@ -21,8 +21,10 @@ from kedro.framework.cli.utils import (
 )
 from kedro.framework.project import settings
 from kedro.framework.session import KedroSession
-from kedro.framework.startup import ProjectMetadata
 from kedro.utils import load_obj
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
 
 NO_DEPENDENCY_MESSAGE = """{module} is not installed. Please make sure {module} is in
 requirements.txt and run 'pip install -r requirements.txt'."""
@@ -69,13 +71,13 @@ def project_group() -> None:  # pragma: no cover
 @forward_command(project_group, forward_help=True)
 @env_option
 @click.pass_obj  # this will pass the metadata as first argument
-def ipython(metadata: ProjectMetadata, /, env: str, args: Any, **kwargs: Any) -> None:  # noqa: unused-argument
+def ipython(metadata: ProjectMetadata, /, env: str, args: Any, **kwargs: Any) -> None:
     """Open IPython with project specific variables loaded."""
     _check_module_importable("IPython")
 
     if env:
         os.environ["KEDRO_ENV"] = env
-    call(["ipython", "--ext", "kedro.ipython"] + list(args))
+    call(["ipython", "--ext", "kedro.ipython", *list(args)])
 
 
 @project_group.command()

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -12,16 +12,14 @@ import shutil
 import stat
 import sys
 import tempfile
-from collections import OrderedDict
 from itertools import groupby
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import click
 import requests
 import yaml
 from attrs import define, field
-from importlib_metadata import EntryPoints
 from packaging.version import parse
 
 import kedro
@@ -34,6 +32,11 @@ from kedro.framework.cli.utils import (
     _safe_load_entry_point,
     command_with_verbosity,
 )
+
+if TYPE_CHECKING:
+    from collections import OrderedDict
+
+    from importlib_metadata import EntryPoints
 
 TOOLS_ARG_HELP = """
 Select which tools you'd like to include. By default, none are included.\n
@@ -226,7 +229,7 @@ def _parse_yes_no_to_bool(value: str) -> Any:
 
 
 def _validate_selected_tools(selected_tools: str | None) -> None:
-    valid_tools = list(TOOLS_SHORTNAME_TO_NUMBER) + ["all", "none"]
+    valid_tools = [*list(TOOLS_SHORTNAME_TO_NUMBER), "all", "none"]
 
     if selected_tools is not None:
         tools = re.sub(r"\s", "", selected_tools).split(",")
@@ -973,7 +976,7 @@ def _create_project(
 class _Prompt:
     """Represent a single CLI prompt for `kedro new`"""
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: unused-argument
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         try:
             self.title = kwargs["title"]
         except KeyError as exc:
@@ -988,7 +991,7 @@ class _Prompt:
     def __str__(self) -> str:
         title = self.title.strip().title()
         title = click.style(title + "\n" + "=" * len(title), bold=True)
-        prompt_lines = [title] + [self.text]
+        prompt_lines = [title, self.text]
         prompt_text = "\n".join(str(line).strip() for line in prompt_lines)
         return f"\n{prompt_text}\n"
 
@@ -1002,7 +1005,6 @@ class _Prompt:
             sys.exit(1)
 
 
-# noqa: unused-argument
 def _remove_readonly(
     func: Callable, path: Path, excinfo: tuple
 ) -> None:  # pragma: no cover

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -63,7 +63,7 @@ def python_call(
     module: str, arguments: Iterable[str], **kwargs: Any
 ) -> None:  # pragma: no cover
     """Run a subprocess command that invokes a Python module."""
-    call([sys.executable, "-m", module] + list(arguments), **kwargs)
+    call([sys.executable, "-m", module, *list(arguments)], **kwargs)
 
 
 def find_stylesheets() -> Iterable[str]:  # pragma: no cover

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -4,18 +4,21 @@ from __future__ import annotations
 import logging
 from copy import deepcopy
 from pathlib import Path, PurePosixPath, PureWindowsPath
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from warnings import warn
 
 from attrs import define, field
 from omegaconf import OmegaConf
-from pluggy import PluginManager
 
 from kedro.config import AbstractConfigLoader, MissingConfigException
 from kedro.framework.project import settings
-from kedro.io import DataCatalog
 from kedro.pipeline.transcoding import _transcode_split
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+    from kedro.io import DataCatalog
 
 
 def _is_relative_path(path_string: str) -> bool:
@@ -197,7 +200,7 @@ class KedroContext:
         try:
             params = self.config_loader["parameters"]
         except MissingConfigException as exc:
-            warn(f"Parameters not found in your Kedro project config.\n{str(exc)}")
+            warn(f"Parameters not found in your Kedro project config.\n{exc!s}")
             params = {}
 
         if self._extra_params:

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -13,12 +13,11 @@ from omegaconf import OmegaConf
 
 from kedro.config import AbstractConfigLoader, MissingConfigException
 from kedro.framework.project import settings
+from kedro.io import DataCatalog  # noqa: TCH001
 from kedro.pipeline.transcoding import _transcode_split
 
 if TYPE_CHECKING:
     from pluggy import PluginManager
-
-    from kedro.io import DataCatalog
 
 
 def _is_relative_path(path_string: str) -> bool:

--- a/kedro/framework/context/context.py
+++ b/kedro/framework/context/context.py
@@ -127,13 +127,13 @@ def _validate_transcoded_datasets(catalog: DataCatalog) -> None:
     """Validates transcoded datasets are correctly named
 
     Args:
-        catalog (DataCatalog): The catalog object containing the
-        datasets to be validated.
+        catalog: The catalog object containing the datasets to be
+            validated.
 
     Raises:
         ValueError: If a dataset name does not conform to the expected
-        transcoding naming conventions,a ValueError is raised by the
-        `_transcode_split` function.
+            transcoding naming conventions,a ValueError is raised by the
+            `_transcode_split` function.
 
     """
     for dataset_name in catalog._datasets.keys():

--- a/kedro/framework/hooks/specs.py
+++ b/kedro/framework/hooks/specs.py
@@ -4,14 +4,15 @@ For more information about these specifications, please visit
 """
 from __future__ import annotations
 
-from typing import Any
-
-from kedro.framework.context import KedroContext
-from kedro.io import DataCatalog
-from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node
+from typing import TYPE_CHECKING, Any
 
 from .markers import hook_spec
+
+if TYPE_CHECKING:
+    from kedro.framework.context import KedroContext
+    from kedro.io import DataCatalog
+    from kedro.pipeline import Pipeline
+    from kedro.pipeline.node import Node
 
 
 class DataCatalogSpecs:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -7,12 +7,11 @@ import logging.config
 import operator
 import os
 import traceback
-import types
 import warnings
 from collections import UserDict
 from collections.abc import MutableMapping
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import dynaconf
 import importlib_resources
@@ -21,6 +20,9 @@ from dynaconf import LazySettings
 from dynaconf.validator import ValidationError, Validator
 
 from kedro.pipeline import Pipeline, pipeline
+
+if TYPE_CHECKING:
+    import types
 
 IMPORT_ERROR_MESSAGE = (
     "An error occurred while importing the '{module}' module. Nothing "
@@ -238,7 +240,7 @@ class _ProjectLogging(UserDict):
             # Fallback to the framework default loggings
             path = default_logging_path
 
-        msg = f"Using '{str(path)}' as logging configuration. " + msg
+        msg = f"Using '{path!s}' as logging configuration. " + msg
 
         # Load and apply the logging configuration
         logging_config = Path(path).read_text(encoding="utf-8")

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -103,7 +103,7 @@ class _ProjectSettings(LazySettings):
     )
     _SESSION_STORE_CLASS = _IsSubclassValidator(
         "SESSION_STORE_CLASS",
-        default=_get_default_class("kedro.framework.session.session.BaseSessionStore"),
+        default=_get_default_class("kedro.framework.session.store.BaseSessionStore"),
     )
     _SESSION_STORE_ARGS = Validator("SESSION_STORE_ARGS", default={})
     _DISABLE_HOOKS_FOR_PLUGINS = Validator("DISABLE_HOOKS_FOR_PLUGINS", default=tuple())

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -10,13 +10,11 @@ import sys
 import traceback
 from copy import deepcopy
 from pathlib import Path
-from typing import Any, Iterable
+from typing import TYPE_CHECKING, Any, Iterable
 
 import click
 
 from kedro import __version__ as kedro_version
-from kedro.config import AbstractConfigLoader
-from kedro.framework.context import KedroContext
 from kedro.framework.hooks import _create_hook_manager
 from kedro.framework.hooks.manager import _register_hooks, _register_hooks_entry_points
 from kedro.framework.project import (
@@ -24,10 +22,14 @@ from kedro.framework.project import (
     settings,
     validate_settings,
 )
-from kedro.framework.session.store import BaseSessionStore
 from kedro.io.core import generate_timestamp
 from kedro.runner import AbstractRunner, SequentialRunner
 from kedro.utils import _find_kedro_project
+
+if TYPE_CHECKING:
+    from kedro.config import AbstractConfigLoader
+    from kedro.framework.context import KedroContext
+    from kedro.framework.session.store import BaseSessionStore
 
 
 def _describe_git(project_path: Path) -> dict[str, dict[str, Any]]:

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -104,7 +104,7 @@ def _get_project_metadata(project_path: Path) -> ProjectMetadata:
     try:
         return ProjectMetadata(**metadata_dict)
     except TypeError as exc:
-        expected_keys = mandatory_keys + ["source_dir", "tools", "example_pipeline"]
+        expected_keys = [*mandatory_keys, "source_dir", "tools", "example_pipeline"]
         raise RuntimeError(
             f"Found unexpected keys in '{_PYPROJECT}'. Make sure "
             f"it only contains the following keys: {expected_keys}."
@@ -142,7 +142,7 @@ def _add_src_to_path(source_dir: Path, project_path: Path) -> None:
     python_path = os.getenv("PYTHONPATH", "")
     if str(source_dir) not in python_path:
         sep = os.pathsep if python_path else ""
-        os.environ["PYTHONPATH"] = f"{str(source_dir)}{sep}{python_path}"
+        os.environ["PYTHONPATH"] = f"{source_dir!s}{sep}{python_path}"
 
 
 def bootstrap_project(project_path: str | Path) -> ProjectMetadata:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import abc
 import copy
 import logging
-import os
 import pprint
 import re
 import sys
@@ -17,13 +16,16 @@ from functools import partial
 from glob import iglob
 from operator import attrgetter
 from pathlib import Path, PurePath, PurePosixPath
-from typing import Any, Callable, Generic, TypeVar
+from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 from urllib.parse import urlsplit
 
 from cachetools import Cache, cachedmethod
 from cachetools.keys import hashkey
 
 from kedro.utils import load_obj
+
+if TYPE_CHECKING:
+    import os
 
 VERSION_FORMAT = "%Y-%m-%dT%H.%M.%S.%fZ"
 VERSIONED_FLAG_KEY = "versioned"
@@ -157,7 +159,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         except Exception as exc:
             raise DatasetError(
                 f"An exception occurred when parsing config "
-                f"for dataset '{name}':\n{str(exc)}"
+                f"for dataset '{name}':\n{exc!s}"
             ) from exc
 
         try:
@@ -198,9 +200,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         except Exception as exc:
             # This exception handling is by design as the composed data sets
             # can throw any type of exception.
-            message = (
-                f"Failed while loading data from data set {str(self)}.\n{str(exc)}"
-            )
+            message = f"Failed while loading data from data set {self!s}.\n{exc!s}"
             raise DatasetError(message) from exc
 
     def save(self, data: _DI) -> None:
@@ -226,7 +226,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         except (FileNotFoundError, NotADirectoryError):
             raise
         except Exception as exc:
-            message = f"Failed while saving data to data set {str(self)}.\n{str(exc)}"
+            message = f"Failed while saving data to data set {self!s}.\n{exc!s}"
             raise DatasetError(message) from exc
 
     def __str__(self) -> str:
@@ -311,9 +311,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             self._logger.debug("Checking whether target of %s exists", str(self))
             return self._exists()
         except Exception as exc:
-            message = (
-                f"Failed during exists check for data set {str(self)}.\n{str(exc)}"
-            )
+            message = f"Failed during exists check for data set {self!s}.\n{exc!s}"
             raise DatasetError(message) from exc
 
     def _exists(self) -> bool:
@@ -334,7 +332,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             self._logger.debug("Releasing %s", str(self))
             self._release()
         except Exception as exc:
-            message = f"Failed during release for data set {str(self)}.\n{str(exc)}"
+            message = f"Failed during release for data set {self!s}.\n{exc!s}"
             raise DatasetError(message) from exc
 
     def _release(self) -> None:
@@ -643,7 +641,7 @@ class AbstractVersionedDataset(AbstractDataset[_DI, _DO], abc.ABC):
 
         if self._exists_function(str(versioned_path)):
             raise DatasetError(
-                f"Save path '{versioned_path}' for {str(self)} must not exist if "
+                f"Save path '{versioned_path}' for {self!s} must not exist if "
                 f"versioning is enabled."
             )
 
@@ -698,9 +696,7 @@ class AbstractVersionedDataset(AbstractDataset[_DI, _DO], abc.ABC):
         except VersionNotFoundError:
             return False
         except Exception as exc:  # SKIP_IF_NO_SPARK
-            message = (
-                f"Failed during exists check for data set {str(self)}.\n{str(exc)}"
-            )
+            message = f"Failed during exists check for data set {self!s}.\n{exc!s}"
             raise DatasetError(message) from exc
 
     def _release(self) -> None:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -225,9 +225,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             except Exception as exc:
                 # This exception handling is by design as the composed data sets
                 # can throw any type of exception.
-                message = (
-                    f"Failed while loading data from data set {str(self)}.\n{str(exc)}"
-                )
+                message = f"Failed while loading data from data set {self!s}.\n{exc!s}"
                 raise DatasetError(message) from exc
 
         load.__annotations__["return"] = load_func.__annotations__.get("return")
@@ -251,9 +249,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             except (DatasetError, FileNotFoundError, NotADirectoryError):
                 raise
             except Exception as exc:
-                message = (
-                    f"Failed while saving data to data set {str(self)}.\n{str(exc)}"
-                )
+                message = f"Failed while saving data to data set {self!s}.\n{exc!s}"
                 raise DatasetError(message) from exc
 
         save.__annotations__["data"] = save_func.__annotations__.get("data", Any)

--- a/kedro/io/shared_memory_dataset.py
+++ b/kedro/io/shared_memory_dataset.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import pickle
-from multiprocessing.managers import SyncManager
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from kedro.io.core import AbstractDataset, DatasetError
+
+if TYPE_CHECKING:
+    from multiprocessing.managers import SyncManager
 
 
 class SharedMemoryDataset(AbstractDataset):
@@ -47,7 +49,7 @@ class SharedMemoryDataset(AbstractDataset):
                 pickle.dumps(data)
             except Exception as serialisation_exc:  # SKIP_IF_NO_SPARK
                 raise DatasetError(
-                    f"{str(data.__class__)} cannot be serialised. ParallelRunner "
+                    f"{data.__class__!s} cannot be serialised. ParallelRunner "
                     "implicit memory datasets can only be used with serialisable data"
                 ) from serialisation_exc
             raise exc  # pragma: no cover

--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -3,12 +3,14 @@ from __future__ import annotations
 
 import copy
 import difflib
-from typing import AbstractSet, Iterable
+from typing import TYPE_CHECKING, AbstractSet, Iterable
 
-from kedro.pipeline.node import Node
 from kedro.pipeline.pipeline import Pipeline
 
 from .transcoding import TRANSCODING_SEPARATOR, _strip_transcoding, _transcode_split
+
+if TYPE_CHECKING:
+    from kedro.pipeline.node import Node
 
 
 class ModularPipelineError(Exception):

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -205,8 +205,8 @@ class Node:
 
     def __repr__(self) -> str:  # pragma: no cover
         return (
-            f"Node({self._func_name}, {repr(self._inputs)}, {repr(self._outputs)}, "
-            f"{repr(self._name)})"
+            f"Node({self._func_name}, {self._inputs!r}, {self._outputs!r}, "
+            f"{self._name!r})"
         )
 
     def __call__(self, **kwargs: Any) -> dict[str, Any]:
@@ -396,7 +396,7 @@ class Node:
     def _run_with_no_inputs(self, inputs: dict[str, Any]) -> Any:
         if inputs:
             raise ValueError(
-                f"Node {str(self)} expected no inputs, "
+                f"Node {self!s} expected no inputs, "
                 f"but got the following {len(inputs)} input(s) instead: "
                 f"{sorted(inputs.keys())}."
             )
@@ -406,7 +406,7 @@ class Node:
     def _run_with_one_input(self, inputs: dict[str, Any], node_input: str) -> Any:
         if len(inputs) != 1 or node_input not in inputs:
             raise ValueError(
-                f"Node {str(self)} expected one input named '{node_input}', "
+                f"Node {self!s} expected one input named '{node_input}', "
                 f"but got the following {len(inputs)} input(s) instead: "
                 f"{sorted(inputs.keys())}."
             )
@@ -417,7 +417,7 @@ class Node:
         # Node inputs and provided run inputs should completely overlap
         if set(node_inputs) != set(inputs.keys()):
             raise ValueError(
-                f"Node {str(self)} expected {len(node_inputs)} input(s) {node_inputs}, "
+                f"Node {self!s} expected {len(node_inputs)} input(s) {node_inputs}, "
                 f"but got the following {len(inputs)} input(s) instead: "
                 f"{sorted(inputs.keys())}."
             )
@@ -430,7 +430,7 @@ class Node:
         # Node inputs and provided run inputs should completely overlap
         if set(node_inputs.values()) != set(inputs.keys()):
             raise ValueError(
-                f"Node {str(self)} expected {len(set(node_inputs.values()))} input(s) "
+                f"Node {self!s} expected {len(set(node_inputs.values()))} input(s) "
                 f"{sorted(set(node_inputs.values()))}, "
                 f"but got the following {len(inputs)} input(s) instead: "
                 f"{sorted(inputs.keys())}."
@@ -457,7 +457,7 @@ class Node:
                 )
             if set(keys) != set(result.keys()):
                 raise ValueError(
-                    f"Failed to save outputs of node {str(self)}.\n"
+                    f"Failed to save outputs of node {self!s}.\n"
                     f"The node's output keys {set(result.keys())} "
                     f"do not match with the returned output's keys {set(keys)}."
                 )
@@ -477,14 +477,14 @@ class Node:
 
             if not isinstance(result, (list, tuple)):
                 raise ValueError(
-                    f"Failed to save outputs of node {str(self)}.\n"
+                    f"Failed to save outputs of node {self!s}.\n"
                     f"The node definition contains a list of "
                     f"outputs {self._outputs}, whereas the node function "
                     f"returned a '{type(result).__name__}'."
                 )
             if len(result) != len(self._outputs):
                 raise ValueError(
-                    f"Failed to save outputs of node {str(self)}.\n"
+                    f"Failed to save outputs of node {self!s}.\n"
                     f"The node function returned {len(result)} output(s), "
                     f"whereas the node definition contains {len(self._outputs)} "
                     f"output(s)."

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -25,13 +25,13 @@ def __getattr__(name: str) -> Any:
         from kedro.pipeline.transcoding import TRANSCODING_SEPARATOR
 
         warnings.warn(
-            f"{repr(name)} has been moved to 'kedro.pipeline.transcoding', "
+            f"{name!r} has been moved to 'kedro.pipeline.transcoding', "
             f"and the alias will be removed in Kedro 0.20.0",
             kedro.KedroDeprecationWarning,
             stacklevel=2,
         )
         return TRANSCODING_SEPARATOR
-    raise AttributeError(f"module {repr(__name__)} has no attribute {repr(name)}")
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
 
 class OutputNotUniqueError(Exception):

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -12,9 +12,7 @@ from itertools import chain
 from multiprocessing.managers import BaseProxy, SyncManager
 from multiprocessing.reduction import ForkingPickler
 from pickle import PicklingError
-from typing import Any, Iterable
-
-from pluggy import PluginManager
+from typing import TYPE_CHECKING, Any, Iterable
 
 from kedro.framework.hooks.manager import (
     _create_hook_manager,
@@ -28,9 +26,13 @@ from kedro.io import (
     MemoryDataset,
     SharedMemoryDataset,
 )
-from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node
 from kedro.runner.runner import AbstractRunner, run_node
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+    from kedro.pipeline import Pipeline
+    from kedro.pipeline.node import Node
 
 # see https://github.com/python/cpython/blob/master/Lib/concurrent/futures/process.py#L114
 _MAX_WINDOWS_WORKERS = 61

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -15,15 +15,18 @@ from concurrent.futures import (
     as_completed,
     wait,
 )
-from typing import Any, Collection, Iterable, Iterator
+from typing import TYPE_CHECKING, Any, Collection, Iterable, Iterator
 
 from more_itertools import interleave
-from pluggy import PluginManager
 
 from kedro.framework.hooks.manager import _NullPluginManager
 from kedro.io import DataCatalog, MemoryDataset
 from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+    from kedro.pipeline.node import Node
 
 
 class AbstractRunner(ABC):
@@ -404,7 +407,7 @@ def run_node(
             f"Async data loading and saving does not work with "
             f"nodes wrapping generator functions. Please make "
             f"sure you don't use `yield` anywhere "
-            f"in node {str(node)}."
+            f"in node {node!s}."
         )
 
     if is_async:

--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -6,13 +6,15 @@ from __future__ import annotations
 
 from collections import Counter
 from itertools import chain
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pluggy import PluginManager
-
-from kedro.io import DataCatalog
-from kedro.pipeline import Pipeline
 from kedro.runner.runner import AbstractRunner, run_node
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+    from kedro.io import DataCatalog
+    from kedro.pipeline import Pipeline
 
 
 class SequentialRunner(AbstractRunner):

--- a/kedro/runner/thread_runner.py
+++ b/kedro/runner/thread_runner.py
@@ -8,14 +8,16 @@ import warnings
 from collections import Counter
 from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from itertools import chain
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-from pluggy import PluginManager
-
-from kedro.io import DataCatalog
-from kedro.pipeline import Pipeline
-from kedro.pipeline.node import Node
 from kedro.runner.runner import AbstractRunner, run_node
+
+if TYPE_CHECKING:
+    from pluggy import PluginManager
+
+    from kedro.io import DataCatalog
+    from kedro.pipeline import Pipeline
+    from kedro.pipeline.node import Node
 
 
 class ThreadRunner(AbstractRunner):

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -41,12 +41,12 @@ def _is_project(project_path: Union[str, Path]) -> bool:
 
     try:
         return "[tool.kedro]" in metadata_file.read_text(encoding="utf-8")
-    except Exception:  # noqa: broad-except
+    except Exception:
         return False
 
 
 def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
-    paths_to_check = [current_dir] + list(current_dir.parents)
+    paths_to_check = [current_dir, *list(current_dir.parents)]
     for parent_dir in paths_to_check:
         if _is_project(parent_dir):
             return parent_dir

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,14 +214,16 @@ ignore_imports = [
 line-length = 88
 show-fixes = true
 select = [
-    "F",   # Pyflakes
-    "W",   # pycodestyle
-    "E",   # pycodestyle
-    "I",   # isort
-    "UP",  # pyupgrade
-    "PL",  # Pylint
+    "F",    # Pyflakes
+    "W",    # pycodestyle
+    "E",    # pycodestyle
+    "I",    # isort
+    "UP",   # pyupgrade
+    "PL",   # Pylint
     "T201", # Print Statement
-    "S", # flake8-bandit
+    "S",    # flake8-bandit
+    "TCH",  # flake8-type-checking
+    "RUF",  # Ruff-specific rules
 ]
 ignore = ["E501"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ omit = [
     "kedro/runner/parallel_runner.py",
     "*/site-packages/*",
 ]
-exclude_lines = ["pragma: no cover", "raise NotImplementedError"]
+exclude_also = ["raise NotImplementedError", "if TYPE_CHECKING:"]
 
 [tool.pytest.ini_options]
 addopts="""

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -655,7 +655,7 @@ class TestOmegaConfigLoader:
                 "--exclude=local/*.yml",
                 "-czf",
                 f"{tmp_path}/tar_conf.tar.gz",
-                f"--directory={str(tmp_path.parent)}",
+                f"--directory={tmp_path.parent!s}",
                 f"{tmp_path.name}",
             ]
         )

--- a/tests/framework/cli/conftest.py
+++ b/tests/framework/cli/conftest.py
@@ -132,7 +132,7 @@ def fake_project_cli(
     # It's safe to remove the new entries from path due to the python
     # module caching mechanism. Any `reload` on it will not work though.
     old_path = sys.path.copy()
-    sys.path = [str(fake_repo_path / "src")] + sys.path
+    sys.path = [str(fake_repo_path / "src"), *sys.path]
 
     import_module(PACKAGE_NAME)
     configure_project(PACKAGE_NAME)

--- a/tests/framework/cli/micropkg/test_micropkg_package.py
+++ b/tests/framework/cli/micropkg/test_micropkg_package.py
@@ -64,7 +64,7 @@ class TestMicropkgPackageCommand:
         assert result.exit_code == 0
         result = CliRunner().invoke(
             fake_project_cli,
-            ["micropkg", "package", f"pipelines.{PIPELINE_NAME}"] + options,
+            ["micropkg", "package", f"pipelines.{PIPELINE_NAME}", *options],
             obj=fake_metadata,
         )
 

--- a/tests/framework/cli/test_cli_hooks.py
+++ b/tests/framework/cli/test_cli_hooks.py
@@ -2,13 +2,16 @@ from __future__ import annotations
 
 import logging
 from collections import namedtuple
+from typing import TYPE_CHECKING
 
 import pytest
 from click.testing import CliRunner
 
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.cli.hooks import cli_hook_impl, get_cli_hook_manager, manager
-from kedro.framework.startup import ProjectMetadata
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
 
 logger = logging.getLogger(__name__)
 

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -221,7 +221,6 @@ def _assert_requirements_ok(
         )
 
 
-# noqa: PLR0913
 def _assert_template_ok(
     result,
     tools="none",

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import logging
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
-from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pandas as pd
 import pytest
@@ -13,7 +12,6 @@ import yaml
 from dynaconf.validator import Validator
 
 from kedro import __version__ as kedro_version
-from kedro.framework.context.context import KedroContext
 from kedro.framework.hooks import hook_impl
 from kedro.framework.project import (
     _ProjectPipelines,
@@ -21,10 +19,15 @@ from kedro.framework.project import (
     configure_project,
 )
 from kedro.framework.session import KedroSession
-from kedro.io import DataCatalog
-from kedro.pipeline import Pipeline
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 from kedro.pipeline.node import Node, node
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from kedro.framework.context.context import KedroContext
+    from kedro.io import DataCatalog
+    from kedro.pipeline import Pipeline
 
 logger = logging.getLogger(__name__)
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -16,6 +16,7 @@ from omegaconf import OmegaConf
 from kedro import __version__ as kedro_version
 from kedro.config import AbstractConfigLoader, OmegaConfigLoader
 from kedro.framework.cli.utils import _split_params
+from kedro.framework.context import KedroContext
 from kedro.framework.project import (
     LOGGING,
     ValidationError,
@@ -25,7 +26,7 @@ from kedro.framework.project import (
     _ProjectSettings,
 )
 from kedro.framework.session import KedroSession
-from kedro.framework.session.session import KedroContext, KedroSessionError
+from kedro.framework.session.session import KedroSessionError
 from kedro.framework.session.shelvestore import ShelveStore
 from kedro.framework.session.store import BaseSessionStore
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -90,9 +90,7 @@ def mock_runner(mocker):
 def mock_context_class(mocker):
     mock_cls = create_attrs_autospec(KedroContext)
     return mocker.patch(
-        "kedro.framework.session.session.KedroContext",
-        autospec=True,
-        return_value=mock_cls,
+        "kedro.framework.context.KedroContext", autospec=True, return_value=mock_cls
     )
 
 

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -2,7 +2,7 @@ import logging
 import multiprocessing
 import re
 import time
-from typing import Any
+from typing import Any, Optional
 
 import pandas as pd
 import pytest
@@ -548,7 +548,7 @@ def sample_node_multiple_outputs():
 
 
 class LogCatalog(DataCatalog):
-    def load(self, name: str, version: str = None) -> Any:
+    def load(self, name: str, version: Optional[str] = None) -> Any:
         dataset = super().load(name=name, version=version)
         logger.info("Catalog load")
         return dataset

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -65,7 +65,7 @@ class MyDataset(AbstractDataset):
 
 
 class MyVersionedDataset(AbstractVersionedDataset[str, str]):
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         filepath: str,
         version: Version = None,
@@ -109,7 +109,7 @@ class MyVersionedDataset(AbstractVersionedDataset[str, str]):
 
 
 class MyLocalVersionedDataset(AbstractVersionedDataset[str, str]):
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         filepath: str,
         version: Version = None,
@@ -205,7 +205,7 @@ def dummy_data():
 
 
 class TestCoreFunctions:
-    @pytest.mark.parametrize("var", [1, True] + FALSE_BUILTINS)
+    @pytest.mark.parametrize("var", [1, True, *FALSE_BUILTINS])
     def test_str_representation(self, var):
         var_str = pprint.pformat(var)
         filepath_str = pprint.pformat(PurePosixPath("."))
@@ -271,7 +271,7 @@ class TestCoreFunctions:
         "input", [{"key1": "invalid value"}, {"key2": "invalid;value"}]
     )
     def test_validate_forbidden_chars(self, input):
-        key = list(input.keys())[0]
+        key = next(iter(input.keys()))
         expected_error_message = (
             f"Neither white-space nor semicolon are allowed in '{key}'."
         )

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -484,7 +484,7 @@ class MyLegacyDataset(AbstractDataset):
 
 
 class MyLegacyVersionedDataset(AbstractVersionedDataset[str, str]):
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         filepath: str,
         version: Version = None,

--- a/tests/ipython/conftest.py
+++ b/tests/ipython/conftest.py
@@ -10,7 +10,7 @@ from kedro.ipython import (
 from kedro.pipeline import node
 from kedro.pipeline.modular_pipeline import pipeline as modular_pipeline
 
-from . import dummy_function_fixtures  # noqa It is needed for the inspect module
+from . import dummy_function_fixtures  # It is needed for the inspect module
 from .dummy_function_fixtures import (
     dummy_function,
     dummy_function_with_loop,

--- a/tests/pipeline/test_modular_pipeline.py
+++ b/tests/pipeline/test_modular_pipeline.py
@@ -219,7 +219,7 @@ class TestPipelineHelper:
     )
     def test_missing_dataset_name_no_suggestion(
         self, func, inputs, outputs, inputs_map, outputs_map, expected_missing
-    ):  # noqa: PLR0913
+    ):
         raw_pipeline = modular_pipeline([node(func, inputs, outputs)])
 
         with pytest.raises(

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -147,7 +147,7 @@ def pipeline_with_dicts():
             node(triconcat, ["H", "I", "M"], "N", name="node1"),
             node(identity, "H", "I", name="node2"),
             node(identity, "F", {"M": "M", "N": "G"}, name="node3"),
-            node(identity, "E", {"O": "F", "P": "H"}, name="node4"),  # NOQA
+            node(identity, "E", {"O": "F", "P": "H"}, name="node4"),
             node(identity, {"input1": "D"}, None, name="node5"),
             node(identity, "C", "D", name="node6", tags=["foo"]),
             node(identity, "B", {"P": "C", "Q": "E"}, name="node7", tags=["foo"]),
@@ -160,7 +160,7 @@ def pipeline_with_dicts():
             {node(identity, "B", {"P": "C", "Q": "E"}, name="node7", tags=["foo"])},
             {
                 node(identity, "C", "D", name="node6", tags=["foo"]),
-                node(identity, "E", {"O": "F", "P": "H"}, name="node4"),  # NOQA
+                node(identity, "E", {"O": "F", "P": "H"}, name="node4"),
             },
             {
                 node(identity, {"input1": "D"}, None, name="node5"),

--- a/tests/runner/conftest.py
+++ b/tests/runner/conftest.py
@@ -278,17 +278,17 @@ def two_branches_crossed_pipeline_variable_inputs(request):
 
     return pipeline(
         [
-            node(first_arg, ["ds0_A"] + extra_inputs, "_ds1_A", name="node1_A"),
-            node(first_arg, ["ds0_B"] + extra_inputs, "_ds1_B", name="node1_B"),
+            node(first_arg, ["ds0_A", *extra_inputs], "_ds1_A", name="node1_A"),
+            node(first_arg, ["ds0_B", *extra_inputs], "_ds1_B", name="node1_B"),
             node(
                 multi_input_list_output,
-                ["_ds1_A", "_ds1_B"] + extra_inputs,
+                ["_ds1_A", "_ds1_B", *extra_inputs],
                 ["ds2_A", "ds2_B"],
                 name="node2",
             ),
-            node(first_arg, ["ds2_A"] + extra_inputs, "_ds3_A", name="node3_A"),
-            node(first_arg, ["ds2_B"] + extra_inputs, "_ds3_B", name="node3_B"),
-            node(first_arg, ["_ds3_A"] + extra_inputs, "_ds4_A", name="node4_A"),
-            node(first_arg, ["_ds3_B"] + extra_inputs, "_ds4_B", name="node4_B"),
+            node(first_arg, ["ds2_A", *extra_inputs], "_ds3_A", name="node3_A"),
+            node(first_arg, ["ds2_B", *extra_inputs], "_ds3_B", name="node3_B"),
+            node(first_arg, ["_ds3_A", *extra_inputs], "_ds4_A", name="node4_A"),
+            node(first_arg, ["_ds3_B", *extra_inputs], "_ds4_B", name="node4_B"),
         ]
     )

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -102,7 +102,7 @@ class TestMaxWorkers:
         cpu_cores,
         user_specified_number,
         expected_number,
-    ):  # noqa: PLR0913
+    ):
         """
         The system has 2 cores, but we initialize the runner with max_workers=4.
         `fan_out_fan_in` pipeline needs 3 processes.
@@ -198,7 +198,7 @@ class TestInvalidParallelRunner:
         pipeline = modular_pipeline([node(return_not_serialisable, "A", "B")])
         catalog.add_feed_dict(feed_dict={"A": 42})
         pattern = (
-            rf"{str(data.__class__)} cannot be serialised. ParallelRunner implicit "
+            rf"{data.__class__!s} cannot be serialised. ParallelRunner implicit "
             rf"memory datasets can only be used with serialisable data"
         )
 

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -313,7 +313,6 @@ class TestParallelRunnerRelease:
                 node(sink, "dataset", None, name="fred"),
             ]
         )
-        # noqa: no-member
         catalog = DataCatalog(
             {"dataset": runner._manager.LoggingDataset(log, "dataset")}
         )

--- a/tests/runner/test_thread_runner.py
+++ b/tests/runner/test_thread_runner.py
@@ -56,7 +56,7 @@ class TestMaxWorkers:
         catalog,
         user_specified_number,
         expected_number,
-    ):  # noqa: PLR0913
+    ):
         """
         We initialize the runner with max_workers=4.
         `fan_out_fan_in` pipeline needs 3 threads.


### PR DESCRIPTION
## Description
Motivated by the fact that I saw extraneous imports (only necessary for type checking) at the top level, while I was trying to see what was getting imported by the CLI.

## Development notes
When I went to apply TCH-003, I found other violations, so may as well fix them by enabling a few more rules.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
