### PR TITLE
Use PAT token to clone kedro-starters and avoid API rate limits in e2e tests

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -42,6 +42,7 @@ jobs:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
       branch: ${{ inputs.branch }}
+    secrets: inherit
 
   lint:
     strategy:

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -57,6 +57,7 @@ jobs:
           echo "HADOOP_HOME=C:\hadoop" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
           echo "PATH=$env:HADOOP_HOME\bin;$env:PATH" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
       - name: Clone latest kedro-starters release into package/starters
+        shell: bash
         env:
           GH_E2E_AUTH_TOKEN: ${{ secrets.GH_E2E_AUTH_TOKEN }}
         run: |
@@ -73,11 +74,9 @@ jobs:
             exit 1
           fi
 
-          echo "Using kedro-starters tag: $LATEST_TAG"
           mkdir -p package/starters
           git clone --depth 1 --branch "$LATEST_TAG" \
-            https://x-access-token:$GH_E2E_AUTH_TOKEN@github.com/kedro-org/kedro-starters.git \
-            package/starters
+            https://github.com/kedro-org/kedro-starters.git package/starters
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,15 +56,28 @@ jobs:
           Move-Item .\winutils.exe C:\hadoop\bin
           echo "HADOOP_HOME=C:\hadoop" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
           echo "PATH=$env:HADOOP_HOME\bin;$env:PATH" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
-      - name: Clone kedro-starters into package/starters
+      - name: Clone latest kedro-starters release into package/starters
         env:
           GH_E2E_AUTH_TOKEN: ${{ secrets.GH_E2E_AUTH_TOKEN }}
         run: |
-          LATEST_TAG=$(curl -s -H "Authorization: Bearer $GH_E2E_AUTH_TOKEN" https://api.github.com/repos/kedro-org/kedro-starters/releases/latest | jq -r '.tag_name')
-          echo "📦 Using kedro-starters tag: $LATEST_TAG"
+          API_RESPONSE=$(curl -s -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer $GH_E2E_AUTH_TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/kedro-org/kedro-starters/releases/latest)
+
+          LATEST_TAG=$(echo "$API_RESPONSE" | jq -r '.tag_name')
+
+          if [ -z "$LATEST_TAG" ] || [ "$LATEST_TAG" == "null" ]; then
+            echo "Failed to get latest tag"
+            exit 1
+          fi
+
+          echo "Using kedro-starters tag: $LATEST_TAG"
           mkdir -p package/starters
-          git clone --depth 1 --branch "$LATEST_TAG" https://$GH_E2E_AUTH_TOKEN@github.com/kedro-org/kedro-starters.git package/starters
-          echo "✅ Starter cloned to: $(pwd)/package/starters"
+          git clone --depth 1 --branch "$LATEST_TAG" \
+            https://x-access-token:$GH_E2E_AUTH_TOKEN@github.com/kedro-org/kedro-starters.git \
+            package/starters
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -56,6 +56,15 @@ jobs:
           Move-Item .\winutils.exe C:\hadoop\bin
           echo "HADOOP_HOME=C:\hadoop" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
           echo "PATH=$env:HADOOP_HOME\bin;$env:PATH" | Out-File -Append -Encoding ascii -FilePath $env:GITHUB_ENV
+      - name: Clone kedro-starters into package/starters
+        env:
+          GH_E2E_AUTH_TOKEN: ${{ secrets.GH_E2E_AUTH_TOKEN }}
+        run: |
+          LATEST_TAG=$(curl -s -H "Authorization: Bearer $GH_E2E_AUTH_TOKEN" https://api.github.com/repos/kedro-org/kedro-starters/releases/latest | jq -r '.tag_name')
+          echo "📦 Using kedro-starters tag: $LATEST_TAG"
+          mkdir -p package/starters
+          git clone --depth 1 --branch "$LATEST_TAG" https://$GH_E2E_AUTH_TOKEN@github.com/kedro-org/kedro-starters.git package/starters
+          echo "✅ Starter cloned to: $(pwd)/package/starters"
       - name: Install dependencies
         run: |
           pip install --upgrade pip

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -288,6 +288,11 @@ def create_project_with_starter(context, starter):
 
     if starter == "default":
         starter = Path(__file__).parent / "test_starter"
+    else:
+        # Assume pre-cloned starter from GitHub Actions workflow
+        starter = Path("package") / "starters" / starter
+
+    print(f"📁 Using local starter path: {starter.resolve()}")
 
     args = [
         context.kedro,
@@ -295,7 +300,7 @@ def create_project_with_starter(context, starter):
         "-c",
         str(context.config_file),
         "--starter",
-        str(starter),
+        str(starter.resolve()),
     ]
 
     res = run(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
