### PR TITLE
Add ruff to dependencies

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 ## Bug fixes and other changes
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
+* Add Ruff as an optional dependency for development.
 
 ## Upcoming deprecations for Kedro 1.0.0
 * Add deprecation warning for `--namespace` option for `kedro run`. It will be replaced with `--namespaces` option which will allow for running multiple namespaces together.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,7 +94,9 @@ jupyter = [
 benchmark = [
     "asv"
 ]
-all = [ "kedro[test,docs,jupyter,benchmark]" ]
+format = ["ruff>=0.11.0"]
+lint = ["ruff>=0.11.0"]
+all = [ "kedro[test,docs,jupyter,benchmark,format,lint]" ]
 
 [project.urls]
 Homepage = "https://kedro.org"


### PR DESCRIPTION
## Description

Ruff is specified in the pytoml, which I take to mean that Ruff is one of the accepted dev tools. At the same time, ruff is not listed a dependency in the pytoml. 

## Development notes

- Added a `format` and `lint` section to the pytoml which both specify using Ruff.
- No tests were added as this is presumably a tested feature of toml files and Ruff.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
