### PR TITLE
Fix broken tests after making telemetry a dependency

### DIFF
--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -484,7 +484,11 @@ def add_req(context: behave.runner.Context, dependency: str):
 @then("CLI should print the version in an expected format")
 def check_kedro_version(context):
     """Behave step to check validity of the kedro version."""
-    version_no = context.version_str.split()[-1]
+    CLI_flat_list = context.version_str.split()
+    CLI_dictionary = {
+        CLI_flat_list[i]: CLI_flat_list[i + 1] for i in range(0, len(CLI_flat_list), 2)
+    }
+    version_no = CLI_dictionary.get("version")
     assert version_no == kedro.__version__
 
 

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -486,7 +486,8 @@ def check_kedro_version(context):
     """Behave step to check validity of the kedro version."""
     CLI_flat_list = context.version_str.split()
     CLI_dictionary = {
-        CLI_flat_list[i]: CLI_flat_list[i + 1] for i in range(0, len(CLI_flat_list), 2)
+        CLI_flat_list[i]: CLI_flat_list[i + 1]
+        for i in range(0, len(CLI_flat_list) - 1, 2)
     }
     version_no = CLI_dictionary.get("version")
     assert version_no == kedro.__version__

--- a/tests/framework/cli/hooks/test_manager.py
+++ b/tests/framework/cli/hooks/test_manager.py
@@ -5,17 +5,18 @@ from kedro.framework.cli.hooks.specs import CLICommandSpecs
 
 
 @pytest.mark.parametrize(
-    "hook_specs,hook_name",
-    [(CLICommandSpecs, "before_command_run")],
+    "hook_specs,hook_name,hook_params",
+    [(CLICommandSpecs, "after_command_run", ("project_metadata", "command_args"))],
 )
-def test_hook_manager_can_call_hooks_defined_in_specs(hook_specs, hook_name):
+def test_hook_manager_can_call_hooks_defined_in_specs(
+    hook_specs, hook_name, hook_params
+):
     """Tests to make sure that the hook manager can call all hooks defined by specs."""
     cli_hook_manager = CLIHooksManager()
     hook = getattr(cli_hook_manager.hook, hook_name)
     assert hook.spec.namespace == hook_specs
-    # kedro-telemetry installed by default, this test runs the telemetry before_command_run hook, which
-    # is expecting the command_args to be a list version of the command like ['kedro', 'run']
-    kwargs = {"command_args": ["kedro", "run"], "project_metadata": None}
+    kwargs = {param: None for param in hook_params}
     result = hook(**kwargs)
-    # since there hasn't been any hook implementation the result should be empty, but it shouldn't raise
+    # since there hasn't been any hook implementation, the result should be empty
+    # but it shouldn't have raised
     assert result == []

--- a/tests/framework/cli/hooks/test_manager.py
+++ b/tests/framework/cli/hooks/test_manager.py
@@ -5,18 +5,16 @@ from kedro.framework.cli.hooks.specs import CLICommandSpecs
 
 
 @pytest.mark.parametrize(
-    "hook_specs,hook_name,hook_params",
-    [(CLICommandSpecs, "after_command_run", ("project_metadata", "command_args"))],
+    "hook_specs,hook_name",
+    [(CLICommandSpecs, "before_command_run")],
 )
-def test_hook_manager_can_call_hooks_defined_in_specs(
-    hook_specs, hook_name, hook_params
-):
+def test_hook_manager_can_call_hooks_defined_in_specs(hook_specs, hook_name):
     """Tests to make sure that the hook manager can call all hooks defined by specs."""
     cli_hook_manager = CLIHooksManager()
     hook = getattr(cli_hook_manager.hook, hook_name)
     assert hook.spec.namespace == hook_specs
-    kwargs = {param: None for param in hook_params}
+    # kedro-telemetry installed by default, this test runs the telemetry before_command_run hook, which
+    # is expecting the command_args to be a list version of the command like ['kedro', 'run']
+    kwargs = {"command_args": ["kedro", "run"], "project_metadata": None}
     result = hook(**kwargs)
-    # since there hasn't been any hook implementation, the result should be empty
-    # but it shouldn't have raised
     assert result == []

--- a/tests/framework/cli/hooks/test_manager.py
+++ b/tests/framework/cli/hooks/test_manager.py
@@ -5,18 +5,17 @@ from kedro.framework.cli.hooks.specs import CLICommandSpecs
 
 
 @pytest.mark.parametrize(
-    "hook_specs,hook_name,hook_params",
-    [(CLICommandSpecs, "before_command_run", ("project_metadata", "command_args"))],
+    "hook_specs,hook_name",
+    [(CLICommandSpecs, "before_command_run")],
 )
-def test_hook_manager_can_call_hooks_defined_in_specs(
-    hook_specs, hook_name, hook_params
-):
+def test_hook_manager_can_call_hooks_defined_in_specs(hook_specs, hook_name):
     """Tests to make sure that the hook manager can call all hooks defined by specs."""
     cli_hook_manager = CLIHooksManager()
     hook = getattr(cli_hook_manager.hook, hook_name)
     assert hook.spec.namespace == hook_specs
-    kwargs = {param: None for param in hook_params}
+    # kedro-telemetry installed by default, this test runs the telemetry before_command_run hook, which
+    # is expecting the command_args to be a list version of the command like ['kedro', 'run']
+    kwargs = {"command_args": ["kedro", "run"], "project_metadata": None}
     result = hook(**kwargs)
-    # since there hasn't been any hook implementation, the result should be empty
-    # but it shouldn't have raised
+    # since there hasn't been any hook implementation the result should be empty, but it shouldn't raise
     assert result == []


### PR DESCRIPTION
## Description
Fix broken hook test after releasing `0.19.7` which introduces the dependency to `kedro-telemetry`.

## Development notes
- Fix hook manager test now telemetry is included by default
- Fix checking of version in e2e tests now telemetry is included by default

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
