### PR TITLE
Add GH action to automatically label community issues

### DIFF
--- a/.github/workflows/label-community-issues.yml
+++ b/.github/workflows/label-community-issues.yml
@@ -1,0 +1,35 @@
+name: Label Community Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label_external_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if issue author is a member
+        id: check_author
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const issueAuthor = context.payload.issue.user.login;
+
+            // Check if the issue author is a member of the org
+            const { data: membership } = await github.orgs.getMembershipForUser({
+              org: owner,
+              username: issueAuthor
+            }).catch(() => ({ data: null }));
+
+            // Set an output for the membership status
+            return membership ? 'internal' : 'external';
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label issue if author is external
+        if: steps.check_author.outputs.result == 'external'
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'Community'


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
