### PR TITLE
Update airflow deployment docs

### DIFF
--- a/docs/source/deployment/airflow.md
+++ b/docs/source/deployment/airflow.md
@@ -61,6 +61,8 @@ Starting with kedro-airflow release version 0.9.0, you can adopt a different str
 
 4. Open `conf/logging.yml` and modify the `root: handlers` section to `[console]` at the end of the file. By default, Kedro uses the [Rich library](https://rich.readthedocs.io/en/stable/index.html) to enhance log output with sophisticated formatting. However, some deployment systems, including Airflow, don't work well with Rich. Therefore, we're adjusting the logging to a simpler console version. For more information on logging in Kedro, you can refer to the [Kedro docs](https://docs.kedro.org/en/stable/logging/index.html).
 
+> ⚠️ **Note**: This step is optional for recent versions of Airflow, as the compatibility issue has been fixed.
+
 ```shell
 root:
   handlers: [console]


### PR DESCRIPTION
## Description

After reviewing the latest version of Airflow, as discussed in https://github.com/kedro-org/kedro-plugins/issues/603, it’s clear that Airflow has resolved the issue with failures caused by `rich` logging. As a result, our default Kedro projects now work fine in deployments without the need to switch logging to the console.

This PR adds a note to our documentation indicating that this step is optional when using recent versions of Airflow.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
