### PR TITLE
Add `checkout` to cookiecutter args even for tools

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -13,6 +13,7 @@
 * Changed the execution of `SequentialRunner` to not use an executor pool to ensure it's single threaded.
 * Fixed `%load_node` magic command to work with Jupyter Notebook `>=7.2.0`.
 * Remove `7: Kedro Viz` from Kedro tools.
+* Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 
 ## Breaking changes to the API
 ## Documentation changes

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -845,14 +845,18 @@ def _make_cookiecutter_args_and_fetch_template(
     example_pipeline = config["example_pipeline"]
     starter_path = "git+https://github.com/kedro-org/kedro-starters.git"
 
-    cookiecutter_args["checkout"] = _select_checkout_branch_for_cookiecutter(checkout)
-
     if "PySpark" in tools:
         # Use the spaceflights-pyspark starter if only PySpark is chosen.
         cookiecutter_args["directory"] = "spaceflights-pyspark"
+        cookiecutter_args["checkout"] = _select_checkout_branch_for_cookiecutter(
+            checkout
+        )
     elif example_pipeline == "True":
         # Use spaceflights-pandas starter if example was selected, but PySpark wasn't
         cookiecutter_args["directory"] = "spaceflights-pandas"
+        cookiecutter_args["checkout"] = _select_checkout_branch_for_cookiecutter(
+            checkout
+        )
     else:
         # Use the default template path for non PySpark or example options:
         starter_path = template_path

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -840,6 +840,7 @@ def _make_cookiecutter_args_and_fetch_template(
 
     if directory:
         cookiecutter_args["directory"] = directory
+    cookiecutter_args["checkout"] = checkout
 
     tools = config["tools"]
     example_pipeline = config["example_pipeline"]

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -821,8 +821,7 @@ def _make_cookiecutter_args_and_fetch_template(
             ``extra_context`` to cookiecutter and will overwrite the cookiecutter.json
             defaults.
         checkout: The tag, branch or commit in the starter repository to checkout.
-            Maps directly to cookiecutter's ``checkout`` argument. Relevant only when
-            using a starter.
+            Maps directly to cookiecutter's ``checkout`` argument.
         directory: The directory of a specific starter inside a repository containing
             multiple starters. Maps directly to cookiecutter's ``directory`` argument.
             Relevant only when using a starter.
@@ -846,7 +845,7 @@ def _make_cookiecutter_args_and_fetch_template(
     example_pipeline = config["example_pipeline"]
     starter_path = "git+https://github.com/kedro-org/kedro-starters.git"
 
-    cookiecutter_args["checkout"] = checkout
+    cookiecutter_args["checkout"] = _select_checkout_branch_for_cookiecutter(checkout)
 
     if "PySpark" in tools:
         # Use the spaceflights-pyspark starter if only PySpark is chosen.


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #4589 
Actually the fix seems pretty simple - The issue was removal of setting `checkout` flag properly for `viz` and `pyspark` tool 
Instead of directly assigning `none` to `checkout` when not specified, set it using `_select_checkout_branch_for_cookiecutter()`


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
