### PR TITLE
Align get() method with updated pattern resolution logic

### DIFF
--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -31,7 +31,7 @@ class CatalogConfigResolver:
         credentials: dict[str, dict[str, Any]] | None = None,
         runtime_patterns: Patterns | None = None,
     ):
-        if not runtime_patterns:
+        if runtime_patterns is None:
             self._logger.warning(
                 f"Since runtime patterns are not provided, setting"
                 f"the runtime pattern to default value: {DEFAULT_RUNTIME_PATTERN}"

--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -31,6 +31,11 @@ class CatalogConfigResolver:
         credentials: dict[str, dict[str, Any]] | None = None,
         runtime_patterns: Patterns | None = None,
     ):
+        if not runtime_patterns:
+            self._logger.warning(
+                f"Since runtime patterns are not provided, setting"
+                f"the runtime pattern to default value: {DEFAULT_RUNTIME_PATTERN}"
+            )
         self._runtime_patterns = runtime_patterns or DEFAULT_RUNTIME_PATTERN
         self._dataset_patterns, self._default_pattern = self._extract_patterns(
             config, credentials

--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -320,11 +320,10 @@ class CatalogConfigResolver:
 
     def resolve_pattern(self, ds_name: str) -> dict[str, Any]:
         """Resolve dataset patterns and return resolved configurations based on the existing patterns."""
-        matched_pattern = self.match_pattern(ds_name) or self.match_default_pattern(
-            ds_name
-        )
-
-        if matched_pattern and ds_name not in self._resolved_configs:
+        if ds_name not in self._resolved_configs:
+            matched_pattern = self.match_pattern(ds_name) or self.match_default_pattern(
+                ds_name
+            )
             pattern_config = self._get_pattern_config(matched_pattern)
             ds_config = self._resolve_dataset_config(
                 ds_name, matched_pattern, copy.deepcopy(pattern_config)
@@ -342,4 +341,4 @@ class CatalogConfigResolver:
                 )
             return ds_config  # type: ignore[no-any-return]
 
-        return self._resolved_configs.get(ds_name, {})
+        return self._resolved_configs.get(ds_name)

--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 Patterns = dict[str, dict[str, Any]]
 
 CREDENTIALS_KEY = "credentials"
+DEFAULT_RUNTIME_PATTERN = {"{default}": {"type": "kedro.io.MemoryDataset"}}
 
 
 class CatalogConfigResolver:
@@ -30,7 +31,7 @@ class CatalogConfigResolver:
         credentials: dict[str, dict[str, Any]] | None = None,
         runtime_patterns: Patterns | None = None,
     ):
-        self._runtime_patterns = runtime_patterns or {}
+        self._runtime_patterns = runtime_patterns or DEFAULT_RUNTIME_PATTERN
         self._dataset_patterns, self._default_pattern = self._extract_patterns(
             config, credentials
         )

--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -208,12 +208,13 @@ class CatalogConfigResolver:
         matches = self._get_matches(self._dataset_patterns.keys(), ds_name)
         return next(matches, None)
 
-    def match_default_pattern(self, ds_name: str) -> str | None:
+    def match_default_pattern(self, ds_name: str) -> str:
         """Match a dataset name against default patterns in a dictionary."""
         default_patters = set(self._default_pattern.keys())
         default_patters.update(set(self._runtime_patterns.keys()))
         matches = self._get_matches(default_patters, ds_name)
-        return next(matches, None)
+        # We assume runtime pattern always matches at the end
+        return next(matches)
 
     def _get_pattern_config(self, pattern: str) -> dict[str, Any]:
         return (
@@ -341,4 +342,4 @@ class CatalogConfigResolver:
                 )
             return ds_config  # type: ignore[no-any-return]
 
-        return self._resolved_configs.get(ds_name)
+        return self._resolved_configs[ds_name]

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -993,7 +993,7 @@ class CatalogProtocol(Protocol[_C, _DS]):
         """Returns an iterator for the object."""
         ...
 
-    def __getitem__(self, ds_name: str) -> _DS | None:
+    def __getitem__(self, ds_name: str) -> _DS:
         """Get a dataset by name from an internal collection of datasets."""
         ...
 

--- a/kedro/io/kedro_data_catalog.py
+++ b/kedro/io/kedro_data_catalog.py
@@ -253,7 +253,7 @@ class KedroDataCatalog(CatalogProtocol):
         if lazy_dataset:
             self[key] = lazy_dataset.materialize()
 
-        dataset = self._datasets.get(key)
+        dataset = self._datasets[key]
 
         if version and isinstance(dataset, AbstractVersionedDataset):
             # we only want to return a similar-looking dataset,

--- a/kedro/io/kedro_data_catalog.py
+++ b/kedro/io/kedro_data_catalog.py
@@ -163,7 +163,7 @@ class KedroDataCatalog(CatalogProtocol):
     def __iter__(self) -> Iterator[str]:
         yield from self.keys()
 
