### PR TITLE
Apply namespace to `confirms` in modular pipelines to support namespaced IncrementalDatasets (#4039)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 ## Major features and improvements
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
+* Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
 ## Breaking changes to the API
 ## Documentation changes
 

--- a/kedro/pipeline/modular_pipeline.py
+++ b/kedro/pipeline/modular_pipeline.py
@@ -305,6 +305,7 @@ def pipeline(  # noqa: PLR0913
             inputs=_process_dataset_names(node._inputs),
             outputs=_process_dataset_names(node._outputs),
             namespace=new_namespace,
+            confirms=_process_dataset_names(node._confirms),
         )
         return node_copy
 

--- a/tests/pipeline/test_modular_pipeline.py
+++ b/tests/pipeline/test_modular_pipeline.py
@@ -79,6 +79,23 @@ class TestPipelineHelper:
         assert nodes[2]._inputs == {"input1": "PREFIX.H", "input2": "PREFIX.J"}
         assert nodes[2]._outputs == {"K": "PREFIX.L"}
 
+    def test_confirms_namespaced(self):
+        raw_pipeline = modular_pipeline(
+            [
+                node(
+                    identity,
+                    "input_data",
+                    "output_data",
+                    confirms="input_data",
+                    name="node1",
+                )
+            ]
+        )
+        resulting_pipeline = pipeline(raw_pipeline, namespace="ns")
+
+        node_ = resulting_pipeline.nodes[0]
+        assert node_._confirms == "ns.input_data"
+
     def test_prefixing_and_renaming(self):
         """
         Prefixing and renaming at the same time.


### PR DESCRIPTION
## Description

This PR fixes [#4039](https://github.com/kedro-org/kedro/issues/4039), which highlighted that the `confirms` attribute on `Node` objects does not automatically receive namespace prefixing when used in modular pipelines. As a result, `IncrementalDataset` with a namespace would fail to trigger expected checkpoint behaviour, unless a manual workaround (`confirms=f"{namespace}.dataset"`) was applied.

### What changed
In modular pipeline construction, we now apply `_process_dataset_names(...)` to the `confirms` field the same way it's applied to `inputs` and `outputs`. This ensures confirms are properly namespaced when a pipeline namespace is present:

```python
confirms=_process_dataset_names(node._confirms),
```

### Why it matters
This update ensures that `IncrementalDataset` and other use cases relying on `confirms` work seamlessly with namespaced pipelines. It also removes the need for the manual workaround proposed in the issue and aligns `confirms` behaviour with that of `inputs` and `outputs`.
