### PR TITLE
Use tomllib, if available, else fall back to tomli

### DIFF
--- a/features/environment.py
+++ b/features/environment.py
@@ -131,6 +131,7 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     install_reqs.append("kedro-datasets[pandas-csvdataset]")
-    install_reqs.append("toml")  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
+    # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to plugin's dependencies.
+    install_reqs.append("toml")
     call([context.pip, "install", *install_reqs], env=context.env)
     return context

--- a/features/environment.py
+++ b/features/environment.py
@@ -119,18 +119,7 @@ def _setup_minimal_env(context):
             ],
             env=context.env,
         )
-        call(
-            [
-                context.python,
-                "-m",
-                "pip",
-                "install",
-                "-e",
-                ".",
-                "toml>=0.10.0",  # TODO(deepyaman): Migrate `kedro-telemetry` off `toml`
-            ],
-            env=context.env,
-        )
+        call([context.python, "-m", "pip", "install", "-e", "."], env=context.env)
         return context
 
 

--- a/features/environment.py
+++ b/features/environment.py
@@ -119,7 +119,18 @@ def _setup_minimal_env(context):
             ],
             env=context.env,
         )
-        call([context.python, "-m", "pip", "install", "-e", "."], env=context.env)
+        call(
+            [
+                context.python,
+                "-m",
+                "pip",
+                "install",
+                "-e",
+                ".",
+                "toml>=0.10.0",  # TODO(deepyaman): Migrate `kedro-telemetry` off `toml`
+            ],
+            env=context.env,
+        )
         return context
 
 
@@ -131,7 +142,5 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     install_reqs.append("kedro-datasets[pandas-csvdataset]")
-    # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to plugin's dependencies.
-    install_reqs.append("toml")
     call([context.pip, "install", *install_reqs], env=context.env)
     return context

--- a/features/environment.py
+++ b/features/environment.py
@@ -131,5 +131,6 @@ def _install_project_requirements(context):
     )
     install_reqs = [req for req in install_reqs if "{" not in req and "#" not in req]
     install_reqs.append("kedro-datasets[pandas-csvdataset]")
+    install_reqs.append("toml")  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
     call([context.pip, "install", *install_reqs], env=context.env)
     return context

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -9,6 +9,7 @@ from time import sleep, time
 
 import behave
 import requests
+import tomli_w
 import yaml
 from behave import given, then, when
 from packaging.requirements import Requirement
@@ -453,10 +454,12 @@ def move_package(context: behave.runner.Context, new_source_dir):
 def update_pyproject_toml(context: behave.runner.Context, new_source_dir):
     """Update `source_dir` in pyproject.toml file."""
     pyproject_toml_path = context.root_project_dir / "pyproject.toml"
-    content = tomllib.load(pyproject_toml_path)
+    with pyproject_toml_path.open("rb") as f:
+        content = tomllib.load(f)
+
     content["tool"]["kedro"]["source_dir"] = new_source_dir
-    content_str = tomllib.dumps(content)
-    pyproject_toml_path.write_text(content_str)
+    with pyproject_toml_path.open("wb") as f:
+        tomli_w.dump(content, f)
 
 
 @given("I have updated kedro requirements")

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -9,10 +9,14 @@ from time import sleep, time
 
 import behave
 import requests
-import toml
 import yaml
 from behave import given, then, when
 from packaging.requirements import Requirement
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 import kedro
 from features.steps import util
@@ -449,9 +453,9 @@ def move_package(context: behave.runner.Context, new_source_dir):
 def update_pyproject_toml(context: behave.runner.Context, new_source_dir):
     """Update `source_dir` in pyproject.toml file."""
     pyproject_toml_path = context.root_project_dir / "pyproject.toml"
-    content = toml.load(pyproject_toml_path)
+    content = tomllib.load(pyproject_toml_path)
     content["tool"]["kedro"]["source_dir"] = new_source_dir
-    content_str = toml.dumps(content)
+    content_str = tomllib.dumps(content)
     pyproject_toml_path.write_text(content_str)
 
 

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -7,7 +7,10 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-import toml
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.framework.project import configure_project
@@ -66,8 +69,8 @@ def _get_project_metadata(project_path: Path) -> ProjectMetadata:
         )
 
     try:
