### PR TITLE
Add support for Oracle Cloud Infrastructure (OCI)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,8 @@
 **Note:** ``KedroDataCatalog`` is an experimental feature and is under active development. Therefore, it is possible we'll introduce breaking changes to this class, so be mindful of that if you decide to use it already. Let us know if you have any feedback about the ``KedroDataCatalog`` or ideas for new features.
 
 ## Bug fixes and other changes
+* Added I/O support for Oracle Cloud Infrastructure (OCI) Object Storage filesystem
+
 ## Breaking changes to the API
 ## Documentation changes
 * Updated CLI autocompletion docs with new Click syntax.

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -51,6 +51,7 @@ CLOUD_PROTOCOLS = (
     "gcs",
     "gdrive",
     "gs",
+    "oci",
     "oss",
     "s3",
     "s3a",
@@ -820,9 +821,11 @@ def _parse_filepath(filepath: str) -> dict[str, str]:
         host_with_port = parsed_path.netloc.rsplit("@", 1)[-1]
         host = host_with_port.rsplit(":", 1)[0]
         options["path"] = host + options["path"]
-        # Azure Data Lake Storage Gen2 URIs can store the container name in the
-        # 'username' field of a URL (@ syntax), so we need to add it to the path
-        if protocol == "abfss" and parsed_path.username:
+        # - Azure Data Lake Storage Gen2 URIs can store the container name in the
+        #   'username' field of a URL (@ syntax), so we need to add it to the path
+        # - Oracle Cloud Infrastructure (OCI) Object Storage filesystem (ocifs) also
+        #   uses the @ syntax for I/O operations: "oci://bucket@namespace/path_to_file"
+        if protocol in ["abfss", "oci"] and parsed_path.username:
             options["path"] = parsed_path.username + "@" + options["path"]
 
     return options

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -263,6 +263,7 @@ class TestCoreFunctions:
                 "abfss://mycontainer@mystorageaccount.dfs.core.windows.net/mypath",
                 ("abfss", "mycontainer@mystorageaccount.dfs.core.windows.net/mypath"),
             ),
+            ("oci://bucket@namespace/file.txt", ("oci", "bucket@namespace/file.txt")),
             ("hdfs://namenode:8020/file.txt", ("hdfs", "/file.txt")),
             ("file:///tmp/file.txt", ("file", "/tmp/file.txt")),
             ("/tmp/file.txt", ("file", "/tmp/file.txt")),


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Kedro currently does not support reading and writing from and to Oracle Cloud Infrastructure (OCI) Object Storage filesystem, because the "oci://" protocol is not included in the list of supported cloud protocols.

## Development notes
<!-- What have you changed, and how has this been tested? -->

Similarly to Azure Data Lake Storage Gen2 URIs, [OCI's Object Storage filesystem (ocifs)](https://ocifs.readthedocs.io/en/latest/) uses the @ syntax for I/O operations: "oci://bucket@namespace/path_to_file". 

Therefore, to make Kedro datasets work with OCIFS, I added "oci" to the `CLOUD_PROTOCOLS` list and included the same file path processing step done for Azure Data Lake Storage Gen2 URIs.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
