### PR TITLE
Deprecation warning for namespace

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
+* Add deprecation warning for `namespace`. 
 ## Breaking changes to the API
 ## Documentation changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
-* Add deprecation warning for `namespace`. 
+* Add deprecation warning for `namespace`.
 ## Breaking changes to the API
 ## Documentation changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,7 @@
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
+## Upcoming deprecations for Kedro 1.0.0
 * Add deprecation warning for `--namespace` option for `kedro run`. It will be replaced with `--namespaces` option which will allow for running multiple namespaces together.
 ## Breaking changes to the API
 ## Documentation changes

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
-* Add deprecation warning for `namespace`.
+* Add deprecation warning for `--namespace` option for `kedro run`. It will be replaced with `--namespaces` option which will allow for running multiple namespaces together.
 ## Breaking changes to the API
 ## Documentation changes
 

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -17,10 +17,10 @@ from kedro.framework.cli.utils import (
     call,
     env_option,
     forward_command,
+    namespace_deprecation_warning,
     split_node_names,
     split_string,
     validate_conf_source,
-    namespace_deprecation_warning,
 )
 from kedro.framework.project import settings
 from kedro.framework.session import KedroSession
@@ -181,7 +181,14 @@ def package(metadata: ProjectMetadata) -> None:
     callback=_split_load_versions,
 )
 @click.option("--pipeline", "-p", type=str, default=None, help=PIPELINE_ARG_HELP)
-@click.option("--namespace", "-ns", type=str, default=None, help=NAMESPACE_ARG_HELP, callback=namespace_deprecation_warning)
+@click.option(
+    "--namespace",
+    "-ns",
+    type=str,
+    default=None,
+    help=NAMESPACE_ARG_HELP,
+    callback=namespace_deprecation_warning,
+)
 @click.option(
     "--config",
     "-c",

--- a/kedro/framework/cli/project.py
+++ b/kedro/framework/cli/project.py
@@ -20,6 +20,7 @@ from kedro.framework.cli.utils import (
     split_node_names,
     split_string,
     validate_conf_source,
+    namespace_deprecation_warning,
 )
 from kedro.framework.project import settings
 from kedro.framework.session import KedroSession
@@ -180,7 +181,7 @@ def package(metadata: ProjectMetadata) -> None:
     callback=_split_load_versions,
 )
 @click.option("--pipeline", "-p", type=str, default=None, help=PIPELINE_ARG_HELP)
-@click.option("--namespace", "-ns", type=str, default=None, help=NAMESPACE_ARG_HELP)
+@click.option("--namespace", "-ns", type=str, default=None, help=NAMESPACE_ARG_HELP, callback=namespace_deprecation_warning)
 @click.option(
     "--config",
     "-c",

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -98,6 +98,7 @@ def forward_command(
 
     return wrapit
 
+
 def namespace_deprecation_warning(ctx=None, param=None, value=None):
     message = (
         "DeprecationWarning: 'kedro run' flag '--namespace' is deprecated "
@@ -106,6 +107,7 @@ def namespace_deprecation_warning(ctx=None, param=None, value=None):
     warnings.warn(message, KedroDeprecationWarning)
     click.secho(message, fg="red")
     return value
+
 
 def _suggest_cli_command(
     original_command_name: str, existing_command_names: Iterable[str]

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -98,6 +98,14 @@ def forward_command(
 
     return wrapit
 
+def namespace_deprecation_warning(ctx=None, param=None, value=None):
+    message = (
+        "DeprecationWarning: 'kedro run' flag 'namespace' will be deprecated "
+        "and will not be available from Kedro 1.0.0. "
+        "Use the flag 'namespaces' instead."
+    )
+    warnings.warn(message, KedroDeprecationWarning)
+    click.secho(message, fg="red")
 
 def _suggest_cli_command(
     original_command_name: str, existing_command_names: Iterable[str]

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -99,7 +99,11 @@ def forward_command(
     return wrapit
 
 
-def namespace_deprecation_warning(ctx=None, param=None, value=None):
+def namespace_deprecation_warning(
+    ctx: click.Context | None = None,
+    param: click.Parameter | None = None,
+    value: Any = None,
+) -> Any:
     message = (
         "DeprecationWarning: 'kedro run' flag '--namespace' is deprecated "
         "and will be replaced with '--namespaces' from Kedro 1.0.0 to allow running multiple namespaces. "

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -100,12 +100,12 @@ def forward_command(
 
 def namespace_deprecation_warning(ctx=None, param=None, value=None):
     message = (
-        "DeprecationWarning: 'kedro run' flag 'namespace' will be deprecated "
-        "and will not be available from Kedro 1.0.0. "
-        "Use the flag 'namespaces' instead."
+        "DeprecationWarning: 'kedro run' flag '--namespace' is deprecated "
+        "and will be replaced with '--namespaces' from Kedro 1.0.0 to allow running multiple namespaces. "
     )
     warnings.warn(message, KedroDeprecationWarning)
     click.secho(message, fg="red")
+    return value
 
 def _suggest_cli_command(
     original_command_name: str, existing_command_names: Iterable[str]


### PR DESCRIPTION
## Description
This PR is to create a deprecation warning for namespace, as a part of the change from [4614](https://github.com/kedro-org/kedro/pull/4614)

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
