### PR TITLE
Update error message when executing kedro run without pipeline

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 * Added validation to ensure dataset versions consistency across catalog.
 * Fixed a bug in project creation when using a custom starter template offline.
 * Added `node` import to the pipeline template.
+* Update error message when executing kedro run without pipeline.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/docs/source/get_started/new_project.md
+++ b/docs/source/get_started/new_project.md
@@ -133,7 +133,7 @@ kedro run
 ```
 
 ```{warning}
-`kedro run` requires at least one pipeline with nodes. Please define a pipeline before running this command, and ensure it is registred in `pipeline_registry.py`.
+`kedro run` requires at least one pipeline with nodes. Please define a pipeline before running this command and ensure it is registred in `pipeline_registry.py`.
 ```
 
 ```{note}

--- a/docs/source/get_started/new_project.md
+++ b/docs/source/get_started/new_project.md
@@ -133,7 +133,7 @@ kedro run
 ```
 
 ```{warning}
-`kedro run` requires at least one pipeline with nodes. Please define a pipeline before running this command.
+`kedro run` requires at least one pipeline with nodes. Please define a pipeline before running this command, and ensure it is registred in `pipeline_registry.py`.
 ```
 
 ```{note}

--- a/docs/source/get_started/new_project.md
+++ b/docs/source/get_started/new_project.md
@@ -132,6 +132,10 @@ Now run the project:
 kedro run
 ```
 
+```{warning}
+`kedro run` requires at least one pipeline with nodes. Please define a pipeline before running this command.
+```
+
 ```{note}
 The first time you type a `kedro` command in a new project, you will be asked whether you wish to opt into [usage analytics](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry). Your decision is recorded in the `.telemetry` file so that subsequent calls to `kedro` in this project do not ask this question again.
 ```

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -13,6 +13,7 @@ import shutil
 import stat
 import sys
 import tempfile
+import warnings
 from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
@@ -271,6 +272,13 @@ def _print_selection_and_prompt_info(
         click.secho(
             "It has been created with an example pipeline.",
             fg="green",
+        )
+    else:
+        warnings.warn(
+            "Your project does not contain any pipelines with nodes. "
+            "Please ensure that at least one pipeline has been defined before "
+            "executing 'kedro run'.",
+            UserWarning,
         )
 
     # Give hint for skipping interactive flow

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -772,7 +772,8 @@ class Pipeline:
 
         if not filtered_pipeline.nodes:
             raise ValueError(
-                "Pipeline contains no nodes after applying all provided filters"
+                "Pipeline contains no nodes after applying all provided filters. "
+                "Please ensure that at least one pipeline with nodes has been defined."
             )
         return filtered_pipeline
 


### PR DESCRIPTION
## Description

Resolves #3794 

## Development notes

* Add warning message for `kedro new` doc
* Add warning message when user selects no example pipeline when running `kedro new` without `--starter`
* Improve error message when user executes `kedro run` on an empty kedro project


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
