### PR TITLE
Make packaged kedro project return `session.run()` output

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Upcoming Release
 
 ## Major features and improvements
-* Made packaged kedro project return `session.run()` output when running it in the interactive environment.
+* Made packaged kedro project return `session.run()` output to be used when running it in the interactive environment.
 * Enhanced `OmegaConfigLoader` configuration validation to detect duplicate keys at all parameter levels, ensuring comprehensive nested key checking.
 ## Bug fixes and other changes
 * Fixed bug where using dataset factories breaks with `ThreadRunner`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 
 ## Major features and improvements
+* Made packaged kedro project return `session.run()` output when running it in the interactive environment.
 * Enhanced `OmegaConfigLoader` configuration validation to detect duplicate keys at all parameter levels, ensuring comprehensive nested key checking.
 ## Bug fixes and other changes
 * Fixed bug where using dataset factories breaks with `ThreadRunner`.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,7 @@
 # Upcoming Release
 
 ## Major features and improvements
-* Made packaged kedro project return `session.run()` output to be used when running it in the interactive environment.
+* Made packaged Kedro projects return `session.run()` output to be used when running it in the interactive environment.
 * Enhanced `OmegaConfigLoader` configuration validation to detect duplicate keys at all parameter levels, ensuring comprehensive nested key checking.
 ## Bug fixes and other changes
 * Fixed bug where using dataset factories breaks with `ThreadRunner`.

--- a/docs/source/deployment/prefect.md
+++ b/docs/source/deployment/prefect.md
@@ -40,7 +40,7 @@ Run a Prefect Server instance:
 prefect server start
 ```
 
-In a separate terminal, [create a work pool](https://docs-2.prefect.io/latest/concepts/work-pools/#work-pool-configuration) to organise the work and [create a work queue](https://docs.prefect.io/2.10.17/concepts/work-pools/#work-queues) for your agent to pull from:
+In a separate terminal, [create a work pool](https://docs-2.prefect.io/latest/concepts/work-pools/#work-pool-configuration) to organise the work and [create a work queue](https://docs-2.prefect.io/latest/concepts/work-pools/#work-queues) for your agent to pull from:
 
 ```bash
 prefect work-pool create --type prefect-agent <work_pool_name>

