### PR TITLE
Implement catalog CLI tests

### DIFF
--- a/tests/framework/cli/test_catalog.py
+++ b/tests/framework/cli/test_catalog.py
@@ -1,1 +1,72 @@
-# TODO: Implement tests fot catalog CLI
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+
+@pytest.fixture
+def runner():
+    return CliRunner()
+
+
+@pytest.fixture
+def mock_session():
+    with patch("kedro.framework.session.KedroSession.create") as mock_create_session:
+        mock_context = MagicMock()
+        mock_catalog = MagicMock()
+        mock_context.catalog = mock_catalog
+        mock_session = MagicMock()
+        mock_session.load_context.return_value = mock_context
+        mock_create_session.return_value = mock_session
+        yield mock_catalog
+
+
+def test_list_datasets_cli(runner, mock_session, fake_project_cli, fake_metadata):
+    mock_session.list_datasets.return_value = {
+        "pipeline1": {
+            "datasets": {"CSVDataSet": ["input1.csv"]},
+            "factories": {},
+            "defaults": {},
+        }
+    }
+
+    result = runner.invoke(
+        fake_project_cli,
+        ["catalog", "list-datasets", "--pipeline", "pipeline1", "--env", "local"],
+        obj=fake_metadata,
+    )
+
+    assert result.exit_code == 0
+    assert "pipeline1" in result.output
+    assert "datasets" in result.output
+    mock_session.list_datasets.assert_called_once_with(["pipeline1"])
+
+
+def test_list_patterns_cli(runner, mock_session, fake_project_cli, fake_metadata):
+    mock_session.list_patterns.return_value = ["pattern_*", "other_*"]
+
+    result = runner.invoke(
+        fake_project_cli,
+        ["catalog", "list-patterns", "--env", "local"],
+        obj=fake_metadata,
+    )
+
+    assert result.exit_code == 0
+    assert "pattern_*" in result.output
+    mock_session.list_patterns.assert_called_once()
+
+
+def test_resolve_patterns_cli(runner, mock_session, fake_project_cli, fake_metadata):
+    mock_session.resolve_patterns.return_value = {
+        "dataset1": {"type": "CSVDataSet", "filepath": "data/01_raw/ds1.csv"}
+    }
+
+    result = runner.invoke(
+        fake_project_cli,
+        ["catalog", "resolve-patterns", "--pipeline", "pipeline1", "--env", "local"],
+        obj=fake_metadata,
+    )
+
+    assert result.exit_code == 0
+    assert "dataset1" in result.output
+    mock_session.resolve_patterns.assert_called_once_with(["pipeline1"])


### PR DESCRIPTION
## Description
Partially addresses https://github.com/kedro-org/kedro/issues/4834

1. Logic is tested under `tests/framework/context/test_catalog_commands_mixin.py`
2. Commands are running successfully is tested under `tests/framework/cli/test_catalog.py`

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
