### PR TITLE
Print one dataset per line when printing catalog

### DIFF
--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -260,34 +260,6 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
     def _logger(self) -> logging.Logger:
         return logging.getLogger(__name__)
 
-    def __str__(self) -> str:
-        # TODO: Replace with __repr__ implementation in 1.0.0 release.
-        def _to_str(obj: Any, is_root: bool = False) -> str:
-            """Returns a string representation where
-            1. The root level (i.e. the Dataset.__init__ arguments) are
-            formatted like Dataset(key=value).
-            2. Dictionaries have the keys alphabetically sorted recursively.
-            3. None values are not shown.
-            """
-
-            fmt = "{}={}" if is_root else "'{}': {}"  # 1
-
-            if isinstance(obj, dict):
-                sorted_dict = sorted(obj.items(), key=lambda pair: str(pair[0]))  # 2
-
-                text = ", ".join(
-                    fmt.format(key, _to_str(value))  # 2
-                    for key, value in sorted_dict
-                    if value is not None  # 3
-                )
-
-                return text if is_root else "{" + text + "}"  # 1
-
-            # not a dictionary
-            return str(obj)
-
-        return f"{type(self).__name__}({_to_str(self._describe(), True)})"
-
     @classmethod
     def _load_wrapper(cls, load_func: Callable[[Self], _DO]) -> Callable[[Self], _DO]:
         """Decorate `load_func` with logging and error handling code."""

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -316,9 +316,13 @@ class DataCatalog(CatalogProtocol):
 
             >>> catalog = DataCatalog(datasets={"example": MemoryDataset()})
             >>> print(repr(catalog))
-            # "{'example': kedro.io.memory_dataset.MemoryDataset()}"
+            # "example: kedro.io.memory_dataset.MemoryDataset()"
         """
-        return repr(self._lazy_datasets | self._datasets)
+        combined = self._lazy_datasets | self._datasets
+        lines = []
+        for key, dataset in combined.items():
+            lines.append(f"'{key}': {dataset!r}")
+        return "\n".join(lines)
 
     def __contains__(self, dataset_name: str) -> bool:
         """

--- a/tests/io/test_cached_dataset.py
+++ b/tests/io/test_cached_dataset.py
@@ -135,8 +135,10 @@ class TestCachedDataset:
 
     def test_str(self):
         assert (
-            str(CachedDataset(MemoryDataset(42))) == "CachedDataset(cache={}, "
-            "dataset={'data': <int>})"
+            str(CachedDataset(MemoryDataset(42)))
+            == """kedro.io.cached_dataset.CachedDataset("""
+            """dataset="kedro.io.memory_dataset.MemoryDataset(data='<int>')", """
+            """cache='kedro.io.memory_dataset.MemoryDataset()')"""
         )
 
     def test_release(self, cached_ds):

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -212,15 +212,20 @@ class TestCoreFunctions:
     def test_str_representation(self, var):
         var_str = pprint.pformat(var)
         filepath_str = pprint.pformat(PurePosixPath("."))
-        assert str(MyDataset(var=var)) == f"MyDataset(filepath=., var={var})"
+        assert (
+            str(MyDataset(var=var))
+            == f"tests.io.test_core.MyDataset(filepath={filepath_str}, var={var_str})"
+        )
         assert (
             repr(MyDataset(var=var))
             == f"tests.io.test_core.MyDataset(filepath={filepath_str}, var={var_str})"
         )
 
     def test_str_representation_none(self):
-        assert str(MyDataset()) == "MyDataset(filepath=.)"
         filepath_str = pprint.pformat(PurePosixPath("."))
