### PR TITLE
Drop `_load` and `_save` in core datasets and docs

### DIFF
--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -103,7 +103,7 @@ class CachedDataset(AbstractDataset):
         }
         return self._pretty_repr(object_description)
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         data = self._cache.load() if self._cache.exists() else self._dataset.load()
 
         if not self._cache.exists():
@@ -111,7 +111,7 @@ class CachedDataset(AbstractDataset):
 
         return data
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         self._dataset.save(data)
         self._cache.save(data)
 

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -59,7 +59,7 @@ class MemoryDataset(AbstractDataset):
         if data is not _EMPTY:
             self.save.__wrapped__(self, data)  # type: ignore[attr-defined]
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         if self._data is _EMPTY:
             raise DatasetError("Data for MemoryDataset has not been saved yet.")
 
@@ -67,7 +67,7 @@ class MemoryDataset(AbstractDataset):
         data = _copy_with_mode(self._data, copy_mode=copy_mode)
         return data
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         copy_mode = self._copy_mode or _infer_copy_mode(data)
         self._data = _copy_with_mode(data, copy_mode=copy_mode)
 

--- a/kedro/io/shared_memory_dataset.py
+++ b/kedro/io/shared_memory_dataset.py
@@ -36,10 +36,10 @@ class SharedMemoryDataset(AbstractDataset):
             raise AttributeError()
         return getattr(self.shared_memory_dataset, name)  # pragma: no cover
 
-    def _load(self) -> Any:
+    def load(self) -> Any:
         return self.shared_memory_dataset.load()
 
-    def _save(self, data: Any) -> None:
+    def save(self, data: Any) -> None:
         """Calls save method of a shared MemoryDataset in SyncManager."""
         try:
             self.shared_memory_dataset.save(data)


### PR DESCRIPTION
## Description
Take advantage of the ability to define `load` and `save` publicly in Kedro core (separate PR for Kedro-Datasets upcoming), and provide guidance to users to do the same.

There's no new core functionality introduced here.

## Development notes
I removed this from the initial https://github.com/kedro-org/kedro/pull/3920, due to [potentially breaking changes for Kedro-MLflow users](https://github.com/kedro-org/kedro/pull/3920#issuecomment-2251387537). Now, https://github.com/Galileo-Galilei/kedro-mlflow/pull/590 has been merged (I had created this PR months ago, as you can see, but had been slow on unblocking Kedro-MLflow), so there is a clear path forward for Kedro-MLflow.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
