### PR TITLE
Fix links in aws step function docs

### DIFF
--- a/docs/source/deployment/aws_step_functions.md
+++ b/docs/source/deployment/aws_step_functions.md
@@ -27,7 +27,7 @@ To use AWS Step Functions, ensure you have the following:
   - The final project directory's name should be `spaceflights-step-functions`.
   - You should complete the [spaceflights tutorial](../tutorial/spaceflights_tutorial.md) to understand the project's structure.
 
-* In this tutorial, we will also be using [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) to write our deployment script. To install the `cdk` command, please consult [AWS guide](https://docs.aws.amazon.com/cdk/latest/guide/cli.html). The official method of installation is using [npm](https://www.npmjs.com/):
+* In this tutorial, we will also be using [AWS Cloud Development Kit (CDK)](https://aws.amazon.com/cdk/) to write our deployment script. To install the `cdk` command, please consult [AWS guide](https://docs.aws.amazon.com/cdk/v2/guide/cli.html). The official method of installation is using [npm](https://www.npmjs.com/):
 
 ```console
 $ npm install -g aws-cdk

--- a/docs/source/deployment/aws_step_functions.md
+++ b/docs/source/deployment/aws_step_functions.md
@@ -216,7 +216,7 @@ $ docker push <your-aws-account-id>.dkr.ecr.<your-aws-region>.amazonaws.com/spac
 
 ### Step 3. Write the deployment script
 
-As you will write our deployment script using [AWS CDK in Python](https://docs.aws.amazon.com/cdk/latest/guide/work-with-cdk-python.html), you will have to install some required dependencies from CDK.
+As you will write our deployment script using [AWS CDK in Python](https://docs.aws.amazon.com/cdk/v2/guide/work-with-cdk-python.html), you will have to install some required dependencies from CDK.
 
 * **Step 3.1**: Create a `deploy_requirements.txt` with the following content:
 


### PR DESCRIPTION
## Description
Builds were failing because the link changed.

## Development notes



## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
