### PR TITLE
Add link to advanced runtime_params configuration

### DIFF
--- a/docs/source/configuration/parameters.md
+++ b/docs/source/configuration/parameters.md
@@ -169,3 +169,6 @@ kedro run --params="key1=value with spaces,key2=value"
 ```
 
 Since key-value pairs are split on the first equals sign, values can contain equals signs, but keys cannot.
+
+
+> **Note:** If you want to override values of certain keys in your configuration with runtime parameters provided through the CLI option, you can use the [OmegaConfigLoader `runtime_params` resolver](advanced_configuration.md#how-to-override-configuration-with-runtime-parameters-with-the-omegaconfigloader).


### PR DESCRIPTION
## Description
Closes #3562 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
