### PR TITLE
Update Click types to solve mypy errors

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -212,7 +212,7 @@ class KedroCLI(CommandCollection):
             raise
 
     @property
-    def global_groups(self) -> Sequence[click.MultiCommand]:
+    def global_groups(self) -> Sequence[click.Group]:
         """Property which loads all global command groups from plugins and
         combines them with the built-in ones (eventually overriding the
         built-in ones if they are redefined by plugins).
@@ -220,7 +220,7 @@ class KedroCLI(CommandCollection):
         return [cli, *load_entry_points("global"), global_commands]
 
     @property
-    def project_groups(self) -> Sequence[click.MultiCommand]:
+    def project_groups(self) -> Sequence[click.Group]:
         """Property which loads all project command groups from the
         project and the plugins, then combines them with the built-in ones.
         Built-in commands can be overridden by plugins, which can be

--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -157,7 +157,7 @@ def validate_conf_source(ctx: click.Context, param: Any, value: str) -> str | No
 class CommandCollection(click.CommandCollection):
     """Modified from the Click one to still run the source groups function."""
 
-    def __init__(self, *groups: tuple[str, Sequence[click.MultiCommand]]):
+    def __init__(self, *groups: tuple[str, Sequence[click.Group]]):
         self.groups = [
             (title, self._merge_same_name_collections(cli_list))
             for title, cli_list in groups
@@ -179,9 +179,9 @@ class CommandCollection(click.CommandCollection):
 
     @staticmethod
     def _merge_same_name_collections(
-        groups: Sequence[click.MultiCommand],
+        groups: Sequence[click.Group],
     ) -> list[click.CommandCollection]:
-        named_groups: defaultdict[str, list[click.MultiCommand]] = defaultdict(list)
+        named_groups: defaultdict[str, list[click.Group]] = defaultdict(list)
         helps: defaultdict[str, list] = defaultdict(list)
         for group in groups:
             named_groups[group.name].append(group)  # type: ignore[index]
@@ -409,7 +409,7 @@ def _safe_load_entry_point(
         return
 
 
-def load_entry_points(name: str) -> Sequence[click.MultiCommand]:
+def load_entry_points(name: str) -> Sequence[click.Group]:
     """Load package entry point commands.
 
     Args:
@@ -587,12 +587,12 @@ class LazyGroup(click.Group):
 
     def get_command(  # type: ignore[override]
         self, ctx: click.Context, cmd_name: str
-    ) -> click.BaseCommand | click.Command | None:
+    ) -> click.Command | click.Command | None:
         if cmd_name in self.lazy_subcommands:
             return self._lazy_load(cmd_name)
         return super().get_command(ctx, cmd_name)
 
-    def _lazy_load(self, cmd_name: str) -> click.BaseCommand:
+    def _lazy_load(self, cmd_name: str) -> click.Command:
         # lazily loading a command, first get the module name and attribute name
         import_path = self.lazy_subcommands[cmd_name]
         modname, cmd_object_name = import_path.rsplit(".", 1)


### PR DESCRIPTION
## Description
Click was updated and some classes were deprecated (https://github.com/pallets/click/releases/tag/8.2.0). We were referring  to these types for typing and this was failing the `lint` builds. 

## Development notes
Updated Click type annotations to the latest version.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
