### PR TITLE
Optimise the namespace validation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,8 @@
 # Upcoming Release 1.0.0
 ## Major features and improvements
 ## Bug fixes and other changes
+* Improved namespace validation efficiency to prevent significant slowdowns when creating large pipelines
+
 ## Breaking changes to the API
 ## Upcoming deprecations for Kedro 1.0.0
 ## Documentation changes
@@ -18,7 +20,6 @@
 * Changed pipeline filtering for namespace to return exact namespace matches instead of partial matches.
 * Added support for running multiple namespaces within a single session.
 * Updated `kedro registry describe` to return the node name property instead of creating its own name for the node.
-* Improved namespace validation efficiency to prevent significant slowdowns when creating large pipelines
 
 ## Documentation changes
 * Updated the `DataCatalog` documentation with improved structure and detailed description of new features.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 * Changed pipeline filtering for namespace to return exact namespace matches instead of partial matches.
 * Added support for running multiple namespaces within a single session.
 * Updated `kedro registry describe` to return the node name property instead of creating its own name for the node.
+* Improved namespace validation efficiency to prevent significant slowdowns when creating large pipelines
 
 ## Documentation changes
 * Updated the `DataCatalog` documentation with improved structure and detailed description of new features.

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import dynaconf
+import importlib_resources
 import yaml
 from dynaconf import LazySettings
 from dynaconf.validator import ValidationError, Validator
@@ -420,7 +421,7 @@ def find_pipelines(raise_errors: bool = False) -> dict[str, Pipeline]:  # noqa: 
 
     # Handle the case that a project doesn't have a pipelines directory.
     try:
-        pipelines_package = importlib.resources.files(f"{PACKAGE_NAME}.pipelines")
+        pipelines_package = importlib_resources.files(f"{PACKAGE_NAME}.pipelines")
     except ModuleNotFoundError as exc:
         if str(exc) == f"No module named '{PACKAGE_NAME}.pipelines'":
             return pipelines_dict

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -21,7 +21,7 @@ from more_itertools import spy, unzip
 from .transcoding import _strip_transcoding
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Generator, Iterable
 
 
 @dataclass
@@ -336,6 +336,25 @@ class Node:
             String representing node's namespace, typically from outer to inner scopes.
         """
         return self._namespace
+
+    @cached_property
+    def namespace_prefixes(self) -> list[str]:
+        """Return all hierarchical prefixes of the node's namespace.
+
+        Returns:
+            A list of namespace prefixes, from shortest to longest.
+            For example, a namespace 'a.b.c' would return ['a', 'a.b', 'a.b.c'].
+            If the node has no namespace, returns an empty list.
+        """
+        return list(self._enumerate_namespaces())
+
+    def _enumerate_namespaces(self) -> Generator[str]:
+        parts = (self._namespace or "").split(".")
+        prefix = ""
+        for p in parts:
+            prefix += p
+            yield prefix
+            prefix += "."
 
     @cached_property
     def inputs(self) -> list[str]:

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -312,14 +312,14 @@ class Pipeline:
                 if child not in visited:
                     visited.add(child)
                     queue.append((child, [*path, child]))
-        return []
+        return []  # pragma: no cover
 
     def _validate_namespaces(self) -> None:
         from warnings import warn
 
         node_parents: dict[Node, set[Node]] = self.node_dependencies
 
-        # TODO: See if this can become a persistent trie-like datastructure
+        # Here we keep all visited namespaces for each node
         seen_namespaces: dict[Node, dict[str, set[Node]]] = defaultdict(dict)
         for node in self.nodes:
             visited: dict[str, set[Node]] = defaultdict(set)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "dynaconf>=3.1.2,<4.0",
     "fsspec>=2021.4",
     "gitpython>=3.0",
+    "importlib_resources>=1.3,<7.0",  # This can be removed when we drop 3.9 support
     "importlib-metadata>=3.6,<9.0",  # This can be removed when we drop 3.9 support
     "kedro-telemetry>=0.5.0",
     "more_itertools>=8.14.0",

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -423,6 +423,17 @@ class TestNames:
         assert re.match(r"^namespace\.identity__[0-9a-f]{8}$", n.name)
         assert n.short_name == "Identity"
 
+    def test_namespace_prefixes(self):
+        n = node(identity, ["in"], ["out"], namespace="a.b.c.d.e.f")
+        assert n.namespace_prefixes == [
+            "a",
+            "a.b",
+            "a.b.c",
+            "a.b.c.d",
+            "a.b.c.d.e",
+            "a.b.c.d.e.f",
+        ]
+
     def test_named_and_namespaced(self):
         n = node(identity, ["in"], ["out"], name="name", namespace="namespace")
         assert str(n) == "name: identity([in]) -> [out]"


### PR DESCRIPTION
## Description

After adding validation for namespaces in https://github.com/kedro-org/kedro/pull/4603, Kedro was becoming prohibitively slow for any pipelines that had even slightly more complex pipelines that had many paths. The namespace validation was based on going through all paths, which could be exponentially many. This nicely explained issue has an example when the namespace validation just hangs https://github.com/kedro-org/kedro/issues/4943

I've added the example from the issue as a test.

## Development notes

I've reimplemented the algorithm to use the topologically sorted nodes and keep track of the visited pipeline at each node level. This way we go from `O(P)` down to `O(E + V)`, where `P` is the number of paths, `E` is the number of edges and `V` is the number of nodes. This is a very significant improvement, as `P` can be exponential in the number of nodes. When a violation of the namespace interruption occurs, then we use a `BFS` algorithm to find the shortest path starting from a node that exited the violated namespace. Bear in mind that there might be multiple paths that violate that, but only one will be reported (unlike in the previous algorithm), but that should be sufficient for debugging. 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
