### PR TITLE
Rename `AbstractDataset.to_config()` method

### DIFF
--- a/kedro/framework/context/catalog_mixins.py
+++ b/kedro/framework/context/catalog_mixins.py
@@ -173,7 +173,7 @@ class CatalogCommandsMixin:
                 continue
 
             unresolved_config, _ = self.config_resolver._unresolve_credentials(
-                ds_name, ds.to_config()
+                ds_name, ds._init_config()
             )
             explicit_datasets[ds_name] = unresolved_config
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -204,10 +204,12 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             ) from err
         return dataset
 
-    def to_config(self) -> dict[str, Any]:
-        """Converts the dataset instance into a dictionary-based configuration for
-        serialization. Ensures that any subclass-specific details are handled, with
-        additional logic for versioning and caching implemented for `CachedDataset`.
+    def _init_config(self) -> dict[str, Any]:
+        """Internal method to capture the dataset's initial configuration
+        as provided during instantiation.
+
+        This configuration reflects only the arguments supplied at `__init__` time
+        and does not account for any runtime or dynamic changes to the dataset.
 
         Adds a key for the dataset's type using its module and class name and
         includes the initialization arguments.
@@ -238,7 +240,7 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
             if isinstance(cached_ds, dict):
                 cached_ds_return_config = cached_ds
             elif isinstance(cached_ds, AbstractDataset):
-                cached_ds_return_config = cached_ds.to_config()
+                cached_ds_return_config = cached_ds._init_config()
             if VERSIONED_FLAG_KEY in cached_ds_return_config:
                 return_config[VERSIONED_FLAG_KEY] = cached_ds_return_config.pop(
                     VERSIONED_FLAG_KEY

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -765,7 +765,7 @@ class DataCatalog(CatalogProtocol):
         for ds_name, ds in self._datasets.items():  # type: ignore[assignment]
             if _is_memory_dataset(ds):  # type: ignore[arg-type]
                 continue
-            resolved_config = ds.to_config()  # type: ignore[attr-defined]
+            resolved_config = ds._init_config()  # type: ignore[attr-defined]
             unresolved_config, unresolved_credentials = (
                 self._config_resolver._unresolve_credentials(ds_name, resolved_config)
             )


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4922

## Development notes
- Renamed to `_init_config()` to clearly signal it's for internal use.
- Updated docstring to emphasize that this captures initial configuration only, not dynamic state. 
- Preserved all existing logic.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
