### PR TITLE
Remove outdated telemetry notification

### DIFF
--- a/docs/source/get_started/new_project.md
+++ b/docs/source/get_started/new_project.md
@@ -132,10 +132,6 @@ Now run the project:
 kedro run
 ```
 
-```{note}
-The first time you type a `kedro` command in a new project, you will be asked whether you wish to opt into [usage analytics](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry). Your decision is recorded in the `.telemetry` file so that subsequent calls to `kedro` in this project do not ask this question again.
-```
-
 ## Visualise a Kedro project
 
 This section swiftly introduces project visualisation using Kedro-Viz. See the {doc}`Kedro-Viz documentation<kedro-viz:kedro-viz_visualisation>` for more detail.


### PR DESCRIPTION
## Description
We have transitioned to an opt-out telemetry model (see [documentation](https://docs.kedro.org/en/stable/configuration/telemetry.html)), making this notification redundant and no longer necessary.  

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
