### PR TITLE
Fix ambiguous namespace matching in the `only_nodes_with_namespace` filter

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 * Changed the execution of `SequentialRunner` to not use an executor pool to ensure it's single threaded.
 * Fixed `%load_node` magic command to work with Jupyter Notebook `>=7.2.0`.
 * Remove `7: Kedro Viz` from Kedro tools.
+* Fixed pipeline filtering for namespace to return exact namespace matches instead of partial matches.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -455,7 +455,7 @@ class Pipeline:
         nodes = [
             n
             for n in self._nodes
-            if n.namespace and n.namespace.startswith(node_namespace)
+            if n.namespace and _match_namespaces(n.namespace, node_namespace)
         ]
         if not nodes:
             raise ValueError(
@@ -920,6 +920,12 @@ def _validate_transcoded_inputs_outputs(nodes: list[Node]) -> None:
             f"Please specify a transcoding option or "
             f"rename the datasets."
         )
+
+
+def _match_namespaces(node_namespace: str, filter_namespace: str):
+    return node_namespace.split(".")[
+        : len(filter_namespace.split("."))
+    ] == filter_namespace.split(".")
 
 
 class CircularDependencyError(Exception):


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #3448 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Implement `_match_namespaces()` helper function which returns exact matches instead of `startswith()`

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
