### PR TITLE
Remove mention of black which has been long replaced by ruff

### DIFF
--- a/docs/source/starters/new_project_tools.md
+++ b/docs/source/starters/new_project_tools.md
@@ -44,7 +44,7 @@ To skip this step in future use --tools
 To find out more: https://docs.kedro.org/en/stable/starters/new_project_tools.html
 
 Tools
-1) Lint: Basic linting with Black and Ruff
+1) Lint: Basic linting with Ruff
 2) Test: Basic testing with pytest
 3) Log: Additional, environment-specific logging options
 4) Docs: A Sphinx documentation setup
@@ -65,8 +65,7 @@ A list of available tools can also be accessed by running `kedro new --help`
 
                       Tools
 
-                      1) Linting: Provides a basic linting setup with Black
-                      and Ruff
+                      1) Linting: Provides a basic linting setup with Ruff
 
                       2) Testing: Provides basic testing setup with pytest
 
@@ -165,7 +164,7 @@ The available tools include: [linting](#linting), [testing](#testing), [custom l
 
 ### Linting
 
-The Kedro linting tool introduces [`black`](https://black.readthedocs.io/en/stable/index.html) and [`ruff`](https://docs.astral.sh/ruff/) as dependencies in your new project's requirements. After project creation, make sure these are installed by running the following command from the project root:
+The Kedro linting tool introduces [`ruff`](https://docs.astral.sh/ruff/) as dependency in your new project's requirements. After project creation, make sure these are installed by running the following command from the project root:
 
 ```bash
 pip install -r requirements.txt
@@ -175,7 +174,6 @@ The linting tool will configure `ruff` with the following settings by default:
 ```toml
 #pyproject.toml
 
-[tool.ruff]
 line-length = 88
 show-fixes = true
 select = [
@@ -187,7 +185,7 @@ select = [
     "PL",  # Pylint
     "T201", # Print Statement
 ]
-ignore = ["E501"]  # Black takes care of line-too-long
+ignore = ["E501"]  # Ruff format takes care of line-too-long
 ```
 
 With these installed, you can then make use of the following commands to format and lint your code:


### PR DESCRIPTION
## Description
I noticed the docs about the tools still mention `black` even though that was long ago replaced by `ruff`. 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
