### PR TITLE
Docs/remove-unused-method

### DIFF
--- a/docs/source/extend_kedro/plugins.md
+++ b/docs/source/extend_kedro/plugins.md
@@ -55,7 +55,6 @@ When they run, plugins may request information about the current project by crea
 ```python
 from pathlib import Path
 
-from kedro.framework.startup import _get_project_metadata
 from kedro.framework.session import KedroSession
 
 


### PR DESCRIPTION
## Description
Fixes [4631](https://github.com/kedro-org/kedro/issues/4631)



## Development notes
Remove one un-used method in the documentation, spotted by the user. 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
