### PR TITLE
Make credentials loading consistent between `KedroContext._get_catalog()` and catalog CLI

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@
 * Enhanced `OmegaConfigLoader` configuration validation to detect duplicate keys at all parameter levels, ensuring comprehensive nested key checking.
 ## Bug fixes and other changes
 * Fixed bug where using dataset factories breaks with `ThreadRunner`.
+* Made credentials loading consistent between `KedroContext._get_catalog()` and `resolve_patterns` so that both us
+e `_get_config_credentials()`
 
 ## Breaking changes to the API
 * Removed `ShelveStore` to address a security vulnerability.
@@ -18,6 +20,7 @@
 ## Community contributions
 * [Puneet](https://github.com/puneeter)
 * [ethanknights](https://github.com/ethanknights)
+* [MigQ2](https://github.com/MigQ2)
 
 # Release 0.19.8
 

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -227,7 +227,7 @@ def resolve_patterns(metadata: ProjectMetadata, env: str) -> None:
     context = session.load_context()
 
     catalog_config = context.config_loader["catalog"]
-    credentials_config = context.config_loader.get("credentials", None)
+    credentials_config = context._get_config_credentials()
     data_catalog = DataCatalog.from_config(
         catalog=catalog_config, credentials=credentials_config
     )

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -543,7 +543,7 @@ class TestCatalogFactoryCommands:
             "catalog": fake_catalog_config,
             "credentials": fake_credentials_config,
         }
-        mocked_context._get_config_credentials().return_value = fake_credentials_config
+        mocked_context._get_config_credentials.return_value = fake_credentials_config
         mocked_context.catalog = DataCatalog.from_config(
             catalog=fake_catalog_config, credentials=fake_credentials_config
         )

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -543,6 +543,7 @@ class TestCatalogFactoryCommands:
             "catalog": fake_catalog_config,
             "credentials": fake_credentials_config,
         }
+        mocked_context._get_config_credentials().return_value = fake_credentials_config
         mocked_context.catalog = DataCatalog.from_config(
             catalog=fake_catalog_config, credentials=fake_credentials_config
         )


### PR DESCRIPTION
## Description
I found that credentials initialization is done differently in different cases:

- In [KedroContext._get_catalog()](https://github.com/kedro-org/kedro/blob/main/kedro/framework/context/context.py#L232) the [_get_config_credentials()](https://github.com/kedro-org/kedro/blob/main/kedro/framework/context/context.py#L283) method is used to grab credentials for the DataCatalog
- In [catalog CLI's `resolve_patterns()`](https://github.com/kedro-org/kedro/blob/7e02653d755a6534f158d11dcf8c5aa9db9e2a26/kedro/framework/cli/catalog.py#L230), it is done with `context.config_loader.get("credentials", None)` instead 

Is there a good reason for this? If not, I think it's better to load the credentials in a consistent way and using the same methods everywhere

## Why is this important?

I have a custom catalog class that extends `KedroCatalog` and overrides the `_get_config_credentials()` method because I get my credentials from a cloud secret management service instead of a local `credentials.yml` file. 

This was making the command `kedro catalog resolve` fail because my credentials are not in the `ConfigLoader`

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [X] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [X] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [X] Added tests to cover my changes (I didn't add tests as I'm not adding new functionality and I believe this should be covered by existing tests)
- [X] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
