### PR TITLE
Fix handling of trailing slashes in remote configuration URLs

### DIFF
--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -214,7 +214,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         # Load base env config
         # Handle remote paths
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
-            base_path = f"{self._remote_root_path}/{self.base_env}"
+            base_path = f"{self._remote_root_path.rstrip('/')}/{self.base_env}"
         elif self._protocol == "file":
             base_path = str(Path(self.conf_source) / self.base_env)
         else:
@@ -242,7 +242,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
         # Handle remote paths
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
-            env_path = f"{self._remote_root_path}/{run_env}"
+            env_path = f"{self._remote_root_path.rstrip('/')}/{run_env}"
         elif self._protocol == "file":
             env_path = str(Path(self.conf_source) / run_env)
         else:

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -154,7 +154,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         # Store remote root path if using cloud protocol
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
             options = _parse_filepath(conf_source)
-            self._remote_root_path = options["path"].rstrip('/')
+            self._remote_root_path = options["path"].rstrip("/")
 
         super().__init__(
             conf_source=conf_source,

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -154,7 +154,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         # Store remote root path if using cloud protocol
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
             options = _parse_filepath(conf_source)
-            self._remote_root_path = options["path"]
+            self._remote_root_path = options["path"].rstrip('/')
 
         super().__init__(
             conf_source=conf_source,
@@ -214,7 +214,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         # Load base env config
         # Handle remote paths
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
-            base_path = f"{self._remote_root_path.rstrip('/')}/{self.base_env}"
+            base_path = f"{self._remote_root_path}/{self.base_env}"
         elif self._protocol == "file":
             base_path = str(Path(self.conf_source) / self.base_env)
         else:
@@ -242,7 +242,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
         # Handle remote paths
         if self._protocol in CLOUD_PROTOCOLS or self._protocol in HTTP_PROTOCOLS:
-            env_path = f"{self._remote_root_path.rstrip('/')}/{run_env}"
+            env_path = f"{self._remote_root_path}/{run_env}"
         elif self._protocol == "file":
             env_path = str(Path(self.conf_source) / run_env)
         else:


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

When using `--conf-source` with a URL that includes a trailing slash (e.g., s3://bucket/path/), the command fails with a double slash error:

```
Given configuration path either does not exist or is not a valid directory: 
conf-bucket-kedro/s3_configs//base
```

## Development notes
<!-- What have you changed, and how has this been tested? -->

Normalise the remote root path by removing trailing slashes when it's first extracted.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
