### PR TITLE
feat/error-message-for-DataSet

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -567,6 +567,15 @@ def parse_dataset_definition(
         )
 
     dataset_type = config.pop(TYPE_KEY)
+
+    # This check prevents the use of dataset types with uppercase 'S' in 'Dataset',
+    # which is no longer supported as of Kedro 0.19.
+    if isinstance(dataset_type, str):
+        if dataset_type.endswith("Set"):
+            raise ValueError(
+                f"Since Kedro 0.19, 'Dataset' is spelled with a lowercase 's'. Got '{dataset_type}'."
+            )
+        
     class_obj = None
     if isinstance(dataset_type, str):
         if len(dataset_type.strip(".")) != len(dataset_type):

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -344,6 +344,13 @@ class TestCoreFunctions:
         with pytest.raises(DatasetError, match=pattern):
             parse_dataset_definition({"type": dataset_name})
 
+    def test_parse_dataset_definition_invalid_uppercase_s_in_dataset(self):
+        """Test that an invalid dataset type with uppercase 'S' in 'Dataset' raises a ValueError."""
+        config = {"type": "LambdaDataSet"}
+
+        with pytest.raises(ValueError, match="Since Kedro 0.19, 'Dataset' is spelled with a lowercase 's'."):
+            parse_dataset_definition(config)
+
     def test_parse_dataset_definition(self):
         config = {"type": "LambdaDataset"}
         dataset, _ = parse_dataset_definition(config)


### PR DESCRIPTION
## Description
Fixes #4580 

## Development notes
Include an extra check to  prevents the use of dataset types with uppercase 'S' in 'Dataset', which is no longer supported as of Kedro 0.19.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
