### PR TITLE
Add Python3.13 Support and housekeeping

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       os: ${{ matrix.os }}
@@ -36,7 +36,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       os: ${{ matrix.os }}
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/pip-compile.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -16,7 +16,7 @@ jobs:
           python-version: '3.11'
       - name: Install uv
         run: |
-          python -m pip install "uv==0.1.32"
+          python -m pip install "uv==0.4.29"
       - name: Install dependencies
         run: |
           uv pip install --system requests
@@ -52,7 +52,7 @@ jobs:
           python-version: '3.11'
       - name: Install uv
         run: |
-          python -m pip install "uv==0.1.32"
+          python -m pip install "uv==0.4.29"
       - name: Install dependencies
         run: |
           uv pip install --system build

--- a/.github/workflows/docs-only-checks.yml
+++ b/.github/workflows/docs-only-checks.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
     uses: ./.github/workflows/lint.yml
     with:
       os: ${{ matrix.os }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ default_stages: [pre-commit, manual]
 
 repos:
     - repo: https://github.com/astral-sh/ruff-pre-commit
-      rev: v0.6.1
+      rev: v0.7.1
       hooks:
         - id: ruff
           name: "ruff on kedro/, tests/ and docs/"

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ package: clean install
 	python -m pip install build && python -m build
 
 install-test-requirements:
-	python -m pip install "uv==0.1.32"
+	python -m pip install "uv==0.4.29"
 	uv pip install --system "kedro[test] @ ."
 
 install-pre-commit:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Major features and improvements
 * Implemented dict-like interface for `KedroDataCatalog`.
+* Added Python 3.13 support.
 
 **Note:** ``KedroDataCatalog`` is an experimental feature and is under active development. Therefore, it is possible we'll introduce breaking changes to this class, so be mindful of that if you decide to use it already. Let us know if you have any feedback about the ``KedroDataCatalog`` or ideas for new features.
 

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -21,7 +21,7 @@ if not sys.warnoptions:
     warnings.simplefilter("default", KedroDeprecationWarning)
     warnings.simplefilter("error", KedroPythonVersionWarning)
 
-if sys.version_info >= (3, 13):
+if sys.version_info >= (3, 14):
     warnings.warn(
         """Kedro is not yet fully compatible with this Python version.
 To proceed at your own risk and ignore this warning,

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -274,6 +274,7 @@ def _pull_package(  # noqa: PLR0913
         alias,
         destination,
     )
+    temp_dir.cleanup()
 
 
 def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:

--- a/kedro/framework/cli/micropkg.py
+++ b/kedro/framework/cli/micropkg.py
@@ -275,6 +275,7 @@ def _pull_package(  # noqa: PLR0913
         destination,
     )
     temp_dir.cleanup()
+    click.secho("dummy")
 
 
 def _pull_packages_from_manifest(metadata: ProjectMetadata) -> None:

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -5,7 +5,7 @@ import kedro
 
 def test_import_kedro_with_no_official_support_raise_error(mocker):
     """Test importing kedro with python>=3.14 should fail"""
-    mocker.patch("kedro.sys.version_info", (3, 13))
+    mocker.patch("kedro.sys.version_info", (3, 14))
 
     # We use the parent class to avoid issues with `exec_module`
     with pytest.raises(UserWarning) as excinfo:
@@ -16,7 +16,7 @@ def test_import_kedro_with_no_official_support_raise_error(mocker):
 
 def test_import_kedro_with_no_official_support_emits_warning(mocker):
     """Test importing kedro python>=3.14 and controlled warnings should work"""
-    mocker.patch("kedro.sys.version_info", (3, 13))
+    mocker.patch("kedro.sys.version_info", (3, 14))
     mocker.patch("kedro.sys.warnoptions", ["default:Kedro is not yet fully compatible"])
 
     # We use the parent class to avoid issues with `exec_module`

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,7 +4,7 @@ import kedro
 
 
 def test_import_kedro_with_no_official_support_raise_error(mocker):
-    """Test importing kedro with python>=3.13 should fail"""
+    """Test importing kedro with python>=3.14 should fail"""
     mocker.patch("kedro.sys.version_info", (3, 13))
 
     # We use the parent class to avoid issues with `exec_module`
@@ -15,7 +15,7 @@ def test_import_kedro_with_no_official_support_raise_error(mocker):
 
 
 def test_import_kedro_with_no_official_support_emits_warning(mocker):
-    """Test importing kedro python>=3.13 and controlled warnings should work"""
+    """Test importing kedro python>=3.14 and controlled warnings should work"""
     mocker.patch("kedro.sys.version_info", (3, 13))
     mocker.patch("kedro.sys.warnoptions", ["default:Kedro is not yet fully compatible"])
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fixed #4267 

## Development notes
<!-- What have you changed, and how has this been tested? -->
- bumping uv and ruff versions
- add python 3.13 support


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
