### PR TITLE
Update DryRunner docs

### DIFF
--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -207,7 +207,7 @@ In a simple example, we define a `MemoryDataset` called `xs` to store our inputs
 
 ??? example "View code"
     ```python
-    io = KedroDataCatalog(dict(xs=MemoryDataset()))
+    io = DataCatalog(dict(xs=MemoryDataset()))
     ```
 
     ```python

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -66,7 +66,6 @@ If the built-in Kedro runners do not meet your requirements, you can also define
     from kedro.pipeline import Pipeline
     from kedro.runner.runner import AbstractRunner
     from pluggy import PluginManager
-    from concurrent.futures import Executor
 
     class DryRunner(AbstractRunner):
         """``DryRunner`` is an ``AbstractRunner`` implementation. It can be used to list which
@@ -83,10 +82,7 @@ If the built-in Kedro runners do not meet your requirements, you can also define
             """
             super().__init__(is_async=is_async)
 
-        def _get_executor(self, max_workers: int) -> Executor | None:
-            """Method to provide the correct executor (e.g., ThreadPoolExecutor,
-            ProcessPoolExecutor or None if running sequentially).
-            """
+        def _get_executor(self, max_workers: int) -> None:
             return None
 
         def _run(

--- a/docs/build/slice_a_pipeline.md
+++ b/docs/build/slice_a_pipeline.md
@@ -271,10 +271,10 @@ To demonstrate this, let us save the intermediate output `n` using a `JSONDatase
 ??? example "View code"
     ```python
     from kedro_datasets.pandas import JSONDataset
-    from kedro.io import KedroDataCatalog, MemoryDataset
+    from kedro.io import DataCatalog, MemoryDataset
 
     n_json = JSONDataset(filepath="./data/07_model_output/len.json")
-    io = KedroDataCatalog(dict(xs=MemoryDataset([1, 2, 3]), n=n_json))
+    io = DataCatalog(dict(xs=MemoryDataset([1, 2, 3]), n=n_json))
     ```
 
 Because `n` was not saved previously, checking for its existence returns `False`:

--- a/docs/tutorials/test_a_project.md
+++ b/docs/tutorials/test_a_project.md
@@ -213,12 +213,8 @@ When we put this together, we get the following test:
             }
         }
 
-        catalog.add_feed_dict(
-            {
-                "model_input_table" : dummy_data,
-                "params:model_options": dummy_parameters["model_options"],
-            }
-        )
+        catalog["model_input_table"] = dummy_data
+        catalog["params:model_options"] = dummy_parameters["model_options"]
 
         # Arrange the log testing setup
         caplog.set_level(logging.DEBUG, logger="kedro") # Ensure all logs produced by Kedro are captured
@@ -369,12 +365,9 @@ After incorporating these testing practices, our test file `test_data_science_pi
             .to_nodes("evaluate_model_node")
         )
         catalog = DataCatalog()
-        catalog.add_feed_dict(
-            {
-                "model_input_table" : dummy_data,
-                "params:model_options": dummy_parameters["model_options"],
-            }
-        )
+
+        catalog["model_input_table"] = dummy_data
+        catalog["params:model_options"] = dummy_parameters["model_options"]
 
         caplog.set_level(logging.DEBUG, logger="kedro")
         successful_run_msg = "Pipeline execution completed successfully."

--- a/docs/tutorials/test_a_project.md
+++ b/docs/tutorials/test_a_project.md
@@ -185,7 +185,7 @@ When we put this together, we get the following test:
 
     import logging
     import pandas as pd
-    from kedro.io import KedroDataCatalog
+    from kedro.io import DataCatalog
     from kedro.runner import SequentialRunner
     from spaceflights.pipelines.data_science import create_pipeline as create_ds_pipeline
 
@@ -194,7 +194,7 @@ When we put this together, we get the following test:
         pipeline = create_ds_pipeline()
 
         # Arrange data catalog
-        catalog = KedroDataCatalog()
+        catalog = DataCatalog()
 
         dummy_data = pd.DataFrame(
             {
@@ -318,7 +318,7 @@ After incorporating these testing practices, our test file `test_data_science_pi
     import pandas as pd
     import pytest
 
-    from kedro.io import KedroDataCatalog
+    from kedro.io import DataCatalog
     from kedro.runner import SequentialRunner
     from spaceflights.pipelines.data_science import create_pipeline as create_ds_pipeline
     from spaceflights.pipelines.data_science.nodes import split_data
@@ -368,7 +368,7 @@ After incorporating these testing practices, our test file `test_data_science_pi
             .from_nodes("split_data_node")
             .to_nodes("evaluate_model_node")
         )
-        catalog = KedroDataCatalog()
+        catalog = DataCatalog()
         catalog.add_feed_dict(
             {
                 "model_input_table" : dummy_data,


### PR DESCRIPTION
## Description

Resolves #4842 

## Development notes

- Updated DryRunner docs example to comply with DataCatalog
- Removed KedroDataCatalog references and updated to DataCatalog
- Removed add_feed_dict as it will be deprecated


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
