### PR TITLE
Move config validation to the `CatalogConfigResolver` init

### DIFF
--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -131,12 +131,12 @@ class CatalogConfigResolver:
 
     @classmethod
     def _validate_pattern_config(cls, ds_name: str, ds_config: dict[str, Any]) -> None:
-        # Find all occurrences of {}
+        # Find all occurrences of {} in the string including brackets
         search_regex = r"\{.*?\}"
         name_placeholders = set(re.findall(search_regex, ds_name))
         config_placeholders = set()
 
-        def _traverse_config(config):
+        def _traverse_config(config: Any) -> None:
             if isinstance(config, dict):
                 for value in config.values():
                     _traverse_config(value)

--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -131,6 +131,17 @@ class CatalogConfigResolver:
 
     @classmethod
     def _validate_pattern_config(cls, ds_name: str, ds_config: dict[str, Any]) -> None:
+        """Checks whether a dataset factory pattern configuration is valid - all
+        keys used in the configuration present in the dataset factory pattern name.
+
+        Args:
+            ds_name: Dataset factory pattern name.
+            ds_config: Dataset pattern configuration.
+
+        Raises:
+            DatasetError: when keys used in the configuration do not present in the dataset factory pattern name.
+
+        """
         # Find all occurrences of {} in the string including brackets
         search_regex = r"\{.*?\}"
         name_placeholders = set(re.findall(search_regex, ds_name))

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -946,13 +946,12 @@ class TestDataCatalogDatasetFactories:
         self, config_with_dataset_factories_bad_pattern
     ):
         """Check error raised when key mentioned in the config is not in pattern name"""
-        catalog = DataCatalog.from_config(**config_with_dataset_factories_bad_pattern)
         pattern = (
-            "Unable to resolve 'data/01_raw/{brand}_plane.pq' from the pattern '{type}@planes'. "
-            "Keys used in the configuration should be present in the dataset factory pattern."
+            "Incorrect dataset configuration provided. Keys used in the configuration {'{brand}'} "
+            "should present in the dataset factory pattern name {type}@planes."
         )
         with pytest.raises(DatasetError, match=re.escape(pattern)):
-            catalog._get_dataset("jet@planes")
+            _ = DataCatalog.from_config(**config_with_dataset_factories_bad_pattern)
 
     def test_factory_config_versioned(
         self, config_with_dataset_factories, filepath, dummy_dataframe


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4188

## Development notes
In this PR, we:

1. Added new method - `_validate_pattern_config` to validate pattern configuration at the `CatalogConfigResolver` init
2. Simplified `_resolve_dataset_config` method removing validation and keeping only filling placeholders logic


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
