### PR TITLE
Don't pick up failing `sphinx-notfound-page` 1.0.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,12 +81,13 @@ test = [
     "types-PyYAML",
     "types-cachetools",
     "types-requests",
-    "types-toml"
+    "types-toml",
 ]
 docs = [
-    "kedro-sphinx-theme==2024.4.0",
     "ipykernel>=5.3, <7.0",
     "Jinja2<3.2.0",
+    "kedro-sphinx-theme==2024.4.0",
+    "sphinx-notfound-page!=1.0.3",  # Required by kedro-sphinx-theme. 1.0.3 results in `AttributeError: 'tuple' object has no attribute 'default'`.
 ]
 jupyter = [
     "ipylab>=1.0.0",
@@ -208,7 +209,7 @@ forbidden_modules = [
 ]
 ignore_imports = [
     "kedro.framework.context.context -> kedro.config",
-    "kedro.framework.session.session -> kedro.config"
+    "kedro.framework.session.session -> kedro.config",
 ]
 
 [tool.ruff]


### PR DESCRIPTION
## Description
ReadTheDocs build is currently failing with:

```python
Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/kedro/envs/4046/lib/python3.9/site-packages/sphinx/events.py", line 97, in emit
    results.append(listener.handler(self.app, *args))
  File "/home/docs/checkouts/readthedocs.org/user_builds/kedro/envs/4046/lib/python3.9/site-packages/notfound/extension.py", line 274, in validate_configs
    app.config.values.get("notfound_urls_prefix").default
AttributeError: 'tuple' object has no attribute 'default'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/docs/checkouts/readthedocs.org/user_builds/kedro/envs/4046/lib/python3.9/site-packages/sphinx/cmd/build.py", line 293, in build_main
    app = Sphinx(args.sourcedir, args.confdir, args.outputdir,
  File "/home/docs/checkouts/readthedocs.org/user_builds/kedro/envs/4046/lib/python3.9/site-packages/sphinx/application.py", line 257, in __init__
    self.events.emit('config-inited', self.config)
  File "/home/docs/checkouts/readthedocs.org/user_builds/kedro/envs/4046/lib/python3.9/site-packages/sphinx/events.py", line 108, in emit
    raise ExtensionError(__("Handler %r for event %r threw an exception") %
sphinx.errors.ExtensionError: Handler <function validate_configs at 0x7f64496a9310> for event 'config-inited' threw an exception (exception: 'tuple' object has no attribute 'default')

Extension error (notfound.extension):
Handler <function validate_configs at 0x7f64496a9310> for event 'config-inited' threw an exception (exception: 'tuple' object has no attribute 'default')
```

## Development notes
This should possibly be updated in `kedro-sphinx-theme`; however, this is a faster path to getting the docs build working in the interim.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
