### PR TITLE
Fix cli starters tests

### DIFF
--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -825,9 +825,11 @@ class TestNewWithStarterValid:
         )
         kwargs = {
             "template": "git+https://github.com/kedro-org/kedro-starters.git",
-            "checkout": version,
             "directory": "spaceflights-pandas",
         }
+        starters_version = mock_determine_repo_dir.call_args[1].pop("checkout", None)
+
+        assert starters_version in [version, "main"]
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
 

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -855,11 +855,14 @@ class TestNewWithStarterValid:
             ["new", "--starter", "git+https://github.com/fake/fake.git"],
             input=_make_cli_prompt_input(),
         )
+
         kwargs = {
             "template": "git+https://github.com/fake/fake.git",
-            "checkout": version,
             "directory": None,
         }
+        starters_version = mock_determine_repo_dir.call_args[1].pop("checkout", None)
+
+        assert starters_version in [version, "main"]
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         del kwargs["directory"]
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -904,11 +904,14 @@ class TestNewWithStarterValid:
             ],
             input=_make_cli_prompt_input(),
         )
+
         kwargs = {
             "template": "git+https://github.com/fake/fake.git",
-            "checkout": version,
             "directory": "my_directory",
         }
+        starters_version = mock_determine_repo_dir.call_args[1].pop("checkout", None)
+
+        assert starters_version in [version, "main"]
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
 


### PR DESCRIPTION
## Description
After merging these changes https://github.com/kedro-org/kedro/pull/3900 we use `main` starters branch when the framework and starters versions do not match. This happens for example during the framework release: https://github.com/kedro-org/kedro/pull/4050

This PR includes fixes for unit tests allowing the starters version (checkout) to be either equal to the framework version or `main`.

## Development notes
Test - https://github.com/kedro-org/kedro/pull/4053


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
