### PR TITLE
Fix minor typos across multiple docs and code files

### DIFF
--- a/docs/pages/build/namespaces.md
+++ b/docs/pages/build/namespaces.md
@@ -59,7 +59,7 @@ def create_pipeline(**kwargs) -> Pipeline:
     )
 ```
 
-To use a new set of parameters, you should create a second parameters file to ovewrite parameters specified in  `conf/base/parameters.yml`. To overwrite the parameter `model_options`, create a file  `conf/base/parameters_data_science.yml` and add a parameter called `model_options_1`:
+To use a new set of parameters, you should create a second parameters file to overwrite parameters specified in  `conf/base/parameters.yml`. To overwrite the parameter `model_options`, create a file  `conf/base/parameters_data_science.yml` and add a parameter called `model_options_1`:
 
 ```python
 #conf/base/parameters.yml

--- a/docs/pages/build/run_a_pipeline.md
+++ b/docs/pages/build/run_a_pipeline.md
@@ -257,7 +257,7 @@ run:
 
 This is because the configuration file gets parsed by [Click](https://click.palletsprojects.com/en/8.1.x/), a Python package to handle command line interfaces. Click passes the options defined in the configuration file to a Python function. The option names need to match the argument names in that function.
 
-Variable names and arguments in Python may only contain alpha-numeric characters and underscores, so it's not possible to have a dash in the option names when using the configuration file.
+Variable names and arguments in Python may only contain alphanumeric characters and underscores, so it's not possible to have a dash in the option names when using the configuration file.
 
 !!! note
     If you provide both a configuration file and a CLI option that clashes with the configuration file, the CLI option will take precedence.

--- a/docs/pages/build/slice_a_pipeline.md
+++ b/docs/pages/build/slice_a_pipeline.md
@@ -320,7 +320,7 @@ We can avoid re-calculating `n` (and all other results that have already been sa
     SequentialRunner().run_only_missing(full_pipeline, io)
     ```
 
-    `Ouput`:
+    `Output`:
 
     ```console
     Out[18]: {'v': 0.666666666666667}

--- a/docs/pages/create/new_project_tools.md
+++ b/docs/pages/create/new_project_tools.md
@@ -227,7 +227,7 @@ Kedro promotes the use of unit tests to achieve high code quality and maintainab
 
 Selecting the custom logging tool introduces the file `logging.yml` to your project's `conf` directory. This tool allows you to customise your logging configuration instead of using [Kedro's default logging configuration](https://github.com/kedro-org/kedro/blob/main/kedro/framework/project/default_logging.yml). The populated `conf/logging.yml` provides two additional logging handlers: `console` and `info_file_handler`, as well as `rich` that is available in the default configuration, though only `info_file_handler` and `rich` are used.
 
-To use this provided logging configuration, remember to set the `KEDRO_LOGGING_CONFIG` environment variable to point to `logging.yml` by naviagting to your project root and running the following command:
+To use this provided logging configuration, remember to set the `KEDRO_LOGGING_CONFIG` environment variable to point to `logging.yml` by navigating to your project root and running the following command:
 
 ```bash
 export KEDRO_LOGGING_CONFIG=conf/logging.yml

--- a/docs/pages/deploy/supported-platforms/airflow.md
+++ b/docs/pages/deploy/supported-platforms/airflow.md
@@ -236,7 +236,7 @@ DAGs folder
 Plugins file - optional
   s3://your_S3_bucket/plugins.zip
 Requirements file - optional
-  s3://your_S3_bucket/requrements.txt
+  s3://your_S3_bucket/requirements.txt
 Startup script file - optional
   s3://your_S3_bucket/startup.sh
 ```

--- a/docs/pages/extend/hooks/common_use_cases.md
+++ b/docs/pages/extend/hooks/common_use_cases.md
@@ -232,7 +232,7 @@ from kedro.framework.hooks import hook_impl
 class PDBNodeDebugHook:
     """A hook class for creating a post mortem debugging with the PDB debugger
     whenever an error is triggered within a node. The local scope from when the
-    exception occured is available within this debugging session.
+    exception occurred is available within this debugging session.
     """
 
     @hook_impl
@@ -267,7 +267,7 @@ from kedro.framework.hooks import hook_impl
 class PDBPipelineDebugHook:
     """A hook class for creating a post mortem debugging with the PDB debugger
     whenever an error is triggered within a pipeline. The local scope from when the
-    exception occured is available within this debugging session.
+    exception occurred is available within this debugging session.
     """
 
     @hook_impl

--- a/docs/pages/integrations-and-plugins/notebooks_and_ipython/kedro_and_notebooks.md
+++ b/docs/pages/integrations-and-plugins/notebooks_and_ipython/kedro_and_notebooks.md
@@ -48,7 +48,7 @@ The `kedro jupyter notebook` command launches a notebook with a customised kerne
 * `pipelines` (type `dict[str, Pipeline]`): Pipelines defined in your [pipeline registry](../../build/run_a_pipeline.md#run-a-pipeline-by-name)
 * `session` (type [kedro.framework.session.session.KedroSession][]): [Kedro session](../../extend/session.md) that orchestrates a pipeline run
 
-In addtion, it also runs `%load_ext kedro.ipython` automatically when you launch the notebook.
+In addition, it also runs `%load_ext kedro.ipython` automatically when you launch the notebook.
 
 !!! note
     If the Kedro variables are not available within your Jupyter notebook, you could have a malformed configuration file or missing dependencies. The full error message is shown on the terminal used to launch `kedro jupyter notebook` or run `%load_ext kedro.ipython` in a notebook cell.

--- a/docs/pages/tutorials/notebooks_tutorial.md
+++ b/docs/pages/tutorials/notebooks_tutorial.md
@@ -47,7 +47,7 @@ The `kedro jupyter notebook` command launches a notebook with a customised kerne
 * `pipelines` (type `dict[str, Pipeline]`): Pipelines defined in your [pipeline registry](../build/run_a_pipeline.md#run-a-pipeline-by-name)
 * `session` (type [kedro.framework.session.session.KedroSession][]): [Kedro session](../extend/session.md) that orchestrates a pipeline run
 
-In addtion, it also runs `%load_ext kedro.ipython` automatically when you launch the notebook.
+In addition, it also runs `%load_ext kedro.ipython` automatically when you launch the notebook.
 
 !!! note
     If the Kedro variables are not available within your Jupyter notebook, you could have a malformed configuration file or missing dependencies. The full error message is shown on the terminal used to launch `kedro jupyter notebook` or run `%load_ext kedro.ipython` in a notebook cell.

--- a/docs/stylesheets/globals.css
+++ b/docs/stylesheets/globals.css
@@ -250,7 +250,7 @@
   color: var(--text-secondary-color);
 }
 
-/** hightlight the copy icon buton on hover */
+/** highlight the copy icon button on hover */
 .md-clipboard:hover,
 pre:hover .md-clipboard {
   color: var(--text-hover-color);

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -194,7 +194,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         # Allow bypassing of loading config from patterns if a key and value have been set
         # explicitly on the ``OmegaConfigLoader`` instance.
 
-        # Re-register runtime params resolver incase it was previously deactivated
+        # Re-register runtime params resolver in case it was previously deactivated
         self._register_runtime_params_resolver()
 
         if key in self:

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -1009,7 +1009,7 @@ class CatalogProtocol(Protocol[_C]):
         ...
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Adds dataset using the given key as a datset name and the provided data as the value."""
+        """Adds dataset using the given key as a dataset name and the provided data as the value."""
         ...
 
     def __len__(self) -> int:

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -175,7 +175,7 @@ class DataCatalog(CatalogProtocol):
         return self.get(ds_name)
 
     def __setitem__(self, key: str, value: Any) -> None:
-        """Add dataset to the ``DataCatalog`` using the given key as a datsets name
+        """Add dataset to the ``DataCatalog`` using the given key as a dataset's name
         and the provided data as the value.
 
         The value can either be raw data or a Kedro dataset (i.e., an instance of a class

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -105,7 +105,7 @@ def _infer_copy_mode(data: Any) -> str:
     try:
         import ibis
     except ImportError:  # pragma: no cover
-        ibis = None  # tpye: ignore[assignment] # pragma: no cover
+        ibis = None  # type: ignore[assignment] # pragma: no cover
 
     if pd and isinstance(data, pd.DataFrame) or np and isinstance(data, np.ndarray):
         copy_mode = "copy"

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -1332,7 +1332,7 @@ def _get_param_names_mapping(
         # a set[str] of names will stay the same
         {"params:param_1": "params:param_1", "params:param_2": "params:param_2"}
         >>> _get_param_names_mapping({"param_1": "new_name_for_param_1"})
-        # a dict[str, str] of names will map key to valu
+        # a dict[str, str] of names will map key to value
         {"params:param_1": "params:new_name_for_param_1"}
     """
     params = {}


### PR DESCRIPTION
## Description

I ran [`codespell`](https://github.com/codespell-project/codespell) over Kedro codebase and fixed typos it found.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