--- a/docs/source/deployment/prefect.md
+++ b/docs/source/deployment/prefect.md
@@ -2,7 +2,7 @@
 
 This page explains how to run your Kedro pipeline using [Prefect 2.0](https://www.prefect.io/opensource), an open-source workflow management system.
 
-The scope of this documentation is the deployment to a self hosted [Prefect Server](https://docs.prefect.io/2.10.17/host/), which is an open-source backend that makes it easy to monitor and execute your Prefect flows and automatically extends Prefect 2.0. We will use an [Agent that dequeues submitted flow runs from a Work Queue](https://docs.prefect.io/2.10.17/tutorial/deployments/#why-workpools-and-workers).
+The scope of this documentation is the deployment to a self hosted [Prefect Server](https://docs-2.prefect.io/latest/guides/host/), which is an open-source backend that makes it easy to monitor and execute your Prefect flows and automatically extends Prefect 2.0. We will use an [Agent that dequeues submitted flow runs from a Work Queue](https://docs.prefect.io/2.10.17/tutorial/deployments/#why-workpools-and-workers).
 
 ```{note}
 This deployment has been tested using Kedro 0.18.10 with Prefect version 2.10.17. If you want to deploy with Prefect 1.0, we recommend you review [earlier versions of Kedro's Prefect deployment documentation](https://docs.kedro.org/en/0.18.9/deployment/prefect.html).
@@ -12,7 +12,7 @@ This deployment has been tested using Kedro 0.18.10 with Prefect version 2.10.17
 
 To use Prefect 2.0 and Prefect Server, ensure you have the following prerequisites in place:
 
-- [Prefect 2.0 is installed](https://docs.prefect.io/2.10.17/getting-started/installation/#installing-the-latest-version) on your machine
+- [Prefect 2.0 is installed](https://docs-2.prefect.io/latest/getting-started/installation/#installing-the-prefect-2-latest-version) on your machine
 
 ## Setup
 
@@ -40,7 +40,7 @@ Run a Prefect Server instance:
 prefect server start
 ```
 
-In a separate terminal, [create a work pool](https://docs.prefect.io/2.10.17/concepts/work-pools/#work-pool-configuration) to organise the work and [create a work queue](https://docs.prefect.io/2.10.17/concepts/work-pools/#work-queues) for your agent to pull from:
+In a separate terminal, [create a work pool](https://docs-2.prefect.io/latest/concepts/work-pools/#work-pool-configuration) to organise the work and [create a work queue](https://docs.prefect.io/2.10.17/concepts/work-pools/#work-queues) for your agent to pull from:
 
 ```bash
 prefect work-pool create --type prefect-agent <work_pool_name>
@@ -57,7 +57,7 @@ prefect agent start --pool <work_pool_name> --work-queue <work_queue_name>
 
 ### Convert your Kedro pipeline to Prefect 2.0 flow
 
-To build a [Prefect flow](https://docs.prefect.io/core/concepts/flows.html) for your Kedro pipeline programmatically and register it with the Prefect API, use the following Python script, which should be stored in your project’s **root directory**:
+To build a [Prefect flow](https://docs-2.prefect.io/latest/concepts/flows/) for your Kedro pipeline programmatically and register it with the Prefect API, use the following Python script, which should be stored in your project’s **root directory**:
 
 ```python
 # <project_root>/register_prefect_flow.py
@@ -250,7 +250,7 @@ Be sure that your Prefect Server is up and running. Verify that the deployment s
 
 ### Run Prefect flow
 
-Now, having the flow registered, you can use [Prefect Server UI](https://docs.prefect.io/2.10.17/host/) to orchestrate and monitor it.
+Now, having the flow registered, you can use [Prefect Server UI](https://docs-2.prefect.io/latest/guides/host/) to orchestrate and monitor it.
 
 Navigate to http://localhost:4200/deployments to see your registered flow.
 

--- a/docs/source/deployment/prefect.md
+++ b/docs/source/deployment/prefect.md
@@ -2,7 +2,7 @@
 
 This page explains how to run your Kedro pipeline using [Prefect 2.0](https://www.prefect.io/opensource), an open-source workflow management system.
 
-The scope of this documentation is the deployment to a self hosted [Prefect Server](https://docs-2.prefect.io/latest/guides/host/), which is an open-source backend that makes it easy to monitor and execute your Prefect flows and automatically extends Prefect 2.0. We will use an [Agent that dequeues submitted flow runs from a Work Queue](https://docs.prefect.io/2.10.17/tutorial/deployments/#why-workpools-and-workers).
+The scope of this documentation is the deployment to a self hosted [Prefect Server](https://docs-2.prefect.io/latest/guides/host/), which is an open-source backend that makes it easy to monitor and execute your Prefect flows and automatically extends Prefect 2.0. We will use an [Agent that dequeues submitted flow runs from a Work Queue](https://docs-2.prefect.io/latest/concepts/deployments/#workers-and-work-pools).
 
 ```{note}
 This deployment has been tested using Kedro 0.18.10 with Prefect version 2.10.17. If you want to deploy with Prefect 1.0, we recommend you review [earlier versions of Kedro's Prefect deployment documentation](https://docs.kedro.org/en/0.18.9/deployment/prefect.html).

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -144,6 +144,19 @@ main(
 
 This is equivalent to `python -m <package_name>` at the command line, and you can pass in all the arguments that correspond to the options described by `python -m <package_name> --help`.
 
+```{note}
+If you run the packaged project in the interactive environment like ipython or Databricks you can also consume the output of the `main()`
+which returns the `session.run()` output.
+```
+
+```python
+from spaceflights.__main__ import main
+
+def run_kedro_pipeline():
+   result = main(pipeline_name=<pipeline>)
+   do_something_about(<result>)
+```
+
 ### Docker, Airflow and other deployment targets
 
 There are various methods to deploy packaged pipelines via Kedro plugins:

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -154,7 +154,7 @@ from spaceflights.__main__ import main
 
 def run_kedro_pipeline():
    result = main(pipeline_name=<pipeline>)
-   do_something_about(<result>)
+   do_something_with(<result>)
 ```
 
 ### Docker, Airflow and other deployment targets

--- a/docs/source/tutorial/package_a_project.md
+++ b/docs/source/tutorial/package_a_project.md
@@ -145,7 +145,7 @@ main(
 This is equivalent to `python -m <package_name>` at the command line, and you can pass in all the arguments that correspond to the options described by `python -m <package_name> --help`.
 
 ```{note}
-If you run the packaged project in the interactive environment like ipython or Databricks you can also consume the output of the `main()`
+If you run the packaged project in the interactive environment like IPython or Databricks you can also consume the output of the `main()`
 which returns the `session.run()` output.
 ```
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -215,7 +215,7 @@ def run(  # noqa: PLR0913
     conf_source: str,
     params: dict[str, Any],
     namespace: str,
-) -> None:
+) -> dict[str, Any]:
     """Run the pipeline."""
 
     runner_obj = load_obj(runner or "SequentialRunner", "kedro.runner")
@@ -225,7 +225,7 @@ def run(  # noqa: PLR0913
     with KedroSession.create(
         env=env, conf_source=conf_source, extra_params=params
     ) as session:
-        session.run(
+        return session.run(
             tags=tuple_tags,
             runner=runner_obj(is_async=is_async),
             node_names=tuple_node_names,

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/__main__.py
@@ -3,12 +3,13 @@ as `{{ cookiecutter.repo_name }}` and `python -m {{ cookiecutter.python_package 
 """
 import sys
 from pathlib import Path
+from typing import Any
 
 from kedro.framework.cli.utils import find_run_command
 from kedro.framework.project import configure_project
 
 
-def main(*args, **kwargs):
+def main(*args, **kwargs) -> Any:
     package_name = Path(__file__).parent.name
     configure_project(package_name)
 
@@ -16,7 +17,7 @@ def main(*args, **kwargs):
     kwargs["standalone_mode"] = not interactive
 
     run = find_run_command(package_name)
-    run(*args, **kwargs)
+    return run(*args, **kwargs)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/2681

Should be reviewed and merged with: https://github.com/kedro-org/kedro-starters/pull/235

## Development notes
Modified project run command to return `session.run()` output in the interactive environment


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
