### PR TITLE
Add warning about runtime_params when using `OmegaConfigLoader` directly

### DIFF
--- a/docs/source/configuration/advanced_configuration.md
+++ b/docs/source/configuration/advanced_configuration.md
@@ -219,6 +219,11 @@ companies:
 ```
 If the `folder` parameter is not passed through the CLI `--params` option with `kedro run`, the default value `'data/01_raw/'` is used for the `filepath`.
 
+```{note}
+When manually instantiating `OmegaConfigLoader` in code, runtime parameters passed via the CLI `--params` option will not be available to the resolver. This occurs because the manually created config loader instance doesn't have access to the runtime parameters provided through the CLI.
+If you need to access runtime parameters in code that manually instantiates `OmegaConfigLoader`, you should instead use the Kedro context to access parameters.
+```
+
 #### How to use `globals` and `runtime_params`
 
 As mentioned above, `runtime_params` are not designed to override `globals` configuration. This is done to avoid unexplicit overrides and to simplify parameter resolutions. Thus, `globals` has only one entry point - the `yaml` file.


### PR DESCRIPTION
## Description
Related to: https://github.com/kedro-org/kedro/issues/4437

This PR adds a warning that runtime parameters passed via `--params` are not accessible when `OmegaConfigLoader` is manually instantiated in code.

This addresses issue #4437 where a user encountered errors when trying to use runtime parameters with a manually instantiated `OmegaConfigLoader`.

## Development notes

- Added a warning section

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
