### PR TITLE
Increase close time of info needed tickets to 28

### DIFF
--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: lee-dohm/no-response@v0.5.0
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           responseRequiredLabel: "support: needs more info"
           daysUntilClose: 28
           closeComment: >-

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -4,8 +4,8 @@ on:
   issue_comment:
     types: [created]
   schedule:
-    # Schedule for five minutes after the hour, every hour
-    - cron: '5 * * * *'
+    # Run every day at 9am (UTC time)
+    - cron: '0 9 * * *'
 
 jobs:
   noResponse:

--- a/.github/workflows/no-response.yml
+++ b/.github/workflows/no-response.yml
@@ -15,6 +15,6 @@ jobs:
         with:
           token: ${{ github.token }}
           responseRequiredLabel: "support: needs more info"
-          daysUntilClose: 14
+          daysUntilClose: 28
           closeComment: >-
             This issue has been closed due to lack of information. Feel free to re-open this issue if you're facing a similar problem. Please provide as much information as possible so we can help resolve your issue.


### PR DESCRIPTION
## Description
https://github.com/kedro-org/kedro/pull/4294#issuecomment-2461664133


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
