### PR TITLE
Add performance testing setup to Kedro

### DIFF
--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -21,37 +21,37 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11' 
+          python-version: '3.11'
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
           pip install asv  # Install ASV
-      
+
       - name: Run ASV benchmarks
         run: |
           cd kedro
           asv machine --machine=github-actions
           asv run -v --machine=github-actions
-      
+
       - name: Set git email and name
         run: |
           git config --global user.email "kedro@kedro.com"
           git config --global user.name "Kedro"
-      
+
       - name: Checkout target repository
         uses: actions/checkout@v4
         with:
           repository: kedro-org/kedro-benchmark-results
-          token: ${{ secrets.GH_TAGGING_TOKEN }}  
+          token: ${{ secrets.GH_TAGGING_TOKEN }}
           ref: 'main'
           path: "kedro-benchmark-results"
 
       - name: Copy files to target repository
         run: |
           cp -r /home/runner/work/kedro/kedro/kedro/.asv /home/runner/work/kedro/kedro/kedro-benchmark-results/
-      
-      - name: Commit and Push changes to kedro-org/kedro-benchmark-results 
+
+      - name: Commit and Push changes to kedro-org/kedro-benchmark-results
         run: |
           cd kedro-benchmark-results
           git add .

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -1,0 +1,59 @@
+name: ASV Benchmark
+
+on:
+  push:
+    branches:
+      - main  # Run benchmarks on every commit to the main branch
+  workflow_dispatch:
+
+
+jobs:
+
+  benchmark:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: "kedro"
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11' 
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install asv  # Install ASV
+      
+      - name: Run ASV benchmarks
+        run: |
+          cd kedro
+          asv machine --machine=github-actions
+          asv run -v --machine=github-actions
+      
+      - name: Set git email and name
+        run: |
+          git config --global user.email "kedro@kedro.com"
+          git config --global user.name "Kedro"
+      
+      - name: Checkout target repository
+        uses: actions/checkout@v4
+        with:
+          repository: kedro-org/kedro-benchmark-results
+          token: ${{ secrets.GH_TAGGING_TOKEN }}  
+          ref: 'main'
+          path: "kedro-benchmark-results"
+
+      - name: Copy files to target repository
+        run: |
+          cp -r /home/runner/work/kedro/kedro/kedro/.asv /home/runner/work/kedro/kedro/kedro-benchmark-results/
+      
+      - name: Commit and Push changes to kedro-org/kedro-benchmark-results 
+        run: |
+          cd kedro-benchmark-results
+          git add .
+          git commit -m "Add results"
+          git push

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "project_url": "https://kedro.org/",
     "repo": ".",
     "install_command": ["pip install -e ."],
-    "branches": ["main"], 
+    "branches": ["main"],
     "environment_type": "virtualenv",
     "show_commit_url": "http://github.com/kedro-org/kedro/commit/",
     "results_dir": ".asv/results",

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -1,0 +1,12 @@
+{
+    "version": 1,
+    "project": "Kedro",
+    "project_url": "https://kedro.org/",
+    "repo": ".",
+    "install_command": ["pip install -e ."],
+    "branches": ["main"], 
+    "environment_type": "virtualenv",
+    "show_commit_url": "http://github.com/kedro-org/kedro/commit/",
+    "results_dir": ".asv/results",
+    "html_dir": ".asv/html"
+}

--- a/benchmarks/benchmark_dummy.py
+++ b/benchmarks/benchmark_dummy.py
@@ -1,0 +1,16 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
+
+class TimeSuite:
+    """
+    A dummy benchmark suite to test with asv framework.
+    """
+    def setup(self):
+        self.d = {}
+        for x in range(500):
+            self.d[x] = None
+
+    def time_keys(self):
+        for key in self.d.keys():
+            pass


### PR DESCRIPTION
## Description

Part of https://github.com/kedro-org/kedro/issues/4128

## Development notes

I've managed to set the performance testing framework using `asv` on my fork of Kedro: https://github.com/ankatiyar/kedro

The setup is -
- `benchmarks/` folder is where the performance/stress tests for various components such as `DataCatalog` or `OmegaConfigLoader` will go. Right now I've left a dummy test in that we can replace or leave in. I suggest we leave this in so we will know if some regressions in the future are happening because of the runners on Github Actions and not because of our changes. 
- The workflow in this repository - A copy of https://github.com/ankatiyar/kedro/blob/main/.github/workflows/asv.yml - will run everytime there is a commit to the main repo. The results are then committed to a separate repo -> https://github.com/ankatiyar/benchmark-kedro (example). I made a similar repo in `kedro-org` -> https://github.com/kedro-org/kedro-benchmark-results
- There is an actions workflow that runs on the results repo that publishes the result as github pages. 
    - Example GH Page: https://ankatiyar.github.io/benchmark-kedro/
    - Workflow (on my fork): https://github.com/ankatiyar/benchmark-kedro/blob/main/.github/workflows/publish-benchmark.yml

❗ Disclaimer ❗ : This might not immediately work and might require tweaks with permission issues as follow up PRs so I would like to get a first draft in to test the action with the dummy test. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
