### PR TITLE
Fix docs to work for user defined `cli.py`

### DIFF
--- a/docs/source/development/commands_reference.md
+++ b/docs/source/development/commands_reference.md
@@ -157,7 +157,6 @@ from kedro.framework.cli.project import (
     TAG_ARG_HELP,
     TO_NODES_HELP,
     TO_OUTPUTS_HELP,
-    project_group,
 )
 from kedro.framework.cli.utils import (
     CONTEXT_SETTINGS,
@@ -177,7 +176,7 @@ def cli():
     """Command line tools for manipulating a Kedro project."""
 
 
-@project_group.command()
+@cli.command()
 @click.option(
     "--from-inputs", type=str, default="", help=FROM_INPUTS_HELP, callback=split_string
 )

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -304,7 +304,7 @@ def validate_settings() -> None:
     the settings module, dynaconf would silence any import error (e.g. missing
     dependency, missing/mislabelled pipeline), and users would instead get a cryptic
     error message ``Expected an instance of `ConfigLoader`, got `NoneType` instead``.
-    More info on the dynaconf issue: https://github.com/rochacbruno/dynaconf/issues/460
+    More info on the dynaconf issue: https://github.com/dynaconf/dynaconf/issues/460
     """
     if PACKAGE_NAME is None:
         raise ValueError(


### PR DESCRIPTION
## Description
Fix #4083 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Updated the docs so the `cli.py` example works. 

The user defined `cli.py` is still detected and loaded but the docs example plugs in the user defined command to `project_group` which is now lazily loaded. This is the correct way to do it.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
