### PR TITLE
Standardise `.parquet` suffix in docs and tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@
 ## Breaking changes to the API
 ## Documentation changes
 * Updated CLI autocompletion docs with new Click syntax.
-* Standardise suffix `.parquet` in docs & tests.
+* Standardised `.parquet` suffix in docs and tests.
 
 ## Community contributions
 * [Hyewon Choi](https://github.com/hyew0nChoi)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 ## Breaking changes to the API
 ## Documentation changes
 * Updated CLI autocompletion docs with new Click syntax.
+* Standardize suffix `.parquet` in docs & tests.
 
 ## Community contributions
 * [Hyewon Choi](https://github.com/hyew0nChoi)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@
 ## Breaking changes to the API
 ## Documentation changes
 * Updated CLI autocompletion docs with new Click syntax.
-* Standardize suffix `.parquet` in docs & tests.
+* Standardise suffix `.parquet` in docs & tests.
 
 ## Community contributions
 * [Hyewon Choi](https://github.com/hyew0nChoi)

--- a/docs/source/data/kedro_dataset_factories.md
+++ b/docs/source/data/kedro_dataset_factories.md
@@ -164,21 +164,21 @@ entries share `type`, `file_format` and `save_args`:
 ```yaml
 processing.factory_data:
   type: spark.SparkDataset
-  filepath: data/processing/factory_data.pq
+  filepath: data/processing/factory_data.parquet
   file_format: parquet
   save_args:
     mode: overwrite
 
 processing.process_data:
   type: spark.SparkDataset
-  filepath: data/processing/process_data.pq
+  filepath: data/processing/process_data.parquet
   file_format: parquet
   save_args:
     mode: overwrite
 
 modelling.metrics:
   type: spark.SparkDataset
-  filepath: data/modelling/factory_data.pq
+  filepath: data/modelling/factory_data.parquet
   file_format: parquet
   save_args:
     mode: overwrite
@@ -189,7 +189,7 @@ This could be generalised to the following pattern:
 ```yaml
 "{layer}.{dataset_name}":
   type: spark.SparkDataset
-  filepath: data/{layer}/{dataset_name}.pq
+  filepath: data/{layer}/{dataset_name}.parquet
   file_format: parquet
   save_args:
     mode: overwrite
@@ -202,7 +202,7 @@ You can have multiple dataset factories in your catalog. For example:
 ```yaml
 "{namespace}.{dataset_name}@spark":
   type: spark.SparkDataset
-  filepath: data/{namespace}/{dataset_name}.pq
+  filepath: data/{namespace}/{dataset_name}.parquet
   file_format: parquet
 
 "{dataset_name}@csv":
@@ -255,11 +255,11 @@ Consider a catalog file with the following patterns:
 
 "preprocessed_{dataset_name}":
   type: pandas.ParquetDataset
-  filepath: data/02_intermediate/preprocessed_{dataset_name}.pq
+  filepath: data/02_intermediate/preprocessed_{dataset_name}.parquet
 
 "processed_{dataset_name}":
   type: pandas.ParquetDataset
-  filepath: data/03_primary/processed_{dataset_name}.pq
+  filepath: data/03_primary/processed_{dataset_name}.parquet
 
 "{dataset_name}_csv":
   type: pandas.CSVDataset
@@ -267,7 +267,7 @@ Consider a catalog file with the following patterns:
 
 "{namespace}.{dataset_name}_pq":
   type: pandas.ParquetDataset
-  filepath: data/03_primary/{dataset_name}_{namespace}.pq
+  filepath: data/03_primary/{dataset_name}_{namespace}.parquet
 
 "{default_dataset}":
   type: pickle.PickleDataset
@@ -315,11 +315,11 @@ shuttles:
 
 "preprocessed_{name}":
   type: pandas.ParquetDataset
-  filepath: data/02_intermediate/preprocessed_{name}.pq
+  filepath: data/02_intermediate/preprocessed_{name}.parquet
 
 "{default}":
   type: pandas.ParquetDataset
-  filepath: data/03_primary/{default}.pq
+  filepath: data/03_primary/{default}.parquet
 ```
 </details>
 
@@ -365,13 +365,13 @@ companies:
   filepath: data/01_raw/companies.csv
   type: pandas.CSVDataset
 model_input_table:
-  filepath: data/03_primary/model_input_table.pq
+  filepath: data/03_primary/model_input_table.parquet
   type: pandas.ParquetDataset
 preprocessed_companies:
-  filepath: data/02_intermediate/preprocessed_companies.pq
+  filepath: data/02_intermediate/preprocessed_companies.parquet
   type: pandas.ParquetDataset
 preprocessed_shuttles:
-  filepath: data/02_intermediate/preprocessed_shuttles.pq
+  filepath: data/02_intermediate/preprocessed_shuttles.parquet
   type: pandas.ParquetDataset
 reviews:
   filepath: data/01_raw/reviews.csv

--- a/docs/source/integrations/mlflow.md
+++ b/docs/source/integrations/mlflow.md
@@ -195,7 +195,7 @@ For that, you can make use of {ref}`runtime parameters <runtime-params>`:
 # Add the intermediate datasets to run only the inference
 X_test:
   type: pandas.ParquetDataset
-  filepath: data/05_model_input/X_test.pq
+  filepath: data/05_model_input/X_test.parquet
 
 y_test:
   type: pandas.CSVDataset  # https://github.com/pandas-dev/pandas/issues/54638

--- a/docs/source/tutorial/create_a_pipeline.md
+++ b/docs/source/tutorial/create_a_pipeline.md
@@ -200,11 +200,11 @@ Each of the nodes outputs a new dataset (`preprocessed_companies` and `preproces
 ```yaml
 preprocessed_companies:
   type: pandas.ParquetDataset
-  filepath: data/02_intermediate/preprocessed_companies.pq
+  filepath: data/02_intermediate/preprocessed_companies.parquet
 
 preprocessed_shuttles:
   type: pandas.ParquetDataset
-  filepath: data/02_intermediate/preprocessed_shuttles.pq
+  filepath: data/02_intermediate/preprocessed_shuttles.parquet
 ```
 </details>
 
@@ -290,7 +290,7 @@ The following entry in `conf/base/catalog.yml` saves the model input table datas
 ```yaml
 model_input_table:
   type: pandas.ParquetDataset
-  filepath: data/03_primary/model_input_table.pq
+  filepath: data/03_primary/model_input_table.parquet
 ```
 
 ## Test the example again

--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -38,7 +38,7 @@ def fake_catalog_config():
     config = {
         "parquet_{factory_pattern}": {
             "type": "pandas.ParquetDataset",
-            "filepath": "data/01_raw/{factory_pattern}.pq",
+            "filepath": "data/01_raw/{factory_pattern}.parquet",
             "credentials": "db_connection",
         },
         "csv_{factory_pattern}": {
@@ -55,7 +55,7 @@ def fake_catalog_config_resolved():
     config = {
         "parquet_example": {
             "type": "pandas.ParquetDataset",
-            "filepath": "data/01_raw/example.pq",
+            "filepath": "data/01_raw/example.parquet",
             "credentials": {"con": "foo"},
         },
         "csv_example": {
@@ -99,7 +99,7 @@ def fake_catalog_config_with_factories(fake_metadata):
     config = {
         "parquet_{factory_pattern}": {
             "type": "pandas.ParquetDataset",
-            "filepath": "data/01_raw/{factory_pattern}.pq",
+            "filepath": "data/01_raw/{factory_pattern}.parquet",
         },
         "csv_{factory_pattern}": {
             "type": "pandas.CSVDataset",
@@ -108,7 +108,7 @@ def fake_catalog_config_with_factories(fake_metadata):
         "explicit_ds": {"type": "pandas.CSVDataset", "filepath": "test.csv"},
         "{factory_pattern}_ds": {
             "type": "pandas.ParquetDataset",
-            "filepath": "data/01_raw/{factory_pattern}_ds.pq",
+            "filepath": "data/01_raw/{factory_pattern}_ds.parquet",
         },
         "partitioned_{factory_pattern}": {
             "type": "partitions.PartitionedDataset",
@@ -129,7 +129,7 @@ def fake_catalog_config_with_factories_resolved():
     config = {
         "parquet_example": {
             "type": "pandas.ParquetDataset",
-            "filepath": "data/01_raw/example.pq",
+            "filepath": "data/01_raw/example.parquet",
         },
         "csv_example": {
             "type": "pandas.CSVDataset",

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -38,7 +38,7 @@ def config_with_dataset_factories():
             },
             "audi_cars": {
                 "type": "pandas.ParquetDataset",
-                "filepath": "data/01_raw/audi_cars.pq",
+                "filepath": "data/01_raw/audi_cars.parquet",
             },
             "{type}_boats": {
                 "type": "pandas.CSVDataset",
@@ -84,7 +84,7 @@ def config_with_dataset_factories_with_default(config_with_dataset_factories):
 def config_with_dataset_factories_bad_pattern(config_with_dataset_factories):
     config_with_dataset_factories["catalog"]["{type}@planes"] = {
         "type": "pandas.ParquetDataset",
-        "filepath": "data/01_raw/{brand}_plane.pq",
+        "filepath": "data/01_raw/{brand}_plane.parquet",
     }
     return config_with_dataset_factories
 
@@ -95,7 +95,7 @@ def config_with_dataset_factories_only_patterns():
         "catalog": {
             "{namespace}_{dataset}": {
                 "type": "pandas.CSVDataset",
-                "filepath": "data/01_raw/{namespace}_{dataset}.pq",
+                "filepath": "data/01_raw/{namespace}_{dataset}.parquet",
             },
             "{country}_companies": {
                 "type": "pandas.CSVDataset",


### PR DESCRIPTION
## Description

As reported in #4253 , some documentation and tests created Parquet with nonstandard suffix `.pq` rather than the standard `.parquet`. 

## Development notes

Every `.pq` has been changed to `.parquet`.  This was in two test files and three in docs.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
