### PR TITLE
Fix inferred copy mode for Ibis tables in `MemoryDataset`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes and other changes
 * Updated `_LazyDataset` representation when printing `KedroDataCatalog`.
-
+* Fixed `MemoryDataset` to infer `assign` copy mode for Ibis Tables, which previously would be inferred as `deepcopy`.
 ## Breaking changes to the API
 ## Documentation changes
 

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -102,10 +102,14 @@ def _infer_copy_mode(data: Any) -> str:
         import numpy as np
     except ImportError:  # pragma: no cover
         np = None  # type: ignore[assignment] # pragma: no cover
+    try:
+        import ibis
+    except ImportError:  # pragma: no cover
+        ibis = None  # tpye: ignore[assignment] # pragma: no cover
 
     if pd and isinstance(data, pd.DataFrame) or np and isinstance(data, np.ndarray):
         copy_mode = "copy"
-    elif type(data).__name__ == "DataFrame":
+    elif type(data).__name__ == "DataFrame" or ibis and isinstance(data, ibis.Table):
         copy_mode = "assign"
     else:
         copy_mode = "deepcopy"

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -1,4 +1,5 @@
 import re
+import sys
 
 import numpy as np
 import pandas as pd
@@ -233,6 +234,17 @@ def test_infer_mode_assign():
         pass
 
     data = DataFrame()
+    copy_mode = _infer_copy_mode(data)
+    assert copy_mode == "assign"
+
+    # Ibis Table Type
+    class Table:
+        pass
+
+    fake_ibis = type(sys)("ibis")
+    fake_ibis.Table = Table
+    sys.modules["ibis"] = fake_ibis
+    data = Table()
     copy_mode = _infer_copy_mode(data)
     assert copy_mode == "assign"
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
- Presently, the inferred copy mode in `MemoryDataset` for [Ibis](https://ibis-project.org/) tables defaults to `deepcopy` introducing overhead without explicit entry in data catalog with `copy_mode` set to `assign`.

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Modified `_infer_copy_mode` method of `MemoryDataset` class to infer `copy_mode=assign` when data is of type `ibis.Table`
- Extended `test_infer_mode_assign` to capture these cases

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
