### PR TITLE
Revert inconsistent changes from `_meth` to `meth`

### DIFF
--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -49,7 +49,7 @@ class LambdaDataset(AbstractDataset):
 
         return descr
 
-    def load(self) -> Any:
+    def _load(self) -> Any:
         if not self.__load:
             raise DatasetError(
                 "Cannot load data set. No 'load' function "
@@ -57,7 +57,7 @@ class LambdaDataset(AbstractDataset):
             )
         return self.__load()
 
-    def save(self, data: Any) -> None:
+    def _save(self, data: Any) -> None:
         if not self.__save:
             raise DatasetError(
                 "Cannot save to data set. No 'save' function "


### PR DESCRIPTION
## Description
Change `load` and `save` back to `_load` and `_save`, respectively, in the `LambdaDataset` implementation.

## Development notes
When #3920 was merged, the explicit changes from `_load` to `load` and `_save` to `save` were reverted, so as to not break Kedro-MLFlow immediately (relies on internal Kedro implementation details). It seems it was missed for `LambdaDataset`. It's a very niche case/likely won't get hit, but it should be consistent.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
