### PR TITLE
Cache dictionary inputs processing in Node class

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 * Fixed bug where project creation workflow would use the `main` branch version of `kedro-starters` instead of the respective release version.
 * Fixed namespacing for `confirms` during pipeline creation to support `IncrementalDataset`.
 * Fixed bug where `OmegaConf`cause an error during config resolution with runtime parameters.
+* Cached `inputs` in `Node` when created from dictionary for better performance.
 ## Breaking changes to the API
 
 
@@ -15,6 +16,10 @@
 * The `modular_pipeline` module is deprecated and will be removed in Kedro 1.0.0. Use the `pipeline` module instead.
 
 ## Documentation changes
+
+## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
+* [Arnout Verboven](https://github.com/ArnoutVerboven)
 
 # Release 0.19.12
 

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -128,6 +128,10 @@ class Node:
 
         self._func = func
         self._inputs = inputs
+        # Cache the list version of inputs dictionary to avoid recomputing in the inputs property
+        self._dict_inputs_as_list = None
+        if isinstance(self._inputs, dict):
+            self._dict_inputs_as_list = _dict_inputs_to_list(self._func, self._inputs)
         # The type of _outputs is picked up as possibly being None, however the checks above prevent that
         # ever being the case. Mypy doesn't get that though, so it complains about the assignment of outputs to
         # _outputs with different types.
@@ -247,6 +251,10 @@ class Node:
         """
         self._func = func
 
+        # Update cached inputs list if inputs is a dictionary
+        if isinstance(self._inputs, dict):
+            self._dict_inputs_as_list = _dict_inputs_to_list(self._func, self._inputs)
+
     @property
     def tags(self) -> set[str]:
         """Return the tags assigned to the node.
@@ -314,7 +322,7 @@ class Node:
 
         """
         if isinstance(self._inputs, dict):
-            return _dict_inputs_to_list(self._func, self._inputs)
+            return self._dict_inputs_as_list
         return _to_list(self._inputs)
 
     @property

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -128,10 +128,6 @@ class Node:
 
         self._func = func
         self._inputs = inputs
-        # Cache the list version of inputs dictionary to avoid recomputing in the inputs property
-        self._dict_inputs_as_list = None
-        if isinstance(self._inputs, dict):
-            self._dict_inputs_as_list = _dict_inputs_to_list(self._func, self._inputs)
         # The type of _outputs is picked up as possibly being None, however the checks above prevent that
         # ever being the case. Mypy doesn't get that though, so it complains about the assignment of outputs to
         # _outputs with different types.
@@ -251,9 +247,7 @@ class Node:
         """
         self._func = func
 
-        # Update cached inputs list if inputs is a dictionary
-        if isinstance(self._inputs, dict):
-            self._dict_inputs_as_list = _dict_inputs_to_list(self._func, self._inputs)
+        del self.inputs  # clear cached inputs
 
     @property
     def tags(self) -> set[str]:
@@ -312,7 +306,7 @@ class Node:
         """
         return self._namespace
 
-    @property
+    @cached_property
     def inputs(self) -> list[str]:
         """Return node inputs as a list, in the order required to bind them properly to
         the node's function.
@@ -322,7 +316,7 @@ class Node:
 
         """
         if isinstance(self._inputs, dict):
-            return self._dict_inputs_as_list
+            return _dict_inputs_to_list(self._func, self._inputs)
         return _to_list(self._inputs)
 
     @property


### PR DESCRIPTION
## Description
This PR addresses a performance issue in the Kedro framework related to the Node class. When nodes are provided with dictionary inputs, the inputs property recalculates _dict_inputs_to_list on every access, which becomes inefficient when running pipelines with many nodes. This optimization caches the conversion result to avoid redundant computation.

## Development notes
I've made the following changes:
<del>1. Added a _dict_inputs_as_list instance variable in Node.__init__ to cache the result of _dict_inputs_to_list for dictionary inputs
2. Modified the inputs property to use this cached value instead of recomputing it on every access
3. Updated the func setter to recalculate the cached value when the function is changed

EDIT:
1. Changed `@property` to `@cached_property` for the `inputs` method to cache the result
2. Updated the `func` setter to clear the cached property with a simple `del self.inputs` when the function changes

These changes are minimal and tested giving a significant performance improvement on a case with ~1k nodes.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
