### PR TITLE
Fix incorrect typing in generator example in `Nodes` docs

### DIFF
--- a/docs/source/nodes_and_pipelines/nodes.md
+++ b/docs/source/nodes_and_pipelines/nodes.md
@@ -235,7 +235,7 @@ Copy the following code to `nodes.py`. The main change is to use a new model `De
 
 ```python
 import logging
-from typing import Any, Dict, Tuple, Iterator
+from typing import Any, Dict, Tuple, Iterator, Generator
 from sklearn.preprocessing import LabelEncoder
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.metrics import accuracy_score
@@ -274,7 +274,7 @@ def split_data(
 
 def make_predictions(
     X_train: pd.DataFrame, X_test: pd.DataFrame, y_train: pd.Series
-) -> pd.Series:
+) -> Generator[pd.Series, None, None]:
     """Use a DecisionTreeClassifier model to make prediction."""
     model = DecisionTreeClassifier()
     model.fit(X_train, y_train)


### PR DESCRIPTION
## Description
Related to: https://github.com/kedro-org/kedro/issues/4527

Fixes the return type annotation in our generator docs example.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
