### PR TITLE
Introducing Kedro Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 [![Total downloads](https://static.pepy.tech/badge/kedro)](https://pepy.tech/project/kedro)
 
 [![Powered by Kedro](https://img.shields.io/badge/powered_by-kedro-ffc900?logo=kedro)](https://kedro.org)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Kedro%20Guru-006BFF)](https://gurubase.io/g/kedro)
 
 ## What is Kedro?
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
 [![OpenSSF Best Practices](https://bestpractices.coreinfrastructure.org/projects/6711/badge)](https://bestpractices.coreinfrastructure.org/projects/6711)
 [![Monthly downloads](https://static.pepy.tech/badge/kedro/month)](https://pepy.tech/project/kedro)
 [![Total downloads](https://static.pepy.tech/badge/kedro)](https://pepy.tech/project/kedro)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Kedro%20Guru-006BFF)](https://gurubase.io/g/kedro)
 
 [![Powered by Kedro](https://img.shields.io/badge/powered_by-kedro-ffc900?logo=kedro)](https://kedro.org)
-[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20Kedro%20Guru-006BFF)](https://gurubase.io/g/kedro)
 
 ## What is Kedro?
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Kedro Guru](https://gurubase.io/g/kedro) to Gurubase. Kedro Guru uses the data from this repo and data from the [docs](https://docs.kedro.org/en/stable/) to answer questions by leveraging the LLM.

In this PR, I showcased the "Kedro Guru", which highlights that Kedro now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Kedro Guru in Gurubase, just let me know that's totally fine.
