### PR TITLE
Unit tests for `KedroDataCatalog`

### DIFF
--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from kedro_datasets.pandas import CSVDataset
 
 
 @pytest.fixture
@@ -21,3 +22,13 @@ def input_data(request):
 @pytest.fixture
 def new_data():
     return pd.DataFrame({"col1": ["a", "b"], "col2": ["c", "d"], "col3": ["e", "f"]})
+
+
+@pytest.fixture
+def filepath(tmp_path):
+    return (tmp_path / "some" / "dir" / "test.csv").as_posix()
+
+
+@pytest.fixture
+def dataset(filepath):
+    return CSVDataset(filepath=filepath, save_args={"index": False})

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -32,3 +32,20 @@ def filepath(tmp_path):
 @pytest.fixture
 def dataset(filepath):
     return CSVDataset(filepath=filepath, save_args={"index": False})
+
+
+@pytest.fixture
+def sane_config(filepath):
+    return {
+        "catalog": {
+            "boats": {"type": "pandas.CSVDataset", "filepath": filepath},
+            "cars": {
+                "type": "pandas.CSVDataset",
+                "filepath": "s3://test_bucket/test_file.csv",
+                "credentials": "s3_credentials",
+            },
+        },
+        "credentials": {
+            "s3_credentials": {"key": "FAKE_ACCESS_KEY", "secret": "FAKE_SECRET_KEY"}
+        },
+    }

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -71,3 +71,19 @@ def bad_config(filepath):
     return {
         "bad": {"type": "tests.io.test_data_catalog.BadDataset", "filepath": filepath}
     }
+
+
+@pytest.fixture
+def sane_config_with_tracking_ds(tmp_path):
+    boat_path = (tmp_path / "some" / "dir" / "test.csv").as_posix()
+    plane_path = (tmp_path / "some" / "dir" / "metrics.json").as_posix()
+    return {
+        "catalog": {
+            "boats": {
+                "type": "pandas.CSVDataset",
+                "filepath": boat_path,
+                "versioned": True,
+            },
+            "planes": {"type": "tracking.MetricsDataset", "filepath": plane_path},
+        },
+    }

--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -49,3 +49,25 @@ def sane_config(filepath):
             "s3_credentials": {"key": "FAKE_ACCESS_KEY", "secret": "FAKE_SECRET_KEY"}
         },
     }
