### PR TITLE
Temporarily pin pip-tools for compile

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -29,6 +29,6 @@ jobs:
         run: |
           make install-test-requirements
           make install-pre-commit
-          uv pip install "pip-tools>=6.5"
+          uv pip install "pip-tools>=6.5,<7.5"
       - name: Run pip-compile
         run: make pip-compile


### PR DESCRIPTION
## Description
`pip-tools` just released a new version which breaks when you have `Click` as a dependency. 
I opened an issue on their side: https://github.com/jazzband/pip-tools/issues/2215

## Development notes
Pinned `pip-tools` below the latest for the time being to make our builds pass.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
