### PR TITLE
Fix the doc example on Custom Resolvers. 

### DIFF
--- a/docs/source/configuration/advanced_configuration.md
+++ b/docs/source/configuration/advanced_configuration.md
@@ -269,7 +269,7 @@ CONFIG_LOADER_ARGS = {
     "custom_resolvers": {
         "add": lambda *my_list: sum(my_list),
         "polars": lambda x: getattr(pl, x),
-        "today": lambda: date_today(),
+        "today": date_today,
     }
 }
 ```


### PR DESCRIPTION
## Description

A user was confused about how to use Custom Resolvers and used lambda everywhere because the documentation implied it was required. This PR clarifies that lambda is not required. 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
