### PR TITLE
Improve OmegaConfigLoader performance

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,7 @@
 
 ## Major features and improvements
 * Implemented `KedroDataCatalog.to_config()` method that converts the catalog instance into a configuration format suitable for serialization.
+* Improve OmegaConfigLoader performance
 
 ## Bug fixes and other changes
 * Added validation to ensure dataset versions consistency across catalog.

--- a/docs/source/contribution/technical_steering_committee.md
+++ b/docs/source/contribution/technical_steering_committee.md
@@ -56,7 +56,7 @@ We look for commitment markers who can do the following:
 | Name                                                     | Organisation                                                                            |
 |----------------------------------------------------------|---------------------------------------------------------------------------------------- |
 | [Ankita Katiyar](https://github.com/ankatiyar)           | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
-| [Deepyaman Datta](https://github.com/deepyaman)          | [Voltron Data](https://voltrondata.com)                                                 |
+| [Deepyaman Datta](https://github.com/deepyaman)          | [Dagster Labs](https://dagster.io/about)                                                |
 | [Dmitry Sorokin](https://github.com/DimedS)              | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Huong Nguyen](https://github.com/Huongg)                | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |
 | [Ivan Danov](https://github.com/idanov)                  | [QuantumBlack, AI by McKinsey](https://www.mckinsey.com/capabilities/quantumblack)      |

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -347,12 +347,11 @@ class OmegaConfigLoader(AbstractConfigLoader):
                 OmegaConf.merge(*aggregate_config, self.runtime_params), resolve=True
             )
 
+        merged_config_container = OmegaConf.to_container(
+            OmegaConf.merge(*aggregate_config), resolve=True
+        )
         return {
-            k: v
-            for k, v in OmegaConf.to_container(
-                OmegaConf.merge(*aggregate_config), resolve=True
-            ).items()
-            if not k.startswith("_")
+            k: v for k, v in merged_config_container.items() if not k.startswith("_")
         }
 
     @staticmethod

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -126,7 +126,8 @@ class OmegaConfigLoader(AbstractConfigLoader):
         self.base_env = base_env or ""
         self.default_run_env = default_run_env or ""
         self.merge_strategy = merge_strategy or {}
-
+        self._globals_oc = None
+        self._runtime_params_oc = None
         self.config_patterns = {
             "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
             "parameters": ["parameters*", "parameters*/**", "**/parameters*"],
@@ -436,9 +437,12 @@ class OmegaConfigLoader(AbstractConfigLoader):
             raise InterpolationResolutionError(
                 "Keys starting with '_' are not supported for globals."
             )
-        globals_oc = OmegaConf.create(self._globals)
+
+        if not self._globals_oc:
+            self._globals_oc = OmegaConf.create(self._globals)
+
         interpolated_value = OmegaConf.select(
-            globals_oc, variable, default=default_value
+            self._globals_oc, variable, default=default_value
         )
         if interpolated_value != _NO_VALUE:
             return interpolated_value
@@ -449,9 +453,11 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
     def _get_runtime_value(self, variable: str, default_value: Any = _NO_VALUE) -> Any:
         """Return the runtime params values to the resolver"""
-        runtime_oc = OmegaConf.create(self.runtime_params)
+        if not self._runtime_params_oc:
+            self._runtime_params_oc = OmegaConf.create(self.runtime_params)
+
         interpolated_value = OmegaConf.select(
-            runtime_oc, variable, default=default_value
+            self._runtime_params_oc, variable, default=default_value
         )
         if interpolated_value != _NO_VALUE:
             return interpolated_value

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -126,8 +126,8 @@ class OmegaConfigLoader(AbstractConfigLoader):
         self.base_env = base_env or ""
         self.default_run_env = default_run_env or ""
         self.merge_strategy = merge_strategy or {}
-        self._globals_oc = None
-        self._runtime_params_oc = None
+        self._globals_oc: DictConfig | None = None
+        self._runtime_params_oc: DictConfig | None = None
         self.config_patterns = {
             "catalog": ["catalog*", "catalog*/**", "**/catalog*"],
             "parameters": ["parameters*", "parameters*/**", "**/parameters*"],


### PR DESCRIPTION
## Description

Resolves #4322 

## Development notes

* As mentioned by @noklam [here](https://github.com/kedro-org/kedro/issues/4322#issuecomment-2483303870), this PR makes a quick fix for `_get_globals_value` and `_get_runtime_value` by not re-creating `_globals` and `runtime_params` for each reference in the catalog
* As mentioned by @Matthias [here](https://kedro-org.slack.com/archives/C03RKP2LW64/p1734358543251079?thread_ts=1734014203.927209&cid=C03RKP2LW64), separated the config merge and underscore filter which improved the performance as well
* This is a minor improvement to the performance of OCL. The bottleneck still remains the use of 
[OmegaConf.load](https://omegaconf.readthedocs.io/en/2.3_branch/_modules/omegaconf/omegaconf.html#OmegaConf)
[OmegaConf.to_container](https://omegaconf.readthedocs.io/en/2.3_branch/api_reference.html#omegaconf.OmegaConf.to_container)
[OmegaConf.merge](https://omegaconf.readthedocs.io/en/2.3_branch/api_reference.html#omegaconf.OmegaConf.merge)

**Test Data**



```yaml
# globals.yml

compression_type: '${random_choice: gzip, bz2, xz, None}'
random_seed: 42
separator: "${random_choice: ,, \t, |}"
```

```yaml
# catalog.yml with variable number of entries

interpolated_dataset_3610:
  filepath: data/interpolated_dataset_3610.csv
  load_args:
    encoding: '${random_choice: utf-8, iso-8859-1, utf-16}'
    sep: ${globals:separator}
  save_args:
    compression: ${globals:compression_type}
    index: false
  type: pandas.CSVDataSet
```

**Before:**

![10 datasets with variable interpolation 10](https://github.com/user-attachments/assets/1e010304-3a55-46ce-a810-634610c492c8)

<img width="999" alt="Pasted Graphic 9" src="https://github.com/user-attachments/assets/85ff1caf-c614-4283-b755-f72d441fe561">

<hr>

**After:**

![image](https://github.com/user-attachments/assets/ff8dcd72-ddff-46ec-97bc-0c119937f3a8)

![image](https://github.com/user-attachments/assets/5916d150-b3f1-47b3-988d-8f7e06c25bf9)

<hr>

**Observation:**
There is a slight improvement in the performance as seen above

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
