### PR TITLE
Investigate recursion issue DataCatalog

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -227,9 +227,9 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             f"{TYPE_KEY}": f"{type(self).__module__}.{type(self).__name__}"
         }
 
-        if self._init_args:  # type: ignore[attr-defined]
-            self._init_args.pop("self", None)  # type: ignore[attr-defined]
-            return_config.update(self._init_args)  # type: ignore[attr-defined]
+        # if self._init_args:  # type: ignore[attr-defined]
+            # self._init_args.pop("self", None)  # type: ignore[attr-defined]
+            # return_config.update(self._init_args)  # type: ignore[attr-defined]
 
         if type(self).__name__ == "CachedDataset":
             cached_ds = return_config.pop("dataset")

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -344,22 +344,22 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         """
 
         # Save the original __init__ method of the subclass
-        init_func: Callable = cls.__init__
+        # init_func: Callable = cls.__init__
 
-        @wraps(init_func)
-        def new_init(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
-            """Executes the original __init__, then save the arguments used
-            to initialize the instance.
-            """
-            # Call the original __init__ method
-            init_func(self, *args, **kwargs)
-            # Capture and save the arguments passed to the original __init__
-            self._init_args = getcallargs(init_func, self, *args, **kwargs)
+        # @wraps(init_func)
+        # def new_init(self, *args, **kwargs) -> None:  # type: ignore[no-untyped-def]
+        #     """Executes the original __init__, then save the arguments used
+        #     to initialize the instance.
+        #     """
+        #     # Call the original __init__ method
+        #     init_func(self, *args, **kwargs)
+        #     # Capture and save the arguments passed to the original __init__
+        #     self._init_args = getcallargs(init_func, self, *args, **kwargs)
 
-        # Replace the subclass's __init__ with the new_init
-        # A hook for subclasses to capture initialization arguments and save them
-        # in the AbstractDataset._init_args field
-        cls.__init__ = new_init  # type: ignore[method-assign]
+        # # Replace the subclass's __init__ with the new_init
+        # # A hook for subclasses to capture initialization arguments and save them
+        # # in the AbstractDataset._init_args field
+        # cls.__init__ = new_init  # type: ignore[method-assign]
 
         super().__init_subclass__(**kwargs)
 


### PR DESCRIPTION
## Description
Investigate https://github.com/kedro-org/kedro/issues/4683

## Development notes
### The Issue
- The problem was introduced in Kedro `0.19.11` in January 2025
- It was introduced with this PR: https://github.com/kedro-org/kedro/pull/4323
- The problem seems to lie with the init subclass changes (https://github.com/kedro-org/kedro/blob/main/kedro/io/core.py#L337). While the `to_config()` method that needs this is only used with the new DataCatalog, every instance of `AbstractDataset` goes through the `__init_subclass__`

### The Fix
- I have not found an easy way to fix this. Reverting the whole piece of code isn't possible, because it would basically undo the majority of the new catalog work and makes no sense for a `0.19.14` release. 

- The issue has only been reported by [1 person in April ](https://github.com/kedro-org/kedro/issues/4683), almost 2 months after it was released. It's not great that now there exist versions of Kedro where the catalog is broken for certain datasets, but there's the workaround the user described in the issue:

Instead of using:
```
    def _describe(self) -> dict[str, Any]:
        return self.__dict__
```

Use:
```
    def _describe(self) -> dict[str, Any]:
        return {
            "backend": self.backend,
            "model": self.model,
            "credentials": self.credentials,
            "model_params": self.model_params,
            "llm": self.llm,
            "log_dir": self.log_dir
        }
```

- Perhaps there's a way to fix it for just the new catalog, but that wouldn't go into a 0.19.14. 

- Another thing we can do is guide people more in the custom dataset guidelines and tell them not to refer to the object itself which makes the code get into the recursion. 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
