### PR TITLE
Update SparkHook configuration loading line on docs.

### DIFF
--- a/docs/source/integrations/pyspark_integration.md
+++ b/docs/source/integrations/pyspark_integration.md
@@ -35,7 +35,7 @@ class SparkHooks:
         """
 
         # Load the spark configuration in spark.yaml using the config loader
-        parameters = context.config_loader.get("spark*", "spark*/**")
+        parameters = context.config_loader["spark"]
         spark_conf = SparkConf().setAll(parameters.items())
 
         # Initialise the spark session


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/issues/4118 and https://github.com/kedro-org/kedro/issues/4166 pointed out that the way our documentation instructs users to load the `spark.yml` config file might be incorrect. The changed line should work, assuming that the file is at `conf/base/spark.yml`.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
