### PR TITLE
Fix dataset override behavior in `DataCatalog` with `CatalogConfigResolver`

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -202,9 +202,9 @@
         "filename": "tests/io/test_data_catalog.py",
         "hashed_secret": "15dd2c9ccec914f1470b4dccb45789844e49cf70",
         "is_verified": false,
-        "line_number": 564
+        "line_number": 575
       }
     ]
   },
-  "generated_at": "2025-07-09T14:25:37Z"
+  "generated_at": "2025-07-09T16:53:43Z"
 }


### PR DESCRIPTION
## Description
Fix for https://github.com/kedro-org/kedro/issues/4956

## Development notes

- Changed behavior in `DataCatalog.__init__`: Now if a `dataset` name is defined in both `datasets` and the `config_resolver`, the dataset from `datasets` takes precedence. The conflicting entry from `config_resolver.config `is removed, and a warning is logged instead of raising an error.

- Improved dataset replacement logic in `__setitem__`: When replacing a dataset via `catalog["name"] = ...`, the method now removes any existing references from `_datasets`, `_lazy_datasets`, `_config_resolver.config` and `_load_versions`. This ensures internal consistency and avoids versioning conflicts.

- Updated docstrings for` __init__` and `__setitem__`

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
