### PR TITLE
Fix minimal install instructions for v1.0.0 (uv init python version)

### DIFF
--- a/docs/create/minimal_kedro_project.md
+++ b/docs/create/minimal_kedro_project.md
@@ -80,7 +80,7 @@ Next, create a new file named `pyproject.toml` in the project directory with som
 for example using `uv init`:
 
 ```
-uv init --bare --lib
+uv init --bare --lib --python=">=3.9"
 ```
 
 And add the following contents:
@@ -89,7 +89,7 @@ And add the following contents:
 [tool.kedro]
 package_name = "minikedro"
 project_name = "minikedro"
-kedro_init_version = "0.19.9"
+kedro_init_version = "1.0.0"
 source_dir = "."
 ```
 


### PR DESCRIPTION
## Description
Minimal install wasn't working on v1.0.0

Started noticing errors here: https://docs.kedro.org/en/1.0.0/create/minimal_kedro_project/#step-3-install-kedro

`uv kedro add` threw this error:

<details>
<summary>The error...</summary>

```
patcon at MacBook-Pro in ~/repos/kedro_polis_classic (main●●)
$ uv --version
uv 0.7.2 (481d05d8d 2025-04-30)

patcon at MacBook-Pro in ~/repos/kedro_polis_classic (main●●)
$ uv kedro add
Resolved 1 package in 20ms
  × Failed to build `kedro-polis-classic @ file:///Users/patcon/repos/kedro_polis_classic`
  ├─▶ The build backend returned an error
  ╰─▶ Call to `hatchling.build.build_wheel` failed (exit status: 1)

      [stderr]
      Traceback (most recent call last):
        File "<string>", line 11, in <module>
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/build.py", line 58, in build_wheel
          return os.path.basename(next(builder.build(directory=wheel_directory, versions=['standard'])))
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/plugin/interface.py", line 155, in build
          artifact = version_api[version](directory, **build_data)
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/wheel.py", line 477, in build_standard
          for included_file in self.recurse_included_files():
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/plugin/interface.py", line 176, in recurse_included_files
          yield from self.recurse_selected_project_files()
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/plugin/interface.py", line 180, in recurse_selected_project_files
          if self.config.only_include:
        File "/usr/local/Cellar/python@3.8/3.8.20/Frameworks/Python.framework/Versions/3.8/lib/python3.8/functools.py", line 967, in __get__
          val = self.func(instance)
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/config.py", line 713, in only_include
          only_include = only_include_config.get('only-include', self.default_only_include()) or self.packages
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/wheel.py", line 262, in default_only_include
          return self.default_file_selection_options.only_include
        File "/usr/local/Cellar/python@3.8/3.8.20/Frameworks/Python.framework/Versions/3.8/lib/python3.8/functools.py", line 967, in __get__
          val = self.func(instance)
        File "/Users/patcon/.cache/uv/builds-v0/.tmplNSFXN/lib/python3.8/site-packages/hatchling/builders/wheel.py", line 250, in default_file_selection_options
          raise ValueError(message)
      ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

      The most likely cause of this is that there is no directory that matches the name of your project (kedro_polis_classic).

      At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/

      As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

      [tool.hatch.build.targets.wheel]
      packages = ["src/foo"]

      hint: This usually indicates a problem with the package or the build environment.
```
</details>

Got through that by adding this to `pyproject.toml`:

```toml
[tool.hatch.build.targets.wheel]
packages = ["my_project"]
```
But after getting through that, I was getting complaints of there being no `Node` in kedro.pipeline to import.

This was when I realized the root cause:

`uv init --bare --lib` initiated python at `>=3.8`, which caused kedro to be installed <1.0.0, and so all the instructions were wrong.

(Misc note: I even had python 3.6 set as the global python version with pyenv, but I don't think that affected things, as it still chose a minimum python version in pyproject.toml that was beyond that.)

## Development notes
Just ran though it myself. This was the fix that ensured a compatible version of python.

Love you guys, but not going to do the rest of this checklist as I'm just trying to be helpful, but don't have time for your full process <3 It's ok to close this and cherry-pick.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
