### PR TITLE
Update `DryRunner` docs implementation

### DIFF
--- a/docs/source/nodes_and_pipelines/run_a_pipeline.md
+++ b/docs/source/nodes_and_pipelines/run_a_pipeline.md
@@ -114,9 +114,6 @@ class DryRunner(AbstractRunner):
         self._logger.info("Checking inputs...")
         input_names = pipeline.inputs()
 
-        # Register the default dataset pattern with the catalog
-        catalog = catalog.shallow_copy(extra_dataset_patterns=self._extra_dataset_patterns)
-
         missing_inputs = [
             input_name
             for input_name in input_names

--- a/docs/source/nodes_and_pipelines/run_a_pipeline.md
+++ b/docs/source/nodes_and_pipelines/run_a_pipeline.md
@@ -113,10 +113,10 @@ class DryRunner(AbstractRunner):
         )
         self._logger.info("Checking inputs...")
         input_names = pipeline.inputs()
-        
+
         # Register the default dataset pattern with the catalog
         catalog = catalog.shallow_copy(extra_dataset_patterns=self._extra_dataset_patterns)
-        
+
         missing_inputs = [
             input_name
             for input_name in input_names


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Related to: https://github.com/kedro-org/kedro/issues/3609

This PR updates the DryRunner custom runner example in the documentation to align with changes made in #3332, which removed the `create_default_dataset` method in favour of using dataset factory patterns for default datasets.

## Development notes
<!-- What have you changed, and how has this been tested? -->

- Removed the deprecated `create_default_dataset` method from the `DryRunner` example in `docs/source/nodes_and_pipelines/run_a_pipeline.md`

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