+
+
+@pytest.fixture
+def sane_config_with_nested_creds(sane_config):
+    sane_config["catalog"]["cars"]["credentials"] = {
+        "client_kwargs": {"credentials": "other_credentials"},
+        "key": "secret",
+    }
+    sane_config["credentials"]["other_credentials"] = {
+        "client_kwargs": {
+            "aws_access_key_id": "OTHER_FAKE_ACCESS_KEY",
+            "aws_secret_access_key": "OTHER_FAKE_SECRET_KEY",
+        }
+    }
+    return sane_config
+
+
+@pytest.fixture
+def bad_config(filepath):
+    return {
+        "bad": {"type": "tests.io.test_data_catalog.BadDataset", "filepath": filepath}
+    }

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -30,16 +30,6 @@ from kedro.io.core import (
 
 
 @pytest.fixture
-def filepath(tmp_path):
-    return (tmp_path / "some" / "dir" / "test.csv").as_posix()
-
-
-@pytest.fixture
-def dummy_dataframe():
-    return pd.DataFrame({"col1": [1, 2], "col2": [4, 5], "col3": [5, 6]})
-
-
-@pytest.fixture
 def sane_config(filepath):
     return {
         "catalog": {
@@ -178,11 +168,6 @@ def config_with_dataset_factories_only_patterns_no_default(
 ):
     del config_with_dataset_factories_only_patterns["catalog"]["{user_default}"]
     return config_with_dataset_factories_only_patterns
-
-
-@pytest.fixture
-def dataset(filepath):
-    return CSVDataset(filepath=filepath, save_args={"index": False})
 
 
 @pytest.fixture

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -30,21 +30,6 @@ from kedro.io.core import (
 
 
 @pytest.fixture
-def sane_config_with_nested_creds(sane_config):
-    sane_config["catalog"]["cars"]["credentials"] = {
-        "client_kwargs": {"credentials": "other_credentials"},
-        "key": "secret",
-    }
-    sane_config["credentials"]["other_credentials"] = {
-        "client_kwargs": {
-            "aws_access_key_id": "OTHER_FAKE_ACCESS_KEY",
-            "aws_secret_access_key": "OTHER_FAKE_SECRET_KEY",
-        }
-    }
-    return sane_config
-
-
-@pytest.fixture
 def sane_config_with_tracking_ds(tmp_path):
     boat_path = (tmp_path / "some" / "dir" / "test.csv").as_posix()
     plane_path = (tmp_path / "some" / "dir" / "metrics.json").as_posix()
@@ -186,13 +171,6 @@ class BadDataset(AbstractDataset):  # pragma: no cover
 
     def _describe(self):
         return {}
-
-
-@pytest.fixture
-def bad_config(filepath):
-    return {
-        "bad": {"type": "tests.io.test_data_catalog.BadDataset", "filepath": filepath}
-    }
 
 
 @pytest.fixture

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -30,22 +30,6 @@ from kedro.io.core import (
 
 
 @pytest.fixture
-def sane_config_with_tracking_ds(tmp_path):
-    boat_path = (tmp_path / "some" / "dir" / "test.csv").as_posix()
-    plane_path = (tmp_path / "some" / "dir" / "metrics.json").as_posix()
-    return {
-        "catalog": {
-            "boats": {
-                "type": "pandas.CSVDataset",
-                "filepath": boat_path,
-                "versioned": True,
-            },
-            "planes": {"type": "tracking.MetricsDataset", "filepath": plane_path},
-        },
-    }
-
-
-@pytest.fixture
 def config_with_dataset_factories():
     return {
         "catalog": {

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -30,23 +30,6 @@ from kedro.io.core import (
 
 
 @pytest.fixture
-def sane_config(filepath):
-    return {
-        "catalog": {
-            "boats": {"type": "pandas.CSVDataset", "filepath": filepath},
-            "cars": {
-                "type": "pandas.CSVDataset",
-                "filepath": "s3://test_bucket/test_file.csv",
-                "credentials": "s3_credentials",
-            },
-        },
-        "credentials": {
-            "s3_credentials": {"key": "FAKE_ACCESS_KEY", "secret": "FAKE_SECRET_KEY"}
-        },
-    }
-
-
-@pytest.fixture
 def sane_config_with_nested_creds(sane_config):
     sane_config["catalog"]["cars"]["credentials"] = {
         "client_kwargs": {"credentials": "other_credentials"},

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -155,3 +155,7 @@ class TestKedroDataCatalog:
         pattern = f"Invalid regular expression provided: '{escaped_regex}'"
         with pytest.raises(SyntaxError, match=pattern):
             multi_catalog.list("((")
+
+    def test_eq(self, multi_catalog, data_catalog):
+        assert multi_catalog == multi_catalog.shallow_copy()
+        assert multi_catalog != data_catalog

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -1,0 +1,27 @@
+import pytest
+from pandas.testing import assert_frame_equal
+
+from kedro.io import KedroDataCatalog
+
+
+@pytest.fixture
+def data_catalog(dataset):
+    return KedroDataCatalog(datasets={"test": dataset})
+
+
+class TestKedroDataCatalog:
+    def test_save_and_load(self, data_catalog, dummy_dataframe):
+        """Test saving and reloading the data set"""
+        data_catalog.save("test", dummy_dataframe)
+        reloaded_df = data_catalog.load("test")
+
+        assert_frame_equal(reloaded_df, dummy_dataframe)
+
+    def test_add_save_and_load(self, dataset, dummy_dataframe):
+        """Test adding and then saving and reloading the data set"""
+        catalog = KedroDataCatalog(datasets={})
+        catalog.add("test", dataset)
+        catalog.save("test", dummy_dataframe)
+        reloaded_df = catalog.load("test")
+
+        assert_frame_equal(reloaded_df, dummy_dataframe)

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -1,7 +1,12 @@
 import pytest
 from pandas.testing import assert_frame_equal
 
-from kedro.io import KedroDataCatalog
+from kedro.io import (
+    DatasetAlreadyExistsError,
+    DatasetError,
+    DatasetNotFoundError,
+    KedroDataCatalog,
+)
 
 
 @pytest.fixture
@@ -25,3 +30,30 @@ class TestKedroDataCatalog:
         reloaded_df = catalog.load("test")
 
         assert_frame_equal(reloaded_df, dummy_dataframe)
+
+    def test_load_error(self, data_catalog):
+        """Check the error when attempting to load a data set
+        from nonexistent source"""
+        pattern = r"Failed while loading data from data set CSVDataset"
+        with pytest.raises(DatasetError, match=pattern):
+            data_catalog.load("test")
+
+    def test_add_dataset_twice(self, data_catalog, dataset):
+        """Check the error when attempting to add the data set twice"""
+        pattern = r"Dataset 'test' has already been registered"
+        with pytest.raises(DatasetAlreadyExistsError, match=pattern):
+            data_catalog.add("test", dataset)
+
+    def test_load_from_unregistered(self):
+        """Check the error when attempting to load unregistered data set"""
+        catalog = KedroDataCatalog(datasets={})
+        pattern = r"Dataset 'test' not found in the catalog"
+        with pytest.raises(DatasetNotFoundError, match=pattern):
+            catalog.load("test")
+
+    def test_save_to_unregistered(self, dummy_dataframe):
+        """Check the error when attempting to save to unregistered data set"""
+        catalog = KedroDataCatalog(datasets={})
+        pattern = r"Dataset 'test' not found in the catalog"
+        with pytest.raises(DatasetNotFoundError, match=pattern):
+            catalog.save("test", dummy_dataframe)

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -178,6 +178,12 @@ class TestKedroDataCatalog:
 
     def test_adding_datasets_not_allowed(self, data_catalog_from_config):
         """Check error if user tries to update the datasets attribute"""
-        pattern = r"'KedroDataCatalog' object does not support item assignment"
-        with pytest.raises(TypeError, match=pattern):
+        pattern = r"Operation not allowed! Please use KedroDataCatalog.add\(\) instead."
+        with pytest.raises(AttributeError, match=pattern):
             data_catalog_from_config["new_dataset"] = None
+
+        pattern = (
+            r"Operation not allowed! Please change datasets through configuration."
+        )
+        with pytest.raises(AttributeError, match=pattern):
+            data_catalog_from_config["boats"] = None


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4167

## Development notes
Added `test_kedro_data_catalog.py` to reach 100% test coverage after adding `KedroDataCatalog`.

Some fixtures from `test_data_catalog.py` were reused and moved to the `conftets.py`


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
