### PR TITLE
Wizard automation: move issues labelled with more info needed to same column on Wizard board

### DIFF
--- a/.github/workflows/wizard-board.yml
+++ b/.github/workflows/wizard-board.yml
@@ -1,0 +1,16 @@
+name: Move to Needs more info on Wizard Board
+
+on:
+  issues:
+    types: [labeled]
+jobs:
+  Move_Labeled_Issue_On_Wizard_Board:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/move-labeled-or-milestoned-issue@v2.0
+      with:
+        action-token: "${{ secrets.GITHUB_TOKEN }}"
+        project-url: "https://github.com/orgs/kedro-org/projects/10"
+        column-name: "Needs more info"
+        label-name: "support: needs more info"
+        columns-to-ignore: ""


### PR DESCRIPTION
## Description
Any ticket labelled with `support: need more info` is automatically moved to the "Needs more info" column on [the wizard board](https://github.com/orgs/kedro-org/projects/10/views/3). I couldn't find an existing action to remove it from this column when the label is removed, so not super sure if this is actually useful.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