+        assert (
+            str(MyDataset()) == f"tests.io.test_core.MyDataset(filepath={filepath_str})"
+        )
         assert (
             repr(MyDataset())
             == f"tests.io.test_core.MyDataset(filepath={filepath_str})"
@@ -510,7 +515,9 @@ class TestAbstractVersionedDataset:
 
     def test_no_versions(self, my_versioned_dataset):
         """Check the error if no versions are available for load."""
-        pattern = r"Did not find any versions for MyVersionedDataset\(.+\)"
+        pattern = (
+            r"Did not find any versions for tests.io.test_core.MyVersionedDataset\(.+\)"
+        )
         with pytest.raises(DatasetError, match=pattern):
             my_versioned_dataset.load()
 
@@ -545,7 +552,7 @@ class TestAbstractVersionedDataset:
         corresponding json file for a given save version already exists."""
         my_versioned_dataset.save(dummy_data)
         pattern = (
-            r"Save path \'.+\' for MyVersionedDataset\(.+\) must "
+            r"Save path \'.+\' for tests.io.test_core.MyVersionedDataset\(.+\) must "
             r"not exist if versioning is enabled\."
         )
         with pytest.raises(DatasetError, match=pattern):
@@ -565,7 +572,7 @@ class TestAbstractVersionedDataset:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"MyVersionedDataset\(.+\)"
+            r"tests.io.test_core.MyVersionedDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             my_versioned_dataset.save(dummy_data)
@@ -639,7 +646,7 @@ class TestAbstractVersionedDataset:
 
         with pytest.raises(
             VersionNotFoundError,
-            match="Did not find any versions for MyVersionedDataset",
+            match="Did not find any versions for tests.io.test_core.MyVersionedDataset",
         ):
             my_versioned_dataset._fetch_latest_load_version()
 
@@ -764,7 +771,7 @@ class TestLegacyLoadAndSave:
         pattern = (
             f"Save version '{save_version}' did not match "
             f"load version '{load_version}' for "
-            r"MyLegacyVersionedDataset\(.+\)"
+            r"tests.io.test_core.MyLegacyVersionedDataset\(.+\)"
         )
         with pytest.warns(UserWarning, match=pattern):
             my_legacy_versioned_dataset.save(dummy_data)

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -91,7 +91,7 @@ class TestDataCatalog:
     def test_load_error(self, data_catalog):
         """Check the error when attempting to load a dataset
         from nonexistent source"""
-        pattern = r"Failed while loading data from dataset CSVDataset"
+        pattern = r"Failed while loading data from dataset kedro_datasets.pandas.csv_dataset.CSVDataset"
         with pytest.raises(DatasetError, match=pattern):
             data_catalog.load("test")
 

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -146,24 +146,6 @@ class TestMemoryDataset:
         [
             (
                 "dummy_dataframe",
-                "MemoryDataset(data=<DataFrame>)",
-            ),
-            (
-                "dummy_numpy_array",
-                "MemoryDataset(data=<ndarray>)",
-            ),
-        ],
-        indirect=["input_data"],
-    )
-    def test_str_representation(self, memory_dataset, input_data, expected):
-        """Test string representation of the dataset"""
-        assert expected in str(memory_dataset)
-
-    @pytest.mark.parametrize(
-        "input_data,expected",
-        [
-            (
-                "dummy_dataframe",
                 "kedro.io.memory_dataset.MemoryDataset(data='<DataFrame>')",
             ),
             (
@@ -173,8 +155,9 @@ class TestMemoryDataset:
         ],
         indirect=["input_data"],
     )
-    def test_repr_representation(self, memory_dataset, input_data, expected):
+    def test_str_repr_representation(self, memory_dataset, input_data, expected):
         """Test string representation of the dataset"""
+        assert expected in str(memory_dataset)
         assert expected in repr(memory_dataset)
 
     def test_exists(self, new_data):


### PR DESCRIPTION
## Description
Updated `__repr__` method to print one dataset per line

## Development notes
Moving from this representation

```bash
In [1]: catalog
Out[1]: {'shuttle_id_dataset': kedro_datasets.pandas.sql_dataset.SQLQueryDataset, 'preprocessed_shuttles': kedro_datasets.pandas.parquet_dataset.ParquetDataset, 'model_input_table': kedro_datasets.pandas.parquet_dataset.ParquetDataset, 'regressor': kedro_datasets.pickle.pickle_dataset.PickleDataset, 'parameters': kedro.io.memory_dataset.MemoryDataset(data='<dict>'), 'params:data': kedro.io.memory_dataset.MemoryDataset(data='<dict>'), 'params:data.size': kedro.io.memory_dataset.MemoryDataset(data='<float>'), kedro.io.memory_dataset.MemoryDataset(data='<float>'), 'shuttles': kedro_datasets.pandas.excel_dataset.ExcelDataset(filepath=PurePosixPath('//Projects/kedro-tests/default/data/01_raw/shuttles.xlsx'), protocol='file', load_args={'engine': 'openpyxl'}, save_args={'index': False}, writer_args={'engine': 'openpyxl'})}
```

to this

```bash
In [1]: catalog
Out[1]:

'shuttle_id_dataset': kedro_datasets.pandas.sql_dataset.SQLQueryDataset
'preprocessed_shuttles': kedro_datasets.pandas.parquet_dataset.ParquetDataset
'model_input_table': kedro_datasets.pandas.parquet_dataset.ParquetDataset
'regressor': kedro_datasets.pickle.pickle_dataset.PickleDataset
'parameters': kedro.io.memory_dataset.MemoryDataset(data='<dict>')
'params:data': kedro.io.memory_dataset.MemoryDataset(data='<dict>')
'params:data.size': kedro.io.memory_dataset.MemoryDataset(data='<float>')
'shuttles': kedro_datasets.pandas.excel_dataset.ExcelDataset(filepath=PurePosixPath('Projects/kedro-tests/default/data/01_raw/shuttles.xlsx'), protocol='file', load_args={'engine': 'openpyxl'}, save_args={'index': False}, writer_args={'engine': 'openpyxl'})
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
