### PR TITLE
Made catalog `get()` and `get_type()` return `None`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,9 +202,9 @@
         "filename": "tests/io/test_data_catalog.py",
         "hashed_secret": "15dd2c9ccec914f1470b4dccb45789844e49cf70",
         "is_verified": false,
-        "line_number": 543
+        "line_number": 547
       }
     ]
   },
-  "generated_at": "2025-07-02T12:35:56Z"
+  "generated_at": "2025-07-02T13:57:09Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,9 +202,9 @@
         "filename": "tests/io/test_data_catalog.py",
         "hashed_secret": "15dd2c9ccec914f1470b4dccb45789844e49cf70",
         "is_verified": false,
-        "line_number": 545
+        "line_number": 543
       }
     ]
   },
-  "generated_at": "2025-07-02T09:35:57Z"
+  "generated_at": "2025-07-02T12:35:56Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,9 +202,9 @@
         "filename": "tests/io/test_data_catalog.py",
         "hashed_secret": "15dd2c9ccec914f1470b4dccb45789844e49cf70",
         "is_verified": false,
-        "line_number": 548
+        "line_number": 545
       }
     ]
   },
-  "generated_at": "2025-06-19T13:42:44Z"
+  "generated_at": "2025-07-02T09:35:57Z"
 }

--- a/docs/catalog-data/advanced_data_catalog_usage.md
+++ b/docs/catalog-data/advanced_data_catalog_usage.md
@@ -86,7 +86,7 @@ intermediate_ds = catalog.get("intermediate_ds", fallback_to_runtime_pattern=Tru
 - The `.get()` method accepts:
   - `fallback_to_runtime_pattern` (bool): If True, unresolved names fallback to `MemoryDataset` or `SharedMemoryDataset` (in `SharedMemoryDataCatalog`).
   - `version`: Specify dataset version if versioning is enabled.
-- If no match is found and fallback is disabled, a `DatasetNotFoundError` is raised.
+- If no match is found and fallback is disabled, `None` is returned.
 
 ## How to add datasets to the catalog
 
@@ -386,8 +386,4 @@ dataset_type = catalog.get_type("example")
 print(dataset_type)  # kedro.io.memory_dataset.MemoryDataset
 ```
 
-If the dataset is not present and no patterns match, the method raises:
-
-```python
-DatasetNotFoundError: Dataset 'nonexistent' not found in the catalog.
-```
+If the dataset is not present and no patterns match, the method returns `None`.

--- a/docs/catalog-data/test_phase.md
+++ b/docs/catalog-data/test_phase.md
@@ -207,7 +207,7 @@ In [1]: catalog.get("reviews#csv")
 Out[1]: kedro_datasets.pandas.csv_dataset.CSVDataset(filepath=.../data/01_raw/reviews.csv'), protocol='file', load_args={}, save_args={'index': False})
 
 In [2]: catalog.get("nonexistent")
-DatasetNotFoundError: Dataset 'nonexistent' not found in the catalog
+In [2]:
 ```
 
 Enable fallback to use runtime defaults:
@@ -538,7 +538,7 @@ intermediate_ds = catalog.get("intermediate_ds", fallback_to_runtime_pattern=Tru
 - The `.get()` method accepts:
   - `fallback_to_runtime_pattern` (bool): If True, unresolved names fallback to `MemoryDataset` or `SharedMemoryDataset` (in `SharedMemoryDataCatalog`).
   - `version`: Specify dataset version if versioning is enabled.
-- If no match is found and fallback is disabled, a `DatasetNotFoundError` is raised.
+- If no match is found and fallback is disabled, `None` is returned.
 
 #### How to add datasets to the catalog
 
@@ -671,10 +671,8 @@ dataset_type = catalog.get_type("example")
 print(dataset_type)  # kedro.io.memory_dataset.MemoryDataset
 ```
 
-If the dataset is not present and no patterns match, the method raises:
-```python
-DatasetNotFoundError: Dataset 'nonexistent' not found in the catalog.
-```
+If the dataset is not present and no patterns match, the method returns `None`.
+
 
 ## Deprecated API
 

--- a/docs/catalog-data/test_phase.md
+++ b/docs/catalog-data/test_phase.md
@@ -673,7 +673,6 @@ print(dataset_type)  # kedro.io.memory_dataset.MemoryDataset
 
 If the dataset is not present and no patterns match, the method returns `None`.
 
-
 ## Deprecated API
 
 The following `DataCatalog` methods and CLI commands are deprecated and should no longer be used.

--- a/kedro/framework/context/catalog_mixins.py
+++ b/kedro/framework/context/catalog_mixins.py
@@ -220,11 +220,12 @@ def _group_ds_by_type(datasets: set[str], catalog: DataCatalog) -> dict[str, lis
         if is_parameter(ds_name):
             continue
 
-        str_type = (
-            catalog.get_type(ds_name)
-            if ds_name in catalog
-            else catalog.default_runtime_patterns["{default}"]["type"]
-        )
+        str_type = None
+        if ds_name in catalog:
+            str_type = catalog.get_type(ds_name)
+
+        if str_type is None:
+            str_type = catalog.default_runtime_patterns["{default}"]["type"]
 
         if str_type not in mapping:
             mapping[str_type] = []

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -1006,7 +1006,7 @@ class CatalogProtocol(Protocol[_C, _DS]):
         """Create a catalog instance from configuration."""
         ...
 
-    def get(self, key: str, fallback_to_runtime_pattern: bool = False) -> _DS:
+    def get(self, key: str, fallback_to_runtime_pattern: bool = False) -> _DS | None:
         """Get a dataset by name from an internal collection of datasets."""
         ...
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -936,7 +936,7 @@ class DataCatalog(CatalogProtocol):
 
         return filtered
 
-    def get_type(self, ds_name: str) -> str:
+    def get_type(self, ds_name: str) -> str | None:
         """
         Access dataset type without adding resolved dataset to the catalog.
 
@@ -944,11 +944,8 @@ class DataCatalog(CatalogProtocol):
             ds_name: The name of the dataset whose type is to be retrieved.
 
         Returns:
-            The fully qualified type of the dataset (e.g., `kedro.io.memory_dataset.MemoryDataset`).
-
-        Raises:
-            DatasetNotFoundError: When the dataset in not in the internal collection, does not match
-                dataset_patterns or user_catch_all_pattern.
+            The fully qualified type of the dataset (e.g., `kedro.io.memory_dataset.MemoryDataset`)
+            or None if dataset does not match dataset_patterns or user_catch_all_pattern.
 
         Example:
         ::
@@ -960,10 +957,11 @@ class DataCatalog(CatalogProtocol):
             # kedro.io.memory_dataset.MemoryDataset
             >>>
             >>> missing_type = catalog.get_type("nonexistent")
-            # Raises DatasetNotFoundError: Dataset 'nonexistent' not found in the catalog.
+            >>> print(missing_type)
+            # None
         """
         if ds_name not in self:
-            raise DatasetNotFoundError(f"Dataset '{ds_name}' not found in the catalog")
+            return None
 
         if ds_name not in self._datasets and ds_name not in self._lazy_datasets:
             ds_config = self._config_resolver.resolve_pattern(ds_name)

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -451,7 +451,7 @@ class DataCatalog(CatalogProtocol):
         """
         yield from self.keys()
 
-    def __getitem__(self, ds_name: str) -> AbstractDataset:
+    def __getitem__(self, ds_name: str) -> AbstractDataset | None:
         """
         Get a dataset by name from the catalog.
 
@@ -463,7 +463,7 @@ class DataCatalog(CatalogProtocol):
             ds_name: The name of the dataset.
 
         Returns:
-            The dataset instance.
+            The dataset instance if found, otherwise None.
 
         Example:
         ::
@@ -921,7 +921,7 @@ class DataCatalog(CatalogProtocol):
             filtered_types = []
             for ds_name in filtered:
                 # Retrieve the dataset type
-                str_type = self.get_type(ds_name)
+                str_type = self.get_type(ds_name) or ""
                 # Match against type_regex and apply by_type filtering
                 if (not type_regex or re.search(type_regex, str_type)) and (
                     not by_type_set or str_type in by_type_set

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -342,6 +342,10 @@ class TestDataCatalog:
         catalog._datasets["bad_ds"] = None
         assert catalog.get("bad_ds") is None
 
+    def test_get_missing_dataset(self):
+        catalog = DataCatalog(datasets={})
+        assert catalog.get("missing_ds") is None
+
     def test_get_type_missing_dataset(self):
         catalog = DataCatalog(datasets={})
         assert catalog.get_type("missing_ds") is None

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -308,9 +308,10 @@ class TestDataCatalog:
         """Test get_dataset() when dataset is not in the catalog but default pattern matches"""
         match_pattern_ds = "match_pattern_ds"
         assert match_pattern_ds not in data_catalog
-        pattern = r"Dataset \'match_pattern_ds\' not found in the catalog"
-        with pytest.raises(DatasetNotFoundError, match=pattern):
-            _ = data_catalog.get(match_pattern_ds, fallback_to_runtime_pattern=False)
+
+        ds = data_catalog.get(match_pattern_ds, fallback_to_runtime_pattern=False)
+        assert ds is None
+
         ds = data_catalog.get(match_pattern_ds, fallback_to_runtime_pattern=True)
         assert isinstance(ds, MemoryDataset)
 
@@ -336,15 +337,12 @@ class TestDataCatalog:
         data_catalog_copy = deepcopy(data_catalog_from_config)
         assert not data_catalog_copy == expected_catalog
 
-    def test_get_returns_none_dataset_raises(self):
+    def test_get_returns_none_dataset(self):
         catalog = DataCatalog(datasets={})
         catalog._datasets["bad_ds"] = None
-        with pytest.raises(
-            DatasetNotFoundError, match="Dataset 'bad_ds' not found in the catalog"
-        ):
-            catalog.get("bad_ds")
+        assert catalog.get("bad_ds") is None
 
-    def test_get_type_missing_dataset_raises(self):
+    def test_get_type_missing_dataset(self):
         catalog = DataCatalog(datasets={})
         assert catalog.get_type("missing_ds") is None
 

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -346,10 +346,7 @@ class TestDataCatalog:
 
     def test_get_type_missing_dataset_raises(self):
         catalog = DataCatalog(datasets={})
-        with pytest.raises(
-            DatasetNotFoundError, match="Dataset 'missing_ds' not found in the catalog"
-        ):
-            catalog.get_type("missing_ds")
+        assert catalog.get_type("missing_ds") is None
 
     class TestDataCatalogToConfig:
         def test_to_config(self, correct_config_versioned, dataset, filepath):


### PR DESCRIPTION
## Description
Solves https://github.com/kedro-org/kedro/issues/4928

## Development notes
We've changed the behaviour of `catalog.get()` and `catalog.get_type()` to return `None` by default instead of raising an error, but kept the rest of the logic with `fallback_to_runtime_pattern` the same.

Currently, we haven't added a warning message for returning `None` (I prefer fewer warnings). When reviewing, please share your opinion on whether we should raise a warning in this case. Happy to add it if the majority thinks differently.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
