### PR TITLE
Fix docstrings

### DIFF
--- a/docs/catalog-data/advanced_data_catalog_usage.md
+++ b/docs/catalog-data/advanced_data_catalog_usage.md
@@ -84,8 +84,8 @@ intermediate_ds = catalog.get("intermediate_ds", fallback_to_runtime_pattern=Tru
 - Both methods retrieve a dataset by name from the catalog’s internal collection.
 - If the dataset isn’t materialized but matches a configured pattern, it's instantiated and returned.
 - The `.get()` method accepts:
-  - `fallback_to_runtime_pattern` (bool): If True, unresolved names fallback to `MemoryDataset` or `SharedMemoryDataset` (in `SharedMemoryDataCatalog`).
-  - `version`: Specify dataset version if versioning is enabled.
+    - `fallback_to_runtime_pattern` (bool): If True, unresolved names fallback to `MemoryDataset` or `SharedMemoryDataset` (in `SharedMemoryDataCatalog`).
+    - `version`: Specify dataset version if versioning is enabled.
 - If no match is found and fallback is disabled, `.get()` method returns `None`.
 - Dictionary-style access raises a `DatasetNotFoundError` if the dataset is missing.
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -323,9 +323,8 @@ class KedroSession:
             KedroSessionError: If more than one run is attempted to be executed during
                 a single session.
         Returns:
-            Any node outputs that cannot be processed by the ``DataCatalog``.
-            These are returned in a dictionary, where the keys are defined
-            by the node outputs.
+            Dictionary with pipeline outputs, where keys are dataset names
+            and values are dataset objects.
         """
         # Report project name
         self._logger.info("Kedro project %s", self._project_path.name)

--- a/kedro/runner/runner.py
+++ b/kedro/runner/runner.py
@@ -80,7 +80,7 @@ class AbstractRunner(ABC):
 
         Returns:
             Dictionary with pipeline outputs, where keys are dataset names
-            and values are dataset object.
+            and values are dataset objects.
         """
         # Apply missing outputs filtering if requested
         if only_missing_outputs:


### PR DESCRIPTION
## Description
Updated `session` docstrings and fixed indentation on `Advanced: Access the Data Catalog in code` page.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
