### PR TITLE
Safeguard hooks when user incorrectly registers a hook class in settings.py

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 * Added validation to ensure dataset versions consistency across catalog.
 * Fixed a bug in project creation when using a custom starter template offline.
 * Added `node` import to the pipeline template.
+* Safeguard hooks when user incorrectly registers a hook class in settings.py.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/kedro/framework/hooks/manager.py
+++ b/kedro/framework/hooks/manager.py
@@ -4,6 +4,7 @@ in a Kedro's execution process.
 
 import logging
 from collections.abc import Iterable
+from inspect import isclass
 from typing import Any
 
 from pluggy import PluginManager
@@ -48,6 +49,11 @@ def _register_hooks(hook_manager: PluginManager, hooks: Iterable[Any]) -> None:
         # case hooks have already been registered, so we perform a simple check
         # here to avoid an error being raised and break user's workflow.
         if not hook_manager.is_registered(hooks_collection):
+            if isclass(hooks_collection):
+                raise TypeError(
+                    "KedroSession expects hooks to be registered as instances. "
+                    "Have you forgotten the `()` when registering a hook class ?"
+                )
             hook_manager.register(hooks_collection)
 
 


### PR DESCRIPTION
## Description

Resolves #2769 

## Development notes

* Added a condition while registering the user defined hooks.
* Added pytest.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
