### PR TITLE
Fix template projects example tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 * Enhanced `OmegaConfigLoader` configuration validation to detect duplicate keys at all parameter levels, ensuring comprehensive nested key checking.
 ## Bug fixes and other changes
 * Fixed bug where using dataset factories breaks with `ThreadRunner`.
+* Fixed template projects example tests.
 
 ## Breaking changes to the API
 * Removed `ShelveStore` to address a security vulnerability.
@@ -18,6 +19,7 @@
 ## Community contributions
 * [Puneet](https://github.com/puneeter)
 * [ethanknights](https://github.com/ethanknights)
+* [Manezki](https://github.com/Manezki)
 
 # Release 0.19.8
 

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/tests/test_run.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/tests/test_run.py
@@ -28,6 +28,7 @@ def project_context(config_loader):
     return KedroContext(
         package_name="{{ cookiecutter.python_package }}",
         project_path=Path.cwd(),
+        env="local",
         config_loader=config_loader,
         hook_manager=_create_hook_manager(),
     )

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/tests/test_run.py
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/tests/test_run.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 import pytest
 
-from kedro.config import ConfigLoader
+from kedro.config import OmegaConfigLoader
 from kedro.framework.context import KedroContext
 from kedro.framework.hooks import _create_hook_manager
 from kedro.framework.project import settings
@@ -20,7 +20,7 @@ from kedro.framework.project import settings
 
 @pytest.fixture
 def config_loader():
-    return ConfigLoader(conf_source=str(Path.cwd() / settings.CONF_SOURCE))
+    return OmegaConfigLoader(conf_source=str(Path.cwd() / settings.CONF_SOURCE))
 
 
 @pytest.fixture


### PR DESCRIPTION
## Description
New project created by `kedro new --tools test` has example test that does not work.

## Development notes
* Changed ConfigLoader to the newly embraced OmegaConfigLoader.
* Added env argument to KedroContext initialization.

After the changes a new project can successfully run tests with `pytest .`

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
