### PR TITLE
Enable alternative to run Kedro without Rich again.

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -25,7 +25,7 @@ from kedro.io.core import (
     generate_timestamp,
 )
 from kedro.io.memory_dataset import MemoryDataset
-from kedro.logging import _format_rich, _has_rich_handler
+from kedro.utils import _format_rich, _has_rich_handler
 
 Patterns = Dict[str, Dict[str, Any]]
 

--- a/kedro/logging.py
+++ b/kedro/logging.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -55,14 +54,3 @@ class RichHandler(rich.logging.RichHandler):
             # fixed on their side at some point, but until then we disable it.
             # See https://github.com/Textualize/rich/issues/2455
             rich.traceback.install(**traceback_install_kwargs)  # type: ignore[arg-type]
-
-
-@lru_cache(maxsize=None)
-def _has_rich_handler(logger: logging.Logger) -> bool:
-    """Returns true if the logger has a RichHandler attached."""
-    return any(isinstance(handler, RichHandler) for handler in logger.handlers)
-
-
-def _format_rich(value: str, markup: str) -> str:
-    """Format string with rich markup"""
-    return f"[{markup}]{value}[/{markup}]"

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -2,9 +2,16 @@
 of kedro package.
 """
 import importlib
+import logging
 import os
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, Union
+
+try:
+    from kedro.logging import RichHandler
+except ImportError:
+    pass
 
 _PYPROJECT = "pyproject.toml"
 
@@ -78,3 +85,18 @@ def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
         if _is_project(parent_dir):
             return parent_dir
     return None
+
+
+@lru_cache(maxsize=None)
+def _has_rich_handler(logger: logging.Logger) -> bool:
+    """Returns true if the logger has a RichHandler attached."""
+    try:
+        importlib.util.find_spec("rich")
+    except ImportError:
+        return False
+    return any(isinstance(handler, RichHandler) for handler in logger.handlers)
+
+
+def _format_rich(value: str, markup: str) -> str:
+    """Format string with rich markup"""
+    return f"[{markup}]{value}[/{markup}]"

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -8,11 +8,6 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Any, Union
 
-try:
-    from kedro.logging import RichHandler
-except ImportError:
-    pass
-
 _PYPROJECT = "pyproject.toml"
 
 
@@ -91,7 +86,7 @@ def _find_kedro_project(current_dir: Path) -> Any:  # pragma: no cover
 def _has_rich_handler(logger: logging.Logger) -> bool:
     """Returns true if the logger has a RichHandler attached."""
     try:
-        importlib.util.find_spec("rich")
+        from rich.logging import RichHandler
     except ImportError:
         return False
     return any(isinstance(handler, RichHandler) for handler in logger.handlers)

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -155,15 +155,20 @@ def test_rich_format():
     )
 
 
-def test_has_rich_handler():
+def test_has_rich_handler_true():
     test_logger = logging.getLogger("test_logger")
-    assert not _has_rich_handler(test_logger)
-    _has_rich_handler.cache_clear()
     if importlib.util.find_spec("rich"):
         from kedro.logging import RichHandler
 
         test_logger.addHandler(RichHandler())
         assert _has_rich_handler(test_logger)
+    else:
+        pass
+
+
+def test_has_rich_handler_false():
+    test_logger = logging.getLogger("test_logger")
+    assert not _has_rich_handler(test_logger)
 
 
 def test_default_logging_info_emission(monkeypatch, tmp_path, caplog):

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -1,3 +1,4 @@
+import importlib
 import logging
 import sys
 from pathlib import Path
@@ -6,7 +7,6 @@ import pytest
 import yaml
 
 from kedro.framework.project import LOGGING, configure_logging, configure_project
-from kedro.logging import RichHandler
 from kedro.utils import _format_rich, _has_rich_handler
 
 
@@ -159,8 +159,11 @@ def test_has_rich_handler():
     test_logger = logging.getLogger("test_logger")
     assert not _has_rich_handler(test_logger)
     _has_rich_handler.cache_clear()
-    test_logger.addHandler(RichHandler())
-    assert _has_rich_handler(test_logger)
+    if importlib.util.find_spec("rich"):
+        from kedro.logging import RichHandler
+
+        test_logger.addHandler(RichHandler())
+        assert _has_rich_handler(test_logger)
 
 
 def test_default_logging_info_emission(monkeypatch, tmp_path, caplog):

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -2,6 +2,7 @@ import importlib
 import logging
 import sys
 from pathlib import Path
+from unittest import mock
 
 import pytest
 import yaml
@@ -157,10 +158,12 @@ def test_rich_format():
 
 def test_has_rich_handler():
     test_logger = logging.getLogger("test_logger")
-    assert not _has_rich_handler(test_logger)
+    with mock.patch("builtins.__import__", side_effect=ImportError):
+        assert not _has_rich_handler(test_logger)
     _has_rich_handler.cache_clear()
+
     if importlib.util.find_spec("rich"):
-        from kedro.logging import RichHandler
+        from rich.logging import RichHandler
 
         test_logger.addHandler(RichHandler())
         assert _has_rich_handler(test_logger)

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -6,7 +6,8 @@ import pytest
 import yaml
 
 from kedro.framework.project import LOGGING, configure_logging, configure_project
-from kedro.logging import RichHandler, _format_rich, _has_rich_handler
+from kedro.logging import RichHandler
+from kedro.utils import _format_rich, _has_rich_handler
 
 
 @pytest.fixture

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -155,20 +155,17 @@ def test_rich_format():
     )
 
 
-def test_has_rich_handler_true():
+def test_has_rich_handler():
     test_logger = logging.getLogger("test_logger")
+    assert not _has_rich_handler(test_logger)
+    _has_rich_handler.cache_clear()
     if importlib.util.find_spec("rich"):
         from kedro.logging import RichHandler
 
         test_logger.addHandler(RichHandler())
         assert _has_rich_handler(test_logger)
     else:
-        pass
-
-
-def test_has_rich_handler_false():
-    test_logger = logging.getLogger("test_logger")
-    assert not _has_rich_handler(test_logger)
+        assert not _has_rich_handler(test_logger)
 
 
 def test_default_logging_info_emission(monkeypatch, tmp_path, caplog):


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/pull/3682 made our workaround to allow Kedro to be run without Rich stop working. This happened because one of the new functions implemented, `_has_rich_handler`, required importing `RichHandler`, which depended on Rich. The changes on this PR allow the workaround to function again in the same way it did before.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