-        metadata_dict = toml.load(pyproject_toml)
-    except Exception as exc:
+        metadata_dict = tomllib.load(pyproject_toml)
+    except tomllib.TOMLDecodeError as exc:
         raise RuntimeError(f"Failed to parse '{_PYPROJECT}' file.") from exc
 
     try:

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -69,7 +69,8 @@ def _get_project_metadata(project_path: Path) -> ProjectMetadata:
         )
 
     try:
-        metadata_dict = tomllib.load(pyproject_toml)
+        with pyproject_toml.open("rb") as f:
+            metadata_dict = tomllib.load(f)
     except tomllib.TOMLDecodeError as exc:
         raise RuntimeError(f"Failed to parse '{_PYPROJECT}' file.") from exc
 

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -7,7 +7,7 @@ import sys
 from pathlib import Path
 from typing import NamedTuple
 
-if sys.version_info >= (3, 11):
+if sys.version_info >= (3, 11):  # pragma: no cover
     import tomllib
 else:  # pragma: no cover
     import tomli as tomllib

--- a/kedro/framework/startup.py
+++ b/kedro/framework/startup.py
@@ -9,7 +9,7 @@ from typing import NamedTuple
 
 if sys.version_info >= (3, 11):
     import tomllib
-else:
+else:  # pragma: no cover
     import tomli as tomllib
 
 from kedro import __version__ as kedro_version

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -2,6 +2,8 @@ import shutil
 import sys
 from pathlib import Path
 
+import tomli_w
+
 if sys.version_info >= (3, 11):
     import tomllib
 else:
@@ -96,8 +98,8 @@ def _remove_from_toml(file_path: Path, sections_to_remove: list) -> None:
     for section in sections_to_remove:
         _remove_nested_section(data, section)
 
-    with open(file_path, "w") as file:
-        tomllib.dump(data, file)
+    with open(file_path, "wb") as file:
+        tomli_w.dump(data, file)
 
 
 def _remove_dir(path: Path) -> None:

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -89,7 +89,7 @@ def _remove_from_toml(file_path: Path, sections_to_remove: list) -> None:
         sections_to_remove (list): A list of section keys to remove from the TOML file.
     """
     # Load the TOML file
-    with open(file_path) as file:
+    with open(file_path, "rb") as file:
         data = tomllib.load(file)
 
     # Remove the specified sections

--- a/kedro/templates/project/hooks/utils.py
+++ b/kedro/templates/project/hooks/utils.py
@@ -1,6 +1,11 @@
-from pathlib import Path
 import shutil
-import toml
+import sys
+from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 current_dir = Path.cwd()
 
@@ -85,14 +90,14 @@ def _remove_from_toml(file_path: Path, sections_to_remove: list) -> None:
     """
     # Load the TOML file
     with open(file_path) as file:
-        data = toml.load(file)
+        data = tomllib.load(file)
 
     # Remove the specified sections
     for section in sections_to_remove:
         _remove_nested_section(data, section)
 
     with open(file_path, "w") as file:
-        toml.dump(data, file)
+        tomllib.dump(data, file)
 
 
 def _remove_dir(path: Path) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ test = [
     "pytest>=7.2,<9.0",
     "requests_mock",
     "s3fs>=2021.4,<2025.8",
-    "toml",  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
     # mypy related dependencies
     "pandas-stubs",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "PyYAML>=4.2,<7.0",
     "rich>=12.0,<15.0",
     "tomli>=1.1.0;python_version<'3.11'",  # tomllib is part of the standard library in Python 3.11+
+    "tomli-w",
     "typing_extensions>=4.0",
 ]
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "pluggy>=1.0",
     "PyYAML>=4.2,<7.0",
     "rich>=12.0,<15.0",
