### PR TITLE
Loosen pin for pytest-cov

### DIFF
--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -265,7 +265,7 @@ jupyterlab_server>=2.11.1
 jupyterlab~=3.0
 
 # Pytest + useful extensions
-pytest-cov~=3.0
+pytest-cov>=3,<7
 pytest-mock>=1.7.1, <2.0
 pytest~=7.2
 

--- a/features/steps/test_starter/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/features/steps/test_starter/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -31,7 +31,7 @@ docs = [
     "myst-parser>=1.0,<2.1"
 ]
 dev = [
-    "pytest-cov~=3.0",
+    "pytest-cov>=3,<7",
     "pytest-mock>=1.7.1, <2.0",
     "pytest~=7.2",
     "ruff~=0.1.8"

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -10,7 +10,7 @@ lint_pyproject_requirements = ["tool.ruff", "tool.ruff.format", "tool.ruff.lint"
 
 # Requirements and configurations for testing tools and coverage reporting
 test_requirements = (  # For requirements.txt
-    "pytest-cov~=3.0\npytest-mock>=1.7.1, <2.0\npytest~=7.2"
+    "pytest-cov>=3,<7\npytest-mock>=1.7.1, <2.0\npytest~=7.2"
 )
 test_pyproject_requirements = [  # For pyproject.toml
     "tool.pytest.ini_options",

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -32,7 +32,7 @@ docs = [
     "myst-parser>=1.0,<2.1"
 ]
 dev = [
-    "pytest-cov~=3.0",
+    "pytest-cov>=3,<7",
     "pytest-mock>=1.7.1, <2.0",
     "pytest~=7.2",
     "ruff~=0.12.0"

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -183,7 +183,7 @@ def _assert_requirements_ok(
         assert expected["coverage"] == pyproject_config["tool"]["coverage"]
 
         assert (
-            "pytest-cov~=3.0"
+            "pytest-cov>=3,<7"
             in pyproject_config["project"]["optional-dependencies"]["dev"]
         )
         assert (


### PR DESCRIPTION
## Description
Closes https://github.com/kedro-org/kedro/issues/4332

## Development notes
Already done in starters in https://github.com/kedro-org/kedro-starters/pull/291


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
