### PR TITLE
Update telemetry docs for opt-out model

### DIFF
--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -36,7 +36,7 @@ For technical information on how the telemetry collection works, you can browse
 To withdraw consent, you have a few options:
 
 1. **Set Environment Variables**:
-   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of these environment variables will disable telemetry for all Kedro projects in that environment and will override any consent specified in the `.telemetry` file of the specific project.
+   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of any of these environment variables will disable telemetry for all Kedro projects in that environment and will override any consent specified in the `.telemetry` file of the specific project.
 
 2. **CLI Option When Creating a New Project**:
    When creating a new project, you can use the command:
@@ -48,13 +48,13 @@ To withdraw consent, you have a few options:
 
    >*Note:* The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
 
-3. **Modify or Create the .telemetry File**:
+3. **Modify or Create the `.telemetry` file manually**:
    If the `.telemetry` file exists in the root folder of your Kedro project, set the `consent` variable to `false`. If the file does not exist, create it with the following content:
      ```yaml
      consent: false
      ```
 
-4. **Uninstall the Plugin**:
+4. **Uninstall the plugin**:
    Remove the `kedro-telemetry` plugin:
 
    ```console

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -42,9 +42,9 @@ To withdraw consent, you have a few options:
    When creating a new project, you can use the command:
 
    ```console
