### PR TITLE
Make suggested resume commands copy-pasteable even when they extend over multiple lines

### DIFF
--- a/kedro/framework/project/rich_logging.yml
+++ b/kedro/framework/project/rich_logging.yml
@@ -9,10 +9,18 @@ handlers:
     # Advance options for customisation.
     # See https://docs.kedro.org/en/stable/logging/logging.html#project-side-logging-configuration
     # tracebacks_show_locals: False
+  
+  plain:
+    class: kedro.logging.PlainTextHandler
 
 loggers:
   kedro:
     level: INFO
+  
+  kedro.runner.plain:
+    level: INFO
+    handlers: [plain]
+    propagate: False
 
 root:
   handlers: [rich]

--- a/kedro/logging.py
+++ b/kedro/logging.py
@@ -13,6 +13,32 @@ import rich.traceback
 from kedro.utils import _is_databricks
 
 
+class PlainTextHandler(logging.StreamHandler):
+    """A simple handler that outputs log messages with minimal formatting.
+
+    This handler is designed for cases where plain text output without any fancy 
+    formatting, level indicators, timestamps or line wrapping is needed, such as
+    when providing shell command suggestions to users.
+    """
+
+    def __init__(self, stream=None):
+        super().__init__(stream)
+        # Create a formatter that only outputs the message without any additional info
+        self.formatter = logging.Formatter("%(message)s")
+
+    def emit(self, record: LogRecord) -> None:
+        # Skip level indicators entirely and just output the message
+        if record.levelno >= self.level:
+            try:
+                msg = self.formatter.format(record)
+                stream = self.stream
+                stream.write(msg)
+                stream.write(self.terminator)
+                self.flush()
+            except Exception:
+                self.handleError(record)
+
+
 class RichHandler(rich.logging.RichHandler):
     """Identical to rich's logging handler but with a few extra behaviours:
     * warnings issued by the `warnings` module are redirected to logging

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -343,8 +343,9 @@ class AbstractRunner(ABC):
                 f"There are {len(remaining_nodes)} nodes that have not run.\n"
                 "You can resume the pipeline run from the nearest nodes with "
                 "persisted inputs by adding the following "
-                f"argument to your previous command:\n{postfix}"
+                f"argument to your previous command:"
             )
+            self._plain_logger.warning(postfix)
 
     @staticmethod
     def _release_datasets(

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -66,6 +66,10 @@ class AbstractRunner(ABC):
     def _logger(self) -> logging.Logger:
         return logging.getLogger(self.__module__)
 
+    @property
+    def _plain_logger(self) -> logging.Logger:
+        return logging.getLogger("kedro.runner.plain")
+
     def run(
         self,
         pipeline: Pipeline,


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

- Adds a plain text log handler for log outputs that users benefit from being copy pasteable, such as suggested resume commands after pipeline failure
- Ensures such outputs are copy pasteable even for medium and large pipelines whose resume commands would span multiple lines
- The existing rich handler formats these with line breaks for text wrapping, padding spaces, etc, which means commands are not directly copy pasteable

## Development notes
<!-- What have you changed, and how has this been tested? -->

- Add a plain text log handler in `logging.py`
- Configure the plain text handler in `framework/project/rich_logging.yml` (where the rich handler is configured)
- Add the plain text handler as a property to the kedro runner in `runner/runner.py` (where the rich handler is used)
- Use the plain text handler for outputting the `postfix` variable in the `_suggest_resume_scenario` method, in `runner/runner.py`. The text preceding the suggested command is still to use the rich handler.

On testing, gives the following output for arbitrary error raised in a node:

<img width="1158" alt="image" src="https://github.com/user-attachments/assets/410fb88e-43cf-4a27-a848-435efdb616d4" />


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
