### PR TITLE
Fix validation checks for duplicate keys

### DIFF
--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -263,7 +263,7 @@ class TestOmegaConfigLoader:
         pattern = (
             r"Duplicate keys found in "
             r"(.*catalog\.yml and .*nested\.yml|.*nested\.yml and .*catalog\.yml)"
-            r"\: cars, trains"
+            r"\: cars\.filepath, cars\.save_args\.index, cars\.type, trains\.type"
         )
         with pytest.raises(ValueError, match=pattern):
             OmegaConfigLoader(
@@ -285,17 +285,17 @@ class TestOmegaConfigLoader:
         pattern_catalog_nested = (
             r"Duplicate keys found in "
             r"(.*catalog\.yml and .*nested\.yml|.*nested\.yml and .*catalog\.yml)"
-            r"\: cars, trains"
+            r"\: cars\.filepath, cars\.save_args\.index, cars\.type, trains\.type"
         )
         pattern_catalog_local = (
             r"Duplicate keys found in "
             r"(.*catalog\.yml and .*local\.yml|.*local\.yml and .*catalog\.yml)"
-            r"\: cars"
+            r"\: cars\.filepath, cars\.save_args\.index, cars\.type"
         )
         pattern_nested_local = (
             r"Duplicate keys found in "
             r"(.*nested\.yml and .*local\.yml|.*local\.yml and .*nested\.yml)"
-            r"\: cars"
+            r"\: cars\.filepath, cars\.save_args\.index, cars\.type"
         )
 
         with pytest.raises(ValueError) as exc:
@@ -347,7 +347,7 @@ class TestOmegaConfigLoader:
         pattern = (
             r"Duplicate keys found in "
             r"(.*catalog\.yml and .*catalog\.json|.*catalog\.json and .*catalog\.yml)"
-            r"\: cars, trains"
+            r"\: cars\.filepath, cars\.save_args\.index, cars\.type, trains\.type"
         )
         with pytest.raises(ValueError, match=pattern):
             OmegaConfigLoader(str(tmp_path))["catalog"]


### PR DESCRIPTION
## Description

Resolves #4088 

## Development notes

- The OmegaConfigloader now validates the keys to the most granular level (creates `.` separated keys to validate duplication)

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