-    "toml>=0.10.0",
+    "tomli>=1.1.0;python_version<'3.11'",  # tomllib is part of the standard library in Python 3.11+
     "typing_extensions>=4.0",
 ]
 keywords = [
@@ -66,12 +66,12 @@ test = [
     "mypy~=1.0",
     "pandas~=2.0",
     "pluggy>=1.0",
-    "pre-commit>=2.9.2, <5.0",  # The hook `mypy` requires pre-commit version 2.9.2.
+    "pre-commit>=2.9.2,<5.0",  # The hook `mypy` requires pre-commit version 2.9.2.
     "pytest-cov>=3,<7",
-    "pytest-mock>=1.7.1, <4.0",
+    "pytest-mock>=1.7.1,<4.0",
     "pytest-xdist[psutil]>=2.2.1,<3.0",
     "pytest>=7.2,<9.0",
-    "s3fs>=2021.4, <2025.8",
+    "s3fs>=2021.4,<2025.8",
     "requests_mock",
     # mypy related dependencies
     "pandas-stubs",
@@ -87,7 +87,7 @@ docs = [
     "mkdocs-mermaid2-plugin>=1.2.1",
     "mkdocs-autorefs>=1.4.1",
     "mkdocs-get-deps>=0.2.0",
-    "mkdocstrings>=0.29.1",
+    "mkdocstrings>=0.291",
     "mkdocstrings-python>=0.29.1",
     "mkdocs-click",
     "griffe"  # Required by mkdocstrings-python for API documentation generation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,8 +72,9 @@ test = [
     "pytest-mock>=1.7.1,<4.0",
     "pytest-xdist[psutil]>=2.2.1,<3.0",
     "pytest>=7.2,<9.0",
-    "s3fs>=2021.4,<2025.8",
     "requests_mock",
+    "s3fs>=2021.4,<2025.8",
+    "toml",  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
     # mypy related dependencies
     "pandas-stubs",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ docs = [
     "mkdocs-mermaid2-plugin>=1.2.1",
     "mkdocs-autorefs>=1.4.1",
     "mkdocs-get-deps>=0.2.0",
-    "mkdocstrings>=0.291",
+    "mkdocstrings>=0.29.1",
     "mkdocstrings-python>=0.29.1",
     "mkdocs-click",
     "griffe"  # Required by mkdocstrings-python for API documentation generation.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ test = [
     "pytest>=7.2,<9.0",
     "requests_mock",
     "s3fs>=2021.4,<2025.8",
+    "toml",  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
     # mypy related dependencies
     "pandas-stubs",
     "types-PyYAML",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,6 @@ test = [
     "types-PyYAML",
     "types-cachetools",
     "types-requests",
-    "types-toml",
 ]
 docs = [
     "mkdocs>=1.6.1",

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 import os
 import shutil
+import sys
 from pathlib import Path
 
 import pytest
-import toml
 import yaml
 from click.testing import CliRunner
 from cookiecutter.exceptions import RepositoryCloneFailed
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as version
 from kedro.framework.cli.starters import (
@@ -143,7 +148,7 @@ def _assert_requirements_ok(
     tools_list = _parse_tools_input(tools)
 
     if "1" in tools_list:
-        pyproject_config = toml.load(pyproject_file_path)
+        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "tool": {
                 "ruff": {
@@ -164,7 +169,7 @@ def _assert_requirements_ok(
         )
 
     if "2" in tools_list:
-        pyproject_config = toml.load(pyproject_file_path)
+        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "pytest": {
                 "ini_options": {
@@ -195,7 +200,7 @@ def _assert_requirements_ok(
         )
 
     if "4" in tools_list:
-        pyproject_config = toml.load(pyproject_file_path)
+        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "optional-dependencies": {
                 "docs": [

--- a/tests/framework/cli/test_starters.py
+++ b/tests/framework/cli/test_starters.py
@@ -144,11 +144,12 @@ def _assert_requirements_ok(
     assert f"has been created in the directory \n{root_path}" in result.output
 
     pyproject_file_path = root_path / "pyproject.toml"
+    with pyproject_file_path.open("rb") as f:
+        pyproject_config = tomllib.load(f)
 
     tools_list = _parse_tools_input(tools)
 
     if "1" in tools_list:
-        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "tool": {
                 "ruff": {
@@ -169,7 +170,6 @@ def _assert_requirements_ok(
         )
 
     if "2" in tools_list:
-        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "pytest": {
                 "ini_options": {
@@ -200,7 +200,6 @@ def _assert_requirements_ok(
         )
 
     if "4" in tools_list:
-        pyproject_config = tomllib.load(pyproject_file_path)
         expected = {
             "optional-dependencies": {
                 "docs": [

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -4,14 +4,19 @@ import configparser
 import json
 import logging
 import re
+import sys
 import textwrap
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any
 
 import pytest
-import toml
 import yaml
 from pandas.testing import assert_frame_equal
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.config import MissingConfigException
@@ -47,7 +52,7 @@ def _write_yaml(filepath: Path, config: dict):
 
 def _write_toml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    toml_str = toml.dumps(config)
+    toml_str = tomllib.dumps(config)
     filepath.write_text(toml_str)
 
 

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -10,13 +10,9 @@ from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any
 
 import pytest
+import tomli_w
 import yaml
 from pandas.testing import assert_frame_equal
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.config import MissingConfigException
@@ -52,8 +48,8 @@ def _write_yaml(filepath: Path, config: dict):
 
 def _write_toml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    toml_str = tomllib.dumps(config)
-    filepath.write_text(toml_str)
+    with filepath.open("wb") as f:
+        tomli_w.dump(config, f)
 
 
 def _write_json(filepath: Path, config: dict):

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -4,7 +4,6 @@ import configparser
 import json
 import logging
 import re
-import sys
 import textwrap
 from pathlib import Path, PurePath, PurePosixPath, PureWindowsPath
 from typing import Any

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -1,19 +1,14 @@
 from __future__ import annotations
 
 import logging
-import sys
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
 from typing import TYPE_CHECKING, Any
 
 import pytest
+import tomli_w
 import yaml
 from dynaconf.validator import Validator
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.framework.hooks import hook_impl
@@ -51,8 +46,8 @@ def _write_yaml(filepath: Path, config: dict):
 
 def _write_toml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    toml_str = tomllib.dumps(config)
-    filepath.write_text(toml_str)
+    with filepath.open("wb") as f:
+        tomli_w.dump(config, f)
 
 
 def _assert_hook_call_record_has_expected_parameters(

--- a/tests/framework/session/conftest.py
+++ b/tests/framework/session/conftest.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import logging
+import sys
 from logging.handlers import QueueHandler, QueueListener
 from multiprocessing import Queue
 from typing import TYPE_CHECKING, Any
 
 import pytest
-import toml
 import yaml
 from dynaconf.validator import Validator
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.framework.hooks import hook_impl
@@ -46,7 +51,7 @@ def _write_yaml(filepath: Path, config: dict):
 
 def _write_toml(filepath: Path, config: dict):
     filepath.parent.mkdir(parents=True, exist_ok=True)
-    toml_str = toml.dumps(config)
+    toml_str = tomllib.dumps(config)
     filepath.write_text(toml_str)
 
 

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -257,7 +257,7 @@ def fake_project(tmp_path, mock_package_name):
             }
         }
     }
-    with pyproject_toml_path.open("wb", encoding="utf-8") as f:
+    with pyproject_toml_path.open("wb") as f:
         tomli_w.dump(payload, f)
 
     (fake_project_dir / "conf" / "base").mkdir(parents=True)

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -9,9 +9,13 @@ from typing import Any
 from unittest.mock import create_autospec
 
 import pytest
-import toml
 import yaml
 from omegaconf import OmegaConf
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.config import AbstractConfigLoader, OmegaConfigLoader
@@ -257,7 +261,7 @@ def fake_project(tmp_path, mock_package_name):
             }
         }
     }
-    toml_str = toml.dumps(payload)
+    toml_str = tomllib.dumps(payload)
     pyproject_toml_path.write_text(toml_str, encoding="utf-8")
 
     (fake_project_dir / "conf" / "base").mkdir(parents=True)

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -9,13 +9,9 @@ from typing import Any
 from unittest.mock import create_autospec
 
 import pytest
+import tomli_w
 import yaml
 from omegaconf import OmegaConf
-
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.config import AbstractConfigLoader, OmegaConfigLoader
@@ -261,8 +257,8 @@ def fake_project(tmp_path, mock_package_name):
             }
         }
     }
-    toml_str = tomllib.dumps(payload)
-    pyproject_toml_path.write_text(toml_str, encoding="utf-8")
+    with pyproject_toml_path.open("wb", encoding="utf-8") as f:
+        tomli_w.dump(payload, f)
 
     (fake_project_dir / "conf" / "base").mkdir(parents=True)
     (fake_project_dir / "conf" / "local").mkdir()

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -4,7 +4,11 @@ import sys
 from pathlib import Path
 
 import pytest
-import toml
+
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.framework.startup import (
@@ -83,7 +87,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -111,7 +115,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -139,7 +143,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
         pattern = (
             "Found unexpected keys in 'pyproject.toml'. Make sure it "
             "only contains the following keys: ['package_name', "
@@ -159,7 +163,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
         pattern = (
             "Missing required keys ['package_name', 'project_name'] "
             "from 'pyproject.toml'."
@@ -170,7 +174,7 @@ class TestGetProjectMetadata:
 
     def test_toml_file_without_kedro_section(self, mocker):
         mocker.patch.object(Path, "is_file", return_value=True)
-        mocker.patch("toml.load", return_value={})
+        mocker.patch("tomllib.load", return_value={})
 
         pattern = "There's no '[tool.kedro]' section in the 'pyproject.toml'."
 
@@ -190,7 +194,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
 
         project_metadata = _get_project_metadata(self.project_path)
 
@@ -211,7 +215,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "
@@ -236,7 +240,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("toml.load", return_value=pyproject_toml_payload)
+        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "
@@ -302,7 +306,7 @@ class TestBootstrapProject:
             }
         }
         pyproject_toml = tmp_path / "pyproject.toml"
-        pyproject_toml.write_text(toml.dumps(pyproject_toml_payload))
+        pyproject_toml.write_text(tomllib.dumps(pyproject_toml_payload))
         src_dir = tmp_path / "src"
         src_dir.mkdir(exist_ok=True)
 

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -88,7 +88,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -116,7 +116,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
 
         actual = _get_project_metadata(self.project_path)
 
@@ -144,7 +144,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
         pattern = (
             "Found unexpected keys in 'pyproject.toml'. Make sure it "
             "only contains the following keys: ['package_name', "
@@ -164,7 +164,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
         pattern = (
             "Missing required keys ['package_name', 'project_name'] "
             "from 'pyproject.toml'."
@@ -175,7 +175,7 @@ class TestGetProjectMetadata:
 
     def test_toml_file_without_kedro_section(self, mocker):
         mocker.patch.object(Path, "is_file", return_value=True)
-        mocker.patch("tomllib.load", return_value={})
+        mocker.patch.object(tomllib, "load", return_value={})
 
         pattern = "There's no '[tool.kedro]' section in the 'pyproject.toml'."
 
@@ -195,7 +195,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
 
         project_metadata = _get_project_metadata(self.project_path)
 
@@ -216,7 +216,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "
@@ -241,7 +241,7 @@ class TestGetProjectMetadata:
                 }
             }
         }
-        mocker.patch("tomllib.load", return_value=pyproject_toml_payload)
+        mocker.patch.object(tomllib, "load", return_value=pyproject_toml_payload)
 
         pattern = (
             f"Your Kedro project version {invalid_version} does not match "

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -4,6 +4,7 @@ import sys
 from pathlib import Path
 
 import pytest
+import tomli_w
 
 if sys.version_info >= (3, 11):
     import tomllib
@@ -306,7 +307,9 @@ class TestBootstrapProject:
             }
         }
         pyproject_toml = tmp_path / "pyproject.toml"
-        pyproject_toml.write_text(tomllib.dumps(pyproject_toml_payload))
+        with open(pyproject_toml, "wb") as f:
+            tomli_w.dump(pyproject_toml_payload, f)
+
         src_dir = tmp_path / "src"
         src_dir.mkdir(exist_ok=True)
 

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -9,7 +9,7 @@ import tomli_w
 if sys.version_info >= (3, 11):
     import tomllib
 else:
-    import tomli as tomllib  # noqa: F401
+    import tomli as tomllib
 
 from kedro import __version__ as kedro_version
 from kedro.framework.startup import (

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -7,9 +7,9 @@ import pytest
 import tomli_w
 
 if sys.version_info >= (3, 11):
-    import tomllib
+    import tomllib  # noqa: F401
 else:
-    import tomli as tomllib
+    import tomli as tomllib  # noqa: F401
 
 from kedro import __version__ as kedro_version
 from kedro.framework.startup import (

--- a/tests/framework/test_startup.py
+++ b/tests/framework/test_startup.py
@@ -7,7 +7,7 @@ import pytest
 import tomli_w
 
 if sys.version_info >= (3, 11):
-    import tomllib  # noqa: F401
+    import tomllib
 else:
     import tomli as tomllib  # noqa: F401
 


### PR DESCRIPTION
## Description
`tomli` is more standards-compliant than `toml`, and it's including in the standard library as `tomllib` since Python 3.11.

`toml` has not had a release since October 31, 2020.

## Development notes
[Built the compatibility layer, as documented.](https://github.com/hukkin/tomli?tab=readme-ov-file#building-a-tomlitomllib-compatibility-layer)

Unfortunately, `kedro-telemetry` relies on `kedro` to provide the `toml` dependency, so that needs to be updated as well.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