-   kedro new --telemetry=yes/no
+   kedro new --telemetry=no
    ```
-   This will create a new project with a `.telemetry` file in its root folder, containing `consent: true/false` accordingly. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
+   This will create a new project with a `.telemetry` file in its root folder, containing `consent: false`. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
 
    >*Note:* The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
 
@@ -60,3 +60,4 @@ To withdraw consent, you have a few options:
    ```console
    pip uninstall kedro-telemetry
    ```
+   >*Note:* This is a last resort option, as it will break the dependencies of Kedro (for example, `pip check` will report issues).

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -5,13 +5,13 @@ Kedro can capture anonymised telemetry.
 This data is collected with the sole purpose of improving Kedro by understanding feature usage.
 Importantly, we do not store personal information about you or sensitive data from your project,
 and this process is never utilized for marketing or promotional purposes.
-Participation in this program is optional, and Kedro will continue working as normal if you opt-out.
+Participation in this program is optional, and it is enabled by default. Kedro will continue working as normal if you opt-out.
 
 The Kedro Project's telemetry has been reviewed and approved under the
 [Telemetry Data Collection and Usage Policy] of LF Projects, LLC.
 
-Kedro collects anonymous telemetry through [the Kedro-Telemetry plugin],
-which will prompt you for your consent the first time.
+Kedro collects anonymous telemetry through [the Kedro-Telemetry plugin], 
+which is installed as one of Kedro’s dependencies.
 
 [the Kedro-Telemetry plugin]: https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry
 [Telemetry Data Collection and Usage Policy]: https://lfprojects.org/policies/telemetry-data-policy/
@@ -31,38 +31,35 @@ which will prompt you for your consent the first time.
 For technical information on how the telemetry collection works, you can browse
 [the source code of `kedro-telemetry`](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry).
 
-## How do I consent to the use of Kedro-Telemetry?
-
-Kedro-Telemetry is a Python plugin. To install it:
-
-```console
-pip install kedro-telemetry
-```
-
-```{note}
-If you are using an official [Kedro project template](/starters/starters) then `kedro-telemetry` is included in the [project-level `requirements.txt`](/kedro_project_setup/dependencies) of the starter. `kedro-telemetry` is activated after you have a created a new project with a [Kedro project template](/starters/starters) and have run `kedro install` from the terminal.
-```
-
-When you next run the Kedro CLI you will be asked for consent to share usage analytics data for the purposes explained in the privacy notice, and a `.telemetry` YAML file will be created in the project root directory. The variable `consent` will be set according to your choice in the file, e.g. if you consent:
-
-```yaml
-consent: true
-```
-
-```{note}
-The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
-```
-
 ## How do I withdraw consent?
 
-To withdraw consent, you can change the `consent` variable to `false` in `.telemetry` YAML by editing the file in the following way:
+To withdraw consent, you have a few options:
 
-```yaml
-consent: false
-```
+1. **Set Environment Variables**:
+   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of these environment variables will disable telemetry for all Kedro projects in that environment.
 
-Or you can uninstall the plugin:
+2. **CLI Option When Creating a New Project**:
+   When creating a new project, you can use the command:
 
-```console
-pip uninstall kedro-telemetry
-```
+   ```console
+   kedro new --telemetry=yes/no
+   ```
+   This will create a `.telemetry` file inside the new project's folder with `consent: true/false` accordingly. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
+
+3. **Modify or Create the `.telemetry` File**:
+   - If a `.telemetry` file already exists in the root folder of your Kedro project, change the `consent` variable to `false`:
+
+     ```yaml
+     consent: false
+     ```
+   - If the `.telemetry` file does not exist, create it with the following content:
+     ```yaml
+     consent: false
+     ```
+
+4. **Uninstall the Plugin**:
+   Remove the `kedro-telemetry` plugin:
+
+   ```console
+   pip uninstall kedro-telemetry
+   ```

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -36,7 +36,7 @@ For technical information on how the telemetry collection works, you can browse
 To withdraw consent, you have a few options:
 
 1. **Set Environment Variables**:
-   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of these environment variables will disable telemetry for all Kedro projects in that environment.
+   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of these environment variables will disable telemetry for all Kedro projects in that environment and will override any consent specified in the `.telemetry` file of the specific project.
 
 2. **CLI Option When Creating a New Project**:
    When creating a new project, you can use the command:
@@ -44,7 +44,7 @@ To withdraw consent, you have a few options:
    ```console
    kedro new --telemetry=yes/no
    ```
-   This will create a `.telemetry` file inside the new project's folder with `consent: true/false` accordingly. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
+   This will create a new project with a `.telemetry` file in its root folder, containing `consent: true/false` accordingly. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
 
    >*Note:* The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
 

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -10,7 +10,7 @@ Participation in this program is optional, and it is enabled by default. Kedro w
 The Kedro Project's telemetry has been reviewed and approved under the
 [Telemetry Data Collection and Usage Policy] of LF Projects, LLC.
 
-Kedro collects anonymous telemetry through [the Kedro-Telemetry plugin], 
+Kedro collects anonymous telemetry through [the Kedro-Telemetry plugin],
 which is installed as one of Kedro’s dependencies.
 
 [the Kedro-Telemetry plugin]: https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -46,13 +46,10 @@ To withdraw consent, you have a few options:
    ```
    This will create a `.telemetry` file inside the new project's folder with `consent: true/false` accordingly. This file will be used when executing Kedro commands within that project folder. Note that telemetry data about the execution of the `kedro new` command will still be sent if telemetry has not been disabled using environment variables.
 
-3. **Modify or Create the `.telemetry` File**:
-   - If a `.telemetry` file already exists in the root folder of your Kedro project, change the `consent` variable to `false`:
+   >*Note:* The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
 
-     ```yaml
-     consent: false
-     ```
-   - If the `.telemetry` file does not exist, create it with the following content:
+3. **Modify or Create the `.telemetry` File**:
+   If the `.telemetry` file exists in the root folder of your Kedro project, set the `consent` variable to `false`. If the file does not exist, create it with the following content:
      ```yaml
      consent: false
      ```

--- a/docs/source/configuration/telemetry.md
+++ b/docs/source/configuration/telemetry.md
@@ -48,7 +48,7 @@ To withdraw consent, you have a few options:
 
    >*Note:* The `.telemetry` file should not be committed to `git` or packaged in deployment. In `kedro>=0.17.4` the file is git-ignored.
 
-3. **Modify or Create the `.telemetry` File**:
+3. **Modify or Create the .telemetry File**:
    If the `.telemetry` file exists in the root folder of your Kedro project, set the `consent` variable to `false`. If the file does not exist, create it with the following content:
      ```yaml
      consent: false


### PR DESCRIPTION
## Description

Update the telemetry section of the Kedro documentation following the transition to an opt-out model for telemetry.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
