### PR TITLE
Remove tests for tracking datasets

### DIFF
--- a/tests/io/conftest.py
+++ b/tests/io/conftest.py
@@ -139,19 +139,3 @@ def bad_config(filepath):
     return {
         "bad": {"type": "tests.io.test_data_catalog.BadDataset", "filepath": filepath}
     }
-
-
-@pytest.fixture
-def correct_config_with_tracking_ds(tmp_path):
-    boat_path = (tmp_path / "some" / "dir" / "test.csv").as_posix()
-    plane_path = (tmp_path / "some" / "dir" / "metrics.json").as_posix()
-    return {
-        "catalog": {
-            "boats": {
-                "type": "pandas.CSVDataset",
-                "filepath": boat_path,
-                "versioned": True,
-            },
-            "planes": {"type": "tracking.MetricsDataset", "filepath": plane_path},
-        },
-    }

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -680,30 +680,6 @@ class TestDataCatalogVersioned:
         with pytest.raises(DatasetNotFoundError, match=pattern):
             DataCatalog.from_config(**correct_config, load_versions=load_version)
 
-    def test_compare_tracking_and_other_dataset_versioned(
-        self, correct_config_with_tracking_ds, dummy_dataframe
-    ):
-        """Test saving of tracking datasets from config results in the same
-        save version as other versioned datasets."""
-
-        catalog = DataCatalog.from_config(**correct_config_with_tracking_ds)
-
-        catalog.save("boats", dummy_dataframe)
-        dummy_data = {"col1": 1, "col2": 2, "col3": 3}
-        catalog.save("planes", dummy_data)
-
-        # Verify that saved version on tracking dataset is the same as on the CSV dataset
-        csv_timestamp = datetime.strptime(
-            catalog.datasets.boats.resolve_save_version(),
-            VERSION_FORMAT,
-        )
-        tracking_timestamp = datetime.strptime(
-            catalog.datasets.planes.resolve_save_version(),
-            VERSION_FORMAT,
-        )
-
-        assert tracking_timestamp == csv_timestamp
-
     def test_load_version(self, correct_config, dummy_dataframe, mocker):
         """Test load versioned datasets from config"""
         new_dataframe = pd.DataFrame({"col1": [0, 0], "col2": [0, 0], "col3": [0, 0]})

--- a/tests/io/test_kedro_data_catalog.py
+++ b/tests/io/test_kedro_data_catalog.py
@@ -760,30 +760,6 @@ class TestKedroDataCatalog:
                     **correct_config, load_versions=load_version
                 )
 
-        def test_compare_tracking_and_other_dataset_versioned(
-            self, correct_config_with_tracking_ds, dummy_dataframe
-        ):
-            """Test saving of tracking datasets from config results in the same
-            save version as other versioned datasets."""
-
-            catalog = KedroDataCatalog.from_config(**correct_config_with_tracking_ds)
-
-            catalog.save("boats", dummy_dataframe)
-            dummy_data = {"col1": 1, "col2": 2, "col3": 3}
-            catalog.save("planes", dummy_data)
-
-            # Verify that saved version on tracking dataset is the same as on the CSV dataset
-            csv_timestamp = datetime.strptime(
-                catalog.datasets["boats"].resolve_save_version(),
-                VERSION_FORMAT,
-            )
-            tracking_timestamp = datetime.strptime(
-                catalog.datasets["planes"].resolve_save_version(),
-                VERSION_FORMAT,
-            )
-
-            assert tracking_timestamp == csv_timestamp
-
         def test_load_version(self, correct_config, dummy_dataframe, mocker):
             """Test load versioned datasets from config"""
             new_dataframe = pd.DataFrame(


### PR DESCRIPTION
## Description
With the latest `kedro-dataset` release the tracking datasets were removed (https://github.com/kedro-org/kedro-plugins/commit/da4af7e783ae38241175cb197ad419b9f52aa0f6). This made our builds fail, because the `kedro` codebase contains some tests specifically for the tracking datasets. 

## Development notes
I removed these tests as they are no longer needed.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
