### PR TITLE
Refactor grouped_nodes_by_namespace() to return structured GroupedNode list

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@
 * Renamed instances of `extra_params` and `_extra_params` to `runtime_params`.
 * Removed the `modular_pipeline` module and moved functionality to the `pipeline` module instead.
 * Renamed `ModularPipelineError` to `PipelineError`.
+* `Pipeline.grouped_nodes_by_namespace()` now returns a list of `GroupedNodes` instead of a dictionary. This change improves type safety and consistency for deployment plugin integrations.
 
 ## Migration guide from Kedro 0.19.* to 1.*
 [See the migration guide for 1.0.0 in the Kedro documentation](https://docs.kedro.org/en/latest/resources/migration.html).

--- a/kedro/pipeline/__init__.py
+++ b/kedro/pipeline/__init__.py
@@ -2,7 +2,7 @@
 data-driven pipelines.
 """
 
-from .node import Node, node
-from .pipeline import GroupedNode, Pipeline, pipeline
+from .node import GroupedNodes, Node, node
+from .pipeline import Pipeline, pipeline
 
-__all__ = ["node", "pipeline", "Node", "Pipeline", "GroupedNode"]
+__all__ = ["node", "pipeline", "Node", "Pipeline", "GroupedNodes"]

--- a/kedro/pipeline/__init__.py
+++ b/kedro/pipeline/__init__.py
@@ -3,6 +3,6 @@ data-driven pipelines.
 """
 
 from .node import Node, node
-from .pipeline import Pipeline, pipeline
+from .pipeline import GroupedNode, Pipeline, pipeline
 
-__all__ = ["node", "pipeline", "Node", "Pipeline"]
+__all__ = ["node", "pipeline", "Node", "Pipeline", "GroupedNode"]

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -9,6 +9,7 @@ import inspect
 import logging
 import re
 from collections import Counter
+from dataclasses import dataclass, field
 from functools import cached_property
 from typing import TYPE_CHECKING, Any, Callable
 from warnings import warn
@@ -19,6 +20,20 @@ from .transcoding import _strip_transcoding
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+
+@dataclass
+class GroupedNodes:
+    """Represents a logical group of nodes, typically by namespace
+    or a custom grouping. A group can also consist of a single node.
+    This is used to support deployment—for example, by executing
+    the entire group in a single container run.
+    """
+
+    name: str
+    type: str  # "namespace" or "node"
+    nodes: list[str] = field(default_factory=list)
+    dependencies: list[str] = field(default_factory=list)
 
 
 class Node:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -555,7 +555,7 @@ class Pipeline:
         """Return a list of grouped nodes by top-level namespace with
         information about the nodes, their type, and dependencies.
 
-        This property is intended to be used by deployment plugins to group nodes by namespace.
+        This property is intended to be used by deployment plugins to group nodes by namespaces.
         """
         grouped_nodes_map: dict[str, GroupedNode] = {}
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -552,8 +552,8 @@ class Pipeline:
 
     @property
     def grouped_nodes_by_namespace(self) -> list[GroupedNode]:
-        """Return a list of grouped nodes by top-level namespace with
-        information about the nodes, their type, and dependencies.
+        """Return a list of :class:`kedro.pipeline.GroupedNode` objects grouped by top-level namespace,
+        with information about the nodes, their type, and dependencies.
 
         This property is intended to be used by deployment plugins to group nodes by namespace.
         """

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -552,10 +552,13 @@ class Pipeline:
 
     @property
     def grouped_nodes_by_namespace(self) -> list[GroupedNode]:
-        """Return a list of :class:`kedro.pipeline.GroupedNode` objects grouped by top-level namespace,
-        with information about the nodes, their type, and dependencies.
+        """Return a list of grouped nodes by top-level namespace with
+        information about the nodes, their type, and dependencies.
 
         This property is intended to be used by deployment plugins to group nodes by namespace.
+
+        Returns:
+            List[:class:`~kedro.pipeline.GroupedNode`]: A list of grouped nodes.
         """
         grouped_nodes_map: dict[str, GroupedNode] = {}
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -556,9 +556,6 @@ class Pipeline:
         information about the nodes, their type, and dependencies.
 
         This property is intended to be used by deployment plugins to group nodes by namespace.
-
-        Returns:
-            List[:class:`~kedro.pipeline.GroupedNode`]: A list of grouped nodes.
         """
         grouped_nodes_map: dict[str, GroupedNode] = {}
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -574,7 +574,7 @@ class Pipeline:
             dependencies = grouped_nodes_map[key].dependencies
             unique_dependencies = set(dependencies)
 
-            for parent in self.node_dependencies[node]:
+            for parent in sorted(self.node_dependencies[node], key=lambda n: n.name):
                 parent_key = (
                     parent.namespace.split(".")[0] if parent.namespace else parent.name
                 )

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -5,11 +5,10 @@ import pytest
 
 import kedro
 from kedro import KedroDeprecationWarning
-from kedro.pipeline import node, pipeline
+from kedro.pipeline import GroupedNodes, node, pipeline
 from kedro.pipeline.pipeline import (
     CircularDependencyError,
     ConfirmNotUniqueError,
-    GroupedNode,
     OutputNotUniqueError,
     _match_namespaces,
 )
@@ -383,7 +382,7 @@ class TestValidPipeline:
             (
                 "pipeline_with_namespace_simple",
                 [
-                    GroupedNode(
+                    GroupedNodes(
                         name="namespace_1",
                         type="namespace",
                         nodes=[
@@ -393,7 +392,7 @@ class TestValidPipeline:
                         ],
                         dependencies=[],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="namespace_2",
                         type="namespace",
                         nodes=[
@@ -408,25 +407,25 @@ class TestValidPipeline:
             (
                 "pipeline_with_namespace_partial",
                 [
-                    GroupedNode(
+                    GroupedNodes(
                         name="namespace_1",
                         type="namespace",
                         nodes=["namespace_1.node_1", "namespace_1.node_2"],
                         dependencies=[],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="node_3",
                         type="node",
                         nodes=["node_3"],
                         dependencies=["namespace_1"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="namespace_2",
                         type="namespace",
                         nodes=["namespace_2.node_4", "namespace_2.node_5"],
                         dependencies=["node_3"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="node_6",
                         type="node",
                         nodes=["node_6"],
@@ -437,43 +436,43 @@ class TestValidPipeline:
             (
                 "pipeline_with_multiple_dependencies_on_one_node",
                 [
-                    GroupedNode(
+                    GroupedNodes(
                         name="f1",
                         type="node",
                         nodes=["f1"],
                         dependencies=[],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f2",
                         type="node",
                         nodes=["f2"],
                         dependencies=["f1"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f3",
                         type="node",
                         nodes=["f3"],
                         dependencies=["f2"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f4",
                         type="node",
                         nodes=["f4"],
                         dependencies=["f2"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f5",
                         type="node",
                         nodes=["f5"],
                         dependencies=["f2"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f6",
                         type="node",
                         nodes=["f6"],
                         dependencies=["f4"],
                     ),
-                    GroupedNode(
+                    GroupedNodes(
                         name="f7",
                         type="node",
                         nodes=["f7"],
@@ -486,7 +485,7 @@ class TestValidPipeline:
     def test_node_grouping_by_namespace_combined(
         self, request, pipeline_name, expected
     ):
-        """Test that grouped_nodes_by_namespace returns correct GroupedNode list with name, type and node names and dependencies."""
+        """Test that grouped_nodes_by_namespace returns correct GroupedNodes list with name, type and node names and dependencies."""
         p = request.getfixturevalue(pipeline_name)
         grouped = p.grouped_nodes_by_namespace
 


### PR DESCRIPTION
This is the updated version of #4708, now targeting the `develop` branch instead of `main`, since this is a breaking change intended for the upcoming major release.

## Description
First part of #4684 - modified `Pipeline.grouped_nodes_by_namespace()` to return a list of `GroupedNode` objects instead of a dictionary.

This improves the structure and type safety of the API, and makes it easier for deployment plugins and other consumers to work with node grouping results in a uniform way.

There was flakiness in the tests because
```
@property  
def node_dependencies(self) -> dict[Node, set[Node]]:  
```
is not deterministic due to the use of set.
To address this, I implemented additional sorting in `grouped_nodes_by_namespace().`
