### PR TITLE
Document the convention for filepath related attributes in custom dataset creation

### DIFF
--- a/.github/workflows/docs-language-linter.yml
+++ b/.github/workflows/docs-language-linter.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: errata-ai/vale-action@reviewdog
         with:
           reporter: github-pr-check
+          version: 3.9.2 # temp

--- a/docs/source/data/how_to_create_a_custom_dataset.md
+++ b/docs/source/data/how_to_create_a_custom_dataset.md
@@ -40,6 +40,10 @@ This typing is optional however, and defaults to `Any` type.
 
 The `_EPHEMERAL` boolean attribute in `AbstractDataset` indicates if a dataset is persistent. For example, in the case of {py:class}`~kedro.io.MemoryDataset`, which is not persistent, it is set to True. By default, `_EPHEMERAL` is set to False.
 
+```{note}
+The parameter to specify the location of the data file/folder must be called either `filename`, `filepath`, or `path` in the constructor function of the custom dataset class to comply with the Kedro convention.
+```
+
 Here is an example skeleton for `ImageDataset`:
 
 <details>


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolve #2942 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Added a note to the custom dataset creation docs page

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
