### PR TITLE
Update kedro version to align with RC

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -44,6 +44,6 @@ authors:
 - family-names: Brugman
   given-names: Simon
 title: Kedro
-version: 0.19.14
-date-released: 2025-06-17
+version: 1.0.0rc1
+date-released: 2025-06-20
 url: https://github.com/kedro-org/kedro

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import sys
 import warnings
 
-__version__ = "0.19.14"
+__version__ = "1.0.0rc1"
 
 
 class KedroDeprecationWarning(DeprecationWarning):


### PR DESCRIPTION
## Description
We need to update Kedro version to align with RC: https://github.com/kedro-org/kedro/pull/4877

Currently, as @ankatiyar reported, if one has the `main` version installed but in their project the `kedro_init_version` is set to `1.0.0rc1`, it doesn’t work when `kedro run`.

```console
 ValueError: Your Kedro project version 1.0.0rc1 does not match Kedro package version 0.19.14 you are running. Make sure to update your project 
template. See https://github.com/kedro-org/kedro/blob/main/RELEASE.md for how to migrate your Kedro project.
```

Suggested steps:
1. **Disable the release workflow**
2. Merge this PR
3. Enable the release workflow




