### PR TITLE
Fix `--version` option for Kedro command

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -217,7 +217,7 @@ class KedroCLI(CommandCollection):
         combines them with the built-in ones (eventually overriding the
         built-in ones if they are redefined by plugins).
         """
-        return [*load_entry_points("global"), cli, global_commands]
+        return [cli, *load_entry_points("global"), global_commands]
 
     @property
     def project_groups(self) -> Sequence[click.MultiCommand]:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #4296 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Copying the comment from https://github.com/kedro-org/kedro/issues/4296#issuecomment-2456616327
> I figured out what the problem is:
> 
> https://github.com/kedro-org/kedro/blob/a1fae5018f35243a5e49a54a9dd3223b2c4ea743/kedro/framework/cli/cli.py#L220
> 
> Due to the changes in lazy loading PR, I re-ordered the global commands list to consider
> 
> * first the commands loaded from plugins,
> * then `cli` which is the group with `info` and the `version_option` decorator
> * and then the `global_commands` group which contains the `new` and `starter` lazy commands.
> 
> So if any plugin with global commands (eg. Kedro-Viz) is installed in your env, the `--version` option doesn't work. It works when you uninstall Kedro viz. Which is why it must be working in the CI and for @DimedS
> 
> The solution is simply to re-order the command groups to `[cli, *load_entry_points("global"), global_commands]` but that would mean that users can't overwrite `kedro info` which I think is acceptable.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
