### PR TITLE
Ensure dependencies come in a consistent order in grouped_nodes_by_namespace

### DIFF
--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -371,7 +371,11 @@ class Pipeline:
 
     @property
     def grouped_nodes_by_namespace(self) -> dict[str, dict[str, Any]]:
-        """Return a dictionary of the pipeline nodes grouped by top-level namespace."""
+        """Return a dictionary of the pipeline nodes grouped by top-level namespace with
+        information about the nodes, their type, and dependencies. The structure of the dictionary is:
+        {'node_name/namespace_name' : {'name': 'node_name/namespace_name','type': 'namespace' or 'node','nodes': [list of nodes],'dependencies': [list of dependencies]}}
+        This property is intended to be used by deployment plugins to group nodes by namespace.
+        """
         grouped_nodes: dict[str, dict[str, Any]] = defaultdict(dict)
 
         for node in self.nodes:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -397,7 +397,7 @@ class Pipeline:
                 parent_key = (
                     parent.namespace.split(".")[0] if parent.namespace else parent.name
                 )
-                if parent_key != key:
+                if parent_key != key and parent_key not in dependencies:
                     dependencies.append(parent_key)
 
             grouped_nodes[key]["dependencies"].extend(dependencies)

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -377,27 +377,31 @@ class Pipeline:
         This property is intended to be used by deployment plugins to group nodes by namespace.
         """
         grouped_nodes: dict[str, dict[str, Any]] = defaultdict(dict)
-        for node in self.nodes:
-            if node.namespace:
-                key = node.namespace.split(".")[0]  # only take top level namespace
-            else:
-                key = node.name
+        toposorted_nodes = [node for group in self.grouped_nodes for node in group]
+
+        for node in toposorted_nodes:
+            key = node.namespace.split(".")[0] if node.namespace else node.name
+
             if key not in grouped_nodes:
-                grouped_nodes[key] = {}
-                grouped_nodes[key]["name"] = key
-                grouped_nodes[key]["type"] = "namespace" if node.namespace else "node"
-                grouped_nodes[key]["nodes"] = []
-                grouped_nodes[key]["dependencies"] = set()
+                grouped_nodes[key] = {
+                    "name": key,
+                    "type": "namespace" if node.namespace else "node",
+                    "nodes": [],
+                    "dependencies": [],
+                }
+
             grouped_nodes[key]["nodes"].append(node)
-            dependencies = set()
+
+            dependencies = []
             for parent in self.node_dependencies[node]:
-                if parent.namespace:
-                    parent_namespace = parent.namespace.split(".")[0]
-                    if parent_namespace != key:
-                        dependencies.add(parent_namespace)
-                else:
-                    dependencies.add(parent.name)
-            grouped_nodes[key]["dependencies"].update(dependencies)
+                parent_key = (
+                    parent.namespace.split(".")[0] if parent.namespace else parent.name
+                )
+                if parent_key != key:
+                    dependencies.append(parent_key)
+
+            grouped_nodes[key]["dependencies"].extend(dependencies)
+
         return grouped_nodes
 
     def only_nodes(self, *node_names: str) -> Pipeline:

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -483,6 +483,18 @@ class TestValidPipeline:
                     "node_6": {"namespace_2"},
                 },
             ),
+            (
+                "pipeline_with_multiple_dependencies_on_one_node",
+                {
+                    "f1": [],
+                    "f2": ["f1"],
+                    "f3": ["f2"],
+                    "f4": ["f2"],
+                    "f5": ["f2"],
+                    "f6": ["f4"],
+                    "f7": ["f2", "f4"],
+                },
+            ),
         ],
     )
     def test_node_grouping_by_namespace_dependencies(
@@ -924,6 +936,21 @@ def pipeline_with_namespace_nested():
             node(identity, "E", "F", name="node_5", namespace="level1_2.level2"),
             node(identity, "F", "G", name="node_6", namespace="level1_2.level2"),
         ]
+    )
+
+
+@pytest.fixture
+def pipeline_with_multiple_dependencies_on_one_node():
+    return modular_pipeline(
+        [
+            node(identity, "ds1", "ds2", name="f1"),
+            node(lambda x: (x, x), "ds2", ["ds3", "ds4"], name="f2"),
+            node(identity, "ds3", "ds5", name="f3"),
+            node(identity, "ds3", "ds6", name="f4"),
+            node(identity, "ds4", "ds8", name="f5"),
+            node(identity, "ds6", "ds7", name="f6"),
+            node(lambda x, y: x, ["ds3", "ds6"], "ds9", name="f7"),
+        ],
     )
 
 

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -472,12 +472,12 @@ class TestValidPipeline:
         [
             (
                 "pipeline_with_namespace_simple",
-                {"namespace_1": set(), "namespace_2": {"namespace_1"}},
+                {"namespace_1": [], "namespace_2": {"namespace_1"}},
             ),
             (
                 "pipeline_with_namespace_partial",
                 {
-                    "namespace_1": set(),
+                    "namespace_1": [],
                     "node_3": {"namespace_1"},
                     "namespace_2": {"node_3"},
                     "node_6": {"namespace_2"},


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Changes the `pipeline.grouped_nodes_by_namespace` function to ensure dependencies are always inserted in the result object in the same order, preventing the flakiness that is causing issues in https://github.com/kedro-org/kedro-plugins/pull/1031.

Two changes were applied. The first was using the `self.grouped_nodes` property of the pipeline class to ensure the nodes are topologically ordered. Then dependencies are stored in a list instead of a set, to ensure insertion order is preserved. 

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
