### PR TITLE
add ruff as an optional dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ jupyter = [
 benchmark = [
     "asv"
 ]
-all = [ "kedro[test,docs,jupyter,benchmark]" ]
+format = ["ruff>=0.11.0"]
+lint = ["ruff>=0.11.0"]
+all = [ "kedro[test,docs,jupyter,benchmark,format,lint]" ]
 
 [project.urls]
 Homepage = "https://kedro.org"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,21 @@ classifiers = [
 dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
+benchmark = [
+    "asv"
+]
+docs = [
+    "ipykernel>=5.3, <7.0",
+    "Jinja2<3.2.0",
+    "kedro-sphinx-theme==2024.10.3",
+    "sphinx-notfound-page!=1.0.3",  # Required by kedro-sphinx-theme. 1.0.3 results in `AttributeError: 'tuple' object has no attribute 'default'`.
+]
+format = ["ruff>=0.11.0"]
+jupyter = [
+    "ipylab>=1.0.0",
+    "notebook>=7.0.0"  # requires the new share backend of notebook and labs"
+]
+lint = ["ruff>=0.11.0"]
 test = [
     "behave==1.2.6",
     "coverage[toml]",
@@ -81,21 +96,6 @@ test = [
     "types-requests",
     "types-toml",
 ]
-docs = [
-    "ipykernel>=5.3, <7.0",
-    "Jinja2<3.2.0",
-    "kedro-sphinx-theme==2024.10.3",
-    "sphinx-notfound-page!=1.0.3",  # Required by kedro-sphinx-theme. 1.0.3 results in `AttributeError: 'tuple' object has no attribute 'default'`.
-]
-jupyter = [
-    "ipylab>=1.0.0",
-    "notebook>=7.0.0"  # requires the new share backend of notebook and labs"
-]
-benchmark = [
-    "asv"
-]
-format = ["ruff>=0.11.0"]
-lint = ["ruff>=0.11.0"]
 all = [ "kedro[test,docs,jupyter,benchmark,format,lint]" ]
 
 [project.urls]


### PR DESCRIPTION
## Description

While Kedro have configuration for ruff in its pytoml, I noticed that Ruff is not listed as an optional dependency for Kedro.

## Development notes

- Added Ruff to Kedro `pyproject.toml` in two new labels: `format` and `lint`.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
