### PR TITLE
Update lazy dataset representation

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -91,6 +91,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -211,9 +215,9 @@
         "filename": "tests/io/test_kedro_data_catalog.py",
         "hashed_secret": "15dd2c9ccec914f1470b4dccb45789844e49cf70",
         "is_verified": false,
-        "line_number": 499
+        "line_number": 501
       }
     ]
   },
-  "generated_at": "2025-01-27T18:47:13Z"
+  "generated_at": "2025-01-28T14:51:20Z"
 }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 * Updated `Partitioned dataset lazy saving` docs page.
 * Fixed `KedroDataCatalog` mutation after pipeline run.
 * Made `KedroDataCatalog._datasets` compatible with `DataCatalog._datasets`.
+* Updated `_LazyDataset` representation when printing `KedroDataCatalog`.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -2,6 +2,8 @@
 
 ## Major features and improvements
 ## Bug fixes and other changes
+* Updated `_LazyDataset` representation when printing `KedroDataCatalog`.
+
 ## Breaking changes to the API
 ## Documentation changes
 
@@ -25,7 +27,6 @@
 * Updated `Partitioned dataset lazy saving` docs page.
 * Fixed `KedroDataCatalog` mutation after pipeline run.
 * Made `KedroDataCatalog._datasets` compatible with `DataCatalog._datasets`.
-* Updated `_LazyDataset` representation when printing `KedroDataCatalog`.
 
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:

--- a/kedro/io/kedro_data_catalog.py
+++ b/kedro/io/kedro_data_catalog.py
@@ -27,6 +27,7 @@ from kedro.io.core import (
     Version,
     _validate_versions,
     generate_timestamp,
+    parse_dataset_definition,
 )
 from kedro.io.memory_dataset import MemoryDataset, _is_memory_dataset
 from kedro.utils import _format_rich, _has_rich_handler
@@ -48,7 +49,8 @@ class _LazyDataset:
         self.save_version = save_version
 
     def __repr__(self) -> str:
-        return f"{self.config.get('type', 'UnknownType')}"
+        class_type, _ = parse_dataset_definition(self.config)
+        return f"{class_type.__module__}.{class_type.__qualname__}"
 
     def materialize(self) -> AbstractDataset:
         return AbstractDataset.from_config(

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -271,7 +271,9 @@ class TestKedroDataCatalog:
 
     def test_repr_no_type_found(self, data_catalog_from_config):
         del data_catalog_from_config._lazy_datasets["boats"].config["type"]
-        assert data_catalog_from_config.__repr__() == str(data_catalog_from_config)
+        pattern = "'type' is missing from dataset catalog configuration"
+        with pytest.raises(DatasetError, match=re.escape(pattern)):
+            _ = str(data_catalog_from_config)
 
     def test_missing_keys_from_load_versions(self, correct_config):
         """Test load versions include keys missing in the catalog"""

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -266,8 +266,8 @@ class TestKedroDataCatalog:
         assert isinstance(catalog["ds"], CSVDataset)
         assert isinstance(catalog["df"], MemoryDataset)
 
-    def test_repr(self, data_catalog):
-        assert data_catalog.__repr__() == str(data_catalog)
+    def test_repr(self, data_catalog_from_config):
+        assert data_catalog_from_config.__repr__() == str(data_catalog_from_config)
 
     def test_repr_no_type_found(self, data_catalog_from_config):
         del data_catalog_from_config._lazy_datasets["boats"].config["type"]


### PR DESCRIPTION
## Description
Updated lazy dataset representation to print full dataset type paths.

Needed for consistency with `AbstarctDataset.__repr__` and https://github.com/kedro-org/kedro/pull/4449.

## Development notes
Before
```console
>>> catalog
>>> {'shuttle_id_dataset': pandas.SQLQueryDataset, 'shuttles': pandas.ExcelDataset}
```

After
```console
>>> catalog
>>> {'shuttle_id_dataset': kedro_datasets.pandas.sql_dataset.SQLQueryDataset, 'shuttles': kedro_datasets.pandas.excel_dataset.ExcelDataset}
```


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