-    def __getitem__(self, ds_name: str) -> AbstractDataset | None:
+    def __getitem__(self, ds_name: str) -> AbstractDataset:
         """Get a dataset by name from an internal collection of datasets.
 
         If a dataset is not in the collection but matches any pattern

--- a/kedro/io/kedro_data_catalog.py
+++ b/kedro/io/kedro_data_catalog.py
@@ -231,32 +231,29 @@ class KedroDataCatalog(CatalogProtocol):
         self,
         key: str,
         version: Version | None = None,
-        default: AbstractDataset | None = None,
-    ) -> AbstractDataset | None:
+    ) -> AbstractDataset:
         """Get a dataset by name from an internal collection of datasets.
 
         If a dataset is not in the collection but matches any pattern
+        (by default it will match self.runtime_patterns)
         it is instantiated and added to the collection first, then returned.
 
         Args:
             key: A dataset name.
             version: Optional argument to get a specific version of the dataset.
-            default: Optional argument for default dataset to return in case
-                requested dataset not in the catalog.
 
         Returns:
             An instance of AbstractDataset.
         """
         if key not in self._datasets and key not in self._lazy_datasets:
             ds_config = self._config_resolver.resolve_pattern(key)
-            if ds_config:
-                self._add_from_config(key, ds_config)
+            self._add_from_config(key, ds_config)
 
         lazy_dataset = self._lazy_datasets.pop(key, None)
         if lazy_dataset:
             self[key] = lazy_dataset.materialize()
 
-        dataset = self._datasets.get(key, None) or default
+        dataset = self._datasets.get(key)
 
         if version and isinstance(dataset, AbstractVersionedDataset):
             # we only want to return a similar-looking dataset,
@@ -599,9 +596,10 @@ class KedroDataCatalog(CatalogProtocol):
             >>>                    'col3': [5, 6]})
             >>> catalog.save("cars", df)
         """
-        dataset = self.get(ds_name)
-        if dataset is None:
+        if ds_name not in self:
             raise DatasetNotFoundError(f"'{ds_name}' datasets not found in the catalog")
+
+        dataset = self.get(ds_name)
 
         self._logger.info(
             "Saving data to %s (%s)...",
@@ -641,9 +639,9 @@ class KedroDataCatalog(CatalogProtocol):
             >>> df = catalog.load("cars")
         """
         load_version = Version(version, None) if version else None
-        dataset = self.get(ds_name, version=load_version)
-        if dataset is None:
+        if ds_name not in self:
             raise DatasetNotFoundError(f"'{ds_name}' datasets not found in the catalog")
+        dataset = self.get(ds_name, version=load_version)
 
         self._logger.info(
             "Loading data from %s (%s)...",
@@ -654,52 +652,55 @@ class KedroDataCatalog(CatalogProtocol):
 
         return dataset.load()
 
-    def release(self, name: str) -> None:
+    def release(self, ds_name: str) -> None:
         """Release any cached data associated with a dataset
         Args:
-            name: A dataset to be checked.
+            ds_name: A dataset to be checked.
         Raises:
             DatasetNotFoundError: When a dataset with the given name
                 has not yet been registered.
         """
-        dataset = self.get(name)
-        if dataset is None:
-            raise DatasetNotFoundError(f"'{name}' datasets not found in the catalog")
+        if ds_name not in self:
+            raise DatasetNotFoundError(f"'{ds_name}' datasets not found in the catalog")
+
+        dataset = self.get(ds_name)
+
         dataset.release()
 
-    def confirm(self, name: str) -> None:
+    def confirm(self, ds_name: str) -> None:
         """Confirm a dataset by its name.
         Args:
-            name: Name of the dataset.
+            ds_name: Name of the dataset.
         Raises:
             DatasetError: When the dataset does not have `confirm` method.
         """
-        self._logger.info("Confirming dataset '%s'", name)
-        dataset = self.get(name)
-        if dataset is None:
-            raise DatasetNotFoundError(f"'{name}' datasets not found in the catalog")
+        self._logger.info("Confirming dataset '%s'", ds_name)
+        if ds_name not in self:
+            raise DatasetNotFoundError(f"'{ds_name}' datasets not found in the catalog")
+
+        dataset = self.get(ds_name)
 
         if hasattr(dataset, "confirm"):
             dataset.confirm()
         else:
-            raise DatasetError(f"Dataset '{name}' does not have 'confirm' method")
+            raise DatasetError(f"Dataset '{ds_name}' does not have 'confirm' method")
 
-    def exists(self, name: str) -> bool:
+    def exists(self, ds_name: str) -> bool:
         """Checks whether registered dataset exists by calling its `exists()`
         method. Raises a warning and returns False if `exists()` is not
         implemented.
 
         Args:
-            name: A dataset to be checked.
+            ds_name: A dataset to be checked.
 
         Returns:
             Whether the dataset output exists.
 
         """
-        dataset = self.get(name)
-
-        if dataset is None:
+        if ds_name not in self:
             return False
+
+        dataset = self.get(ds_name)
 
         return dataset.exists()
 


### PR DESCRIPTION
## Description
Related to https://github.com/kedro-org/kedro/issues/4476

After we've updated pattern resolution logic: https://github.com/kedro-org/kedro/issues/4475#issuecomment-2749010199, `catalog.get()` always returns a dataset based on the default runtime pattern set at the catalog level.

In this PR we've removed the setting `catalog.get()` default argument and processing the case when `get()` method returns `None` to align with the pattern resolution logic.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
