### PR TITLE
Deprecate LambdaDataset

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -103,6 +103,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 
 ## Upcoming deprecations for Kedro 0.20.0
 * The utility method `get_pkg_version()` is deprecated and will be removed in Kedro 0.20.0.
+* `LambdaDataset` is deprecated and will be removed in Kedro 0.20.0.
 
 ## Documentation changes
 * Improved documentation for configuring dataset parameters in the data catalog

--- a/docs/source/nodes_and_pipelines/run_a_pipeline.md
+++ b/docs/source/nodes_and_pipelines/run_a_pipeline.md
@@ -238,6 +238,10 @@ Out[11]: {'v': 0.666666666666667}
 
 We can also use IO to save outputs to a file. In this example, we define a custom `LambdaDataset` that would serialise the output to a file locally:
 
+```{warning}
+`LambdaDataset` has been deprecated and will be removed in Kedro `0.20.0`.
+```
+
 <details>
 <summary><b>Click to expand</b></summary>
 

--- a/kedro/io/lambda_dataset.py
+++ b/kedro/io/lambda_dataset.py
@@ -5,8 +5,10 @@ providing custom load, save, and exists methods without extending
 
 from __future__ import annotations
 
+import warnings
 from typing import Any, Callable
 
+from kedro import KedroDeprecationWarning
 from kedro.io.core import AbstractDataset, DatasetError
 
 
@@ -100,6 +102,12 @@ class LambdaDataset(AbstractDataset):
             DatasetError: If a method is specified, but is not a Callable.
 
         """
+
+        warnings.warn(
+            "`LambdaDataset` has been deprecated and will be removed in Kedro 0.20.0.",
+            KedroDeprecationWarning,
+        )
+
         for name, value in [
             ("load", load),
             ("save", save),

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -82,7 +82,7 @@ def test_ephemeral_attribute(mocked_dataset):
     assert mocked_dataset._EPHEMERAL is False
 
 
-def test_lambda_dataset_deprecated():
+def test_lambda_dataset_deprecation():
     with pytest.warns(
         KedroDeprecationWarning,
         match=r"\`LambdaDataset\` has been deprecated",

--- a/tests/io/test_lambda_dataset.py
+++ b/tests/io/test_lambda_dataset.py
@@ -1,5 +1,6 @@
 import pytest
 
+from kedro import KedroDeprecationWarning
 from kedro.io import DatasetError, LambdaDataset
 
 
@@ -79,6 +80,14 @@ def test_dataset_describe():
 
 def test_ephemeral_attribute(mocked_dataset):
     assert mocked_dataset._EPHEMERAL is False
+
+
+def test_lambda_dataset_deprecated():
+    with pytest.warns(
+        KedroDeprecationWarning,
+        match=r"\`LambdaDataset\` has been deprecated",
+    ):
+        _ = LambdaDataset(None, None)
 
 
 class TestLambdaDatasetLoad:


### PR DESCRIPTION
## Description

Resolves #4292 

## Development notes

* Add deprecate warning for LambdaDataset
* Update tests
* Update Release note


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
