### PR TITLE
Remove checkout branch check when not an official starter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 
 ## Bug fixes and other changes
 * Added validation to ensure dataset versions consistency across catalog.
+* Fixed a bug in project creation when using a custom starter template offline.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/docs/source/deployment/databricks/databricks_deployment_workflow.md
+++ b/docs/source/deployment/databricks/databricks_deployment_workflow.md
@@ -254,7 +254,7 @@ The Databricks API enables you to programmatically interact with Databricks serv
 1. [Set up your Kedro project for deployment on Databricks](#set-up-your-project-for-deployment-to-databricks)
 2. Create a JSON file containing your job's configuration.
 3. Use the Jobs API's [`/create` endpoint](https://docs.databricks.com/en/reference/jobs-2.0-api.html#create) to create a new job.
-4. Use the Jobs API's [`/runs/submit` endpoint](https://docs.databricks.com/workflows/jobs/jobs-api-updates.html#runs-submit) to run your newly created job.
+4. Use the Jobs API's [`/runs/submit` endpoint](https://docs.databricks.com/en/reference/jobs-2.0-api.html#runs-submit) to run your newly created job.
 
 ### How to use the Databricks CLI to automatically deploy a Kedro project
 

--- a/docs/source/deployment/databricks/databricks_deployment_workflow.md
+++ b/docs/source/deployment/databricks/databricks_deployment_workflow.md
@@ -253,7 +253,7 @@ The Databricks API enables you to programmatically interact with Databricks serv
 
 1. [Set up your Kedro project for deployment on Databricks](#set-up-your-project-for-deployment-to-databricks)
 2. Create a JSON file containing your job's configuration.
-3. Use the Jobs API's [`/create` endpoint](https://docs.databricks.com/workflows/jobs/jobs-api-updates.html#create) to create a new job.
+3. Use the Jobs API's [`/create` endpoint](https://docs.databricks.com/en/reference/jobs-2.0-api.html#create) to create a new job.
 4. Use the Jobs API's [`/runs/submit` endpoint](https://docs.databricks.com/workflows/jobs/jobs-api-updates.html#runs-submit) to run your newly created job.
 
 ### How to use the Databricks CLI to automatically deploy a Kedro project

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -345,7 +345,6 @@ def new(  # noqa: PLR0913
         checkout = _select_checkout_branch_for_cookiecutter(checkout)
     elif starter_alias is not None:
         template_path = starter_alias
-        checkout = _select_checkout_branch_for_cookiecutter(checkout)
     else:
         template_path = str(TEMPLATE_PATH)
 

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -519,7 +519,7 @@ def _get_available_tags(template_path: str) -> list:
         # tags: ['/tags/version', '/tags/version^{}']
         # unique_tags: {'version'}
 
-    except git.GitCommandError:
+    except git.GitCommandError:  # pragma: no cover
         return []
     return sorted(unique_tags)
 

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -861,9 +861,6 @@ class TestNewWithStarterValid:
             "template": "git+https://github.com/fake/fake.git",
             "directory": None,
         }
-        starters_version = mock_determine_repo_dir.call_args[1].pop("checkout", None)
-
-        assert starters_version in [version, "main"]
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         del kwargs["directory"]
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
@@ -910,9 +907,6 @@ class TestNewWithStarterValid:
             "template": "git+https://github.com/fake/fake.git",
             "directory": "my_directory",
         }
-        starters_version = mock_determine_repo_dir.call_args[1].pop("checkout", None)
-
-        assert starters_version in [version, "main"]
         assert kwargs.items() <= mock_determine_repo_dir.call_args[1].items()
         assert kwargs.items() <= mock_cookiecutter.call_args[1].items()
 

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -936,26 +936,6 @@ class TestNewWithStarterInvalid:
         assert result.exit_code != 0
         assert "Kedro project template not found at invalid" in result.output
 
-    def test_invalid_starter_tag_suggestions(self, fake_kedro_cli):
-        result = CliRunner().invoke(
-            fake_kedro_cli,
-            [
-                "new",
-                "-v",
-                "--starter",
-                "https://github.com/kedro-org/kedro-starters.git",
-                "--directory",
-                "spaceflights-pandas",
-                "--checkout",
-                "invalid",
-            ],
-            input=_make_cli_prompt_input(),
-        )
-        assert result.exit_code != 0
-        assert (
-            "Specified tag invalid. The following tags are available:" in result.output
-        )
-
     @pytest.mark.parametrize(
         "starter, repo",
         [

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -936,6 +936,26 @@ class TestNewWithStarterInvalid:
         assert result.exit_code != 0
         assert "Kedro project template not found at invalid" in result.output
 
+    def test_invalid_starter_tag_suggestions(self, fake_kedro_cli):
+        result = CliRunner().invoke(
+            fake_kedro_cli,
+            [
+                "new",
+                "-v",
+                "--starter",
+                "https://github.com/kedro-org/kedro-starters.git",
+                "--directory",
+                "spaceflights-pandas",
+                "--checkout",
+                "invalid",
+            ],
+            input=_make_cli_prompt_input(),
+        )
+        assert result.exit_code != 0
+        assert (
+            "Specified tag invalid. The following tags are available:" in result.output
+        )
+
     @pytest.mark.parametrize(
         "starter, repo",
         [


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #4388 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Removed the check that happens in `_select_checkout_branch_for_cookicutter()` which was causing failures when the user is offline for cases when `--starter` is path to a template rather than an official starter.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
