### PR TITLE
Coverage for `CatalogConfigResolver`

### DIFF
--- a/kedro/io/catalog_config_resolver.py
+++ b/kedro/io/catalog_config_resolver.py
@@ -136,7 +136,7 @@ class CatalogConfigResolver:
         """
         if default_runtime_patterns is None:
             self._logger.warning(
-                f"Since runtime patterns are not provided, setting"
+                f"Since runtime patterns are not provided, setting "
                 f"the runtime pattern to default value: {DEFAULT_RUNTIME_PATTERN}"
             )
         self._default_runtime_patterns = (

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -464,20 +464,19 @@ def mock_session_with_broken_before_node_run_hooks(
 class TestBeforeNodeRunHookWithInputUpdates:
     """Test the behavior of `before_node_run_hook` when updating node inputs."""
 
-    # TODO: Fix test
-    # def test_correct_input_update(
-    #     self,
-    #     mock_session_with_before_node_run_hooks,
-    #     dummy_dataframe,
-    # ):
-    #     context = mock_session_with_before_node_run_hooks.load_context()
-    #     catalog = context.catalog
-    #     catalog.save("cars", dummy_dataframe)
-    #     catalog.save("boats", dummy_dataframe)
-    #
-    #     result = mock_session_with_before_node_run_hooks.run()
-    #     assert isinstance(result["planes"], MockDatasetReplacement)
-    #     assert isinstance(result["ships"], pd.DataFrame)
+    def test_correct_input_update(
+        self,
+        mock_session_with_before_node_run_hooks,
+        dummy_dataframe,
+    ):
+        context = mock_session_with_before_node_run_hooks.load_context()
+        catalog = context.catalog
+        catalog.save("cars", dummy_dataframe)
+        catalog.save("boats", dummy_dataframe)
+
+        result = mock_session_with_before_node_run_hooks.run()
+        assert isinstance(result["planes"].load(), MockDatasetReplacement)
+        assert isinstance(result["ships"].load(), pd.DataFrame)
 
     @SKIP_ON_WINDOWS_AND_MACOS
     def test_correct_input_update_parallel(
@@ -491,8 +490,8 @@ class TestBeforeNodeRunHookWithInputUpdates:
         catalog.save("boats", dummy_dataframe)
 
         result = mock_session_with_before_node_run_hooks.run(runner=ParallelRunner())
-        assert isinstance(result["planes"], MockDatasetReplacement)
-        assert isinstance(result["ships"], pd.DataFrame)
+        assert isinstance(result["planes"].load(), MockDatasetReplacement)
+        assert isinstance(result["ships"].load(), pd.DataFrame)
 
     def test_broken_input_update(
         self, mock_session_with_broken_before_node_run_hooks, dummy_dataframe


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
