### PR TITLE
Clarify cli arguments overwrite config for `kedro new`

### DIFF
--- a/docs/source/starters/index.md
+++ b/docs/source/starters/index.md
@@ -43,6 +43,12 @@ project_name: My First Kedro Project
 repo_name: testing-kedro
 python_package: test_kedro
 ```
+
+``` {note}
+When the `--config` flag is used together with `--name`, `--tools`, or `--example`, the values provided directly on the CLI will overwrite those specified in the configuration file.
+```
+
+
 **Use `kedro new` with a `--starter`** <br />
 You can create a new Kedro project with a [starter](./starters.md) that adds code for a common project use case.
 

--- a/docs/source/starters/new_project_tools.md
+++ b/docs/source/starters/new_project_tools.md
@@ -153,6 +153,10 @@ kedro new --config=<path/to/config.yml>
 Note: When using a configuration file to create a new project, you must provide values for the project name, repository name, and package names. Specifying your tools selection is optional, omitting them results in the default selection of `none`.
 ```
 
+``` {note}
+When the `--config` flag is used together with `--name`, `--tools`, or `--example`, the values provided directly on the CLI will overwrite those specified in the configuration file.
+```
+
 ## Kedro tools
 
 Tools in Kedro serve as modular functionalities that enhance a foundational project template. They provide a means to tailor your Kedro project to meet your unique requirements. When creating a new project, you may select one or more of the available tools, or none at all.


### PR DESCRIPTION
## Description
Closes #3438 

## Development notes
This was marked as a bug, but it was more of a documentation task.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
