### PR TITLE
Change runner logic to not create pool for sequential runner

### DIFF
--- a/kedro/runner/sequential_runner.py
+++ b/kedro/runner/sequential_runner.py
@@ -5,10 +5,6 @@ of provided nodes.
 
 from __future__ import annotations
 
-from concurrent.futures import (
-    Executor,
-    ThreadPoolExecutor,
-)
 from typing import TYPE_CHECKING, Any
 
 from kedro.runner.runner import AbstractRunner
@@ -47,10 +43,8 @@ class SequentialRunner(AbstractRunner):
             is_async=is_async, extra_dataset_patterns=self._extra_dataset_patterns
         )
 
-    def _get_executor(self, max_workers: int) -> Executor:
-        return ThreadPoolExecutor(
-            max_workers=1
-        )  # Single-threaded for sequential execution
+    def _get_executor(self, max_workers: int) -> None:
+        return None
 
     def _run(
         self,


### PR DESCRIPTION
## Description
Address #4486 

## Development notes


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
