### PR TITLE
Added custom CI timeout to save resources and speed up the CI

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -13,6 +13,7 @@ on:
 jobs:
   unit-tests:
     runs-on: ${{ inputs.os }}
+    timeout-minutes: 56 # equal to max + 3*std over the last ~1000 successful runs
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
## Description
Added custom timeout for `unit-tests` job of the `Run all checks on Kedro` workflow based on historical data that could lead to resource savings and faster CI for the project.

#### More details
Over the last ~1000 successful runs, the `unit-tests` job has a maximum runtime of 41 minutes (mean=5, std=5) across all matrix combinations.

However, there are failed runs that fail after reaching the threshold of 6 hours that GitHub imposes. In other words, these jobs seem to get stuck, possibly for external or random reasons. 

One such example is [this](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469533) job run, that failed after 6 hours, while the full list of timed-out jobs feel free to expand the details below. With the proposed changes, a total of **~30 hours would have been saved** over the last few months retrospectively, clearing the queue for other workflows and **speeding up the CI** of the project, while also **saving resources** in general 🌱.

<details>
  <summary>Click here to see all the recently timed-out runs.</summary>

  10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469487)
10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469533)
10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469487)
10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469533)
10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469487)
10-Jun-2025 => [timed-out run](https://github.com/kedro-org/kedro/actions/runs/15560593849/job/43818469533)

</details>

## Development notes
The idea is to set a timeout to stop jobs that run much longer than their historical maximum, because such jobs are probably stuck and will simply fail after GitHub's timeout of 6 hours.

Our PR proposes to set the timeout to `max + 3*std = 56 minutes` where `max` and `std` (standard deviation) are derived from the history of ~1000 successful runs. This will provide sufficient margin if the workflow gets naturally slower in the future, but if you would prefer lower/higher threshold we would be happy to do it.


## Additional Context
Hi,

We are a team of [researchers](https://www.ifi.uzh.ch/en/zest.html) from University of Zurich and we are currently working on energy optimizations in GitHub Actions workflows.

Thanks for your time on this and for your contribution to open-source software in general.

Feel free to let us know (here or in the email below) if you have any questions, and thanks for putting in the time to read this.

Best regards,  
[Konstantinos Kitsios](https://www.ifi.uzh.ch/en/zest/team/konstantinos_kitsios.html)  
konstantinos.kitsios@uzh.ch

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
