### PR TITLE
Add OmegaConfigLoader._get_unresolved_config method which return dictconfig instead of fully resolved configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ kedro/datasets/*
 # Mise
 .mise.toml
 mise.toml
+
+# uv
+uv.lock

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -263,7 +263,6 @@ class OmegaConfigLoader(AbstractConfigLoader):
                 )
             else:
                 raise exc
-
         resulting_config = self._merge_configs(config, env_config, key, env_path)
 
         if not processed_files and key != "globals":
@@ -454,7 +453,6 @@ class OmegaConfigLoader(AbstractConfigLoader):
         merging_strategy = self.merge_strategy.get(key, "destructive")
         try:
             strategy = MergeStrategies[merging_strategy.upper()]
-
             # Get the corresponding merge function and call it
             merge_function_name = MERGING_IMPLEMENTATIONS[strategy]
             merge_function = getattr(self, merge_function_name)
@@ -603,7 +601,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
     ) -> DictConfig:
         # Destructively merge the two env dirs. The chosen env will override base.
         config_dict = OmegaConf.to_container(config)
-        env_config_dict = OmegaConf.to_container(config)
+        env_config_dict = OmegaConf.to_container(env_config)
         common_keys = config_dict.keys() & env_config_dict.keys()
         if common_keys:
             sorted_keys = ", ".join(sorted(common_keys))

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -372,6 +372,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
         return OmegaConf.merge(*aggregate_config)
 
+    @typing.no_type_check
     def load_and_merge_dir_config(
         self,
         conf_path: str,

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -177,7 +177,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
     def __getitem__(self, key: str) -> dict[str, Any]:
         config = self._getitem_dict_config(key)
-        return self._convert_config_to_dict(config, key)
+        return self._convert_config_to_dict(config)
 
     def _getitem_dict_config(self, key: str) -> dict[str, Any]:
         """Get configuration files by key, load and merge them, and
@@ -203,7 +203,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         self._register_runtime_params_resolver()
 
         if key in self:
-            config = super().__getitem__(key)  # type: ignore[no-any-return]
+            config = super().__getitem__(key)
             return config  # type: ignore[no-any-return]
 
         if key not in self.config_patterns:
@@ -364,10 +364,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
 
         return OmegaConf.merge(*aggregate_config)
 
-    def _convert_config_to_dict(self, config: DictConfig, key: str) -> DictConfig:
-        if key == "parameters":
-            # Merge with runtime parameters only for "parameters"
-            return OmegaConf.to_container(config, resolve=True)
+    def _convert_config_to_dict(self, config: DictConfig) -> DictConfig:
         try:
             config_container = OmegaConf.to_container(config, resolve=True)
         except UnsupportedInterpolationType as exc:
@@ -404,11 +401,11 @@ class OmegaConfigLoader(AbstractConfigLoader):
         """
         # Implementation goes here
 
-        merged_omegaconf_config = self._load_and_merge_dir_config(
+        config = self._load_and_merge_dir_config(
             conf_path, patterns, key, processed_files, read_environment_variables
         )
 
-        return self._convert_config_to_dict(merged_omegaconf_config, key)
+        return self._convert_config_to_dict(config)
 
     @staticmethod
     def _initialise_filesystem_and_protocol(

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -171,7 +171,9 @@ class OmegaConfigLoader(AbstractConfigLoader):
         if key == "globals":
             # Update the cached value at self._globals since it is used by the globals resolver
             self._globals = value
-        super().__setitem__(key, value)
+        if isinstance(value, dict):
+            configdict_value = OmegaConf.create(value)
+        super().__setitem__(key, configdict_value)
 
     def __getitem__(self, key: str) -> dict[str, Any]:
         config = self._getitem_dict_config(key)

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -203,7 +203,9 @@ class OmegaConfigLoader(AbstractConfigLoader):
         self._register_runtime_params_resolver()
 
         if key in self:
-            return super().__getitem__(key)  # type: ignore[no-any-return]
+            print(f"{key} key is found")
+            config = super().__getitem__(key)  # type: ignore[no-any-return]
+            return config  # type: ignore[no-any-return]
 
         if key not in self.config_patterns:
             raise KeyError(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

The goal is to **make the underlying DictConfig** returned by omegaconf accessible to developers as described in #2973 (see rational in the issue: it opens a bunch of use cases). The idea is to have a way to access the unresolved config directly from the catalog. With OmegaConfigLoader, you can do ``config["catalog"]`` or ``config.get("catalog")`` to access the resolved catalog configuration.

This PR adds a ``config._get_unresolved_config("catalog")`` methods which returns the omegaconf ``DictConfig`` object. 

## Development notes
<!-- What have you changed, and how has this been tested? -->

This is almost only refactoring to postpone the resolution of config as late as possible (basically, keep the DictConfig object until __getitem__ is called). 

Steps: 
- ``__getitem__`` is only a wrapper of two methods: 
    - ``_get_unresolved_config`` which get the ``DictConfig`` object. It itself calls the refactored ``_load_and_merge_dir_config``which is almost identical to the existing ``load_and_merge_dir_config``, except that the conversion to a dict is not done at the end of the function
    - _convert_config_to_dict which handles the conversion through ``to_container`` calls
I have updated ``OmegaConfigLoader.load_and_merge_dir_config`` to split it into 2 methods: 
- ``_load_and_merge_dir_config_as_dictconfig`` which contains almost all the logic of the original method but returns a DictConfig object (not resolved to a container yet)
- ``load_and_merge_dir_config`` which now call ``_load_and_merge_dir_config_as_dictconfig`` and ``Omegaconf.to_container`` to convert back this ``DictConfig`` object to a python ``dict``. 

#### Comments: 

- ``OmegaConfigLoader.load_and_merge_dir_config`` is no longer used, but it is kept for retrocompatiblity. it now call 
``_load_and_merge_dir_config`` and ``_convert_config_to_dict`` to avoid code duplication, but this pure refactoring. It should be removed in future version, but since it is public API I left it there for now.  
- I did not modify any of the existing logic, hence, all tests pass except 1 (see below) and the public API remains untouched. 
- I did not modify the public API because it should be a much wider change, but I think the namings  should be reworded and the ``_get_unresolved_config```should ultimately be part of the public API. This changes is a first step to give a way to developers to open new use cases which are currently blocked and measure adoption while keeping the cost for the engineering team quite low. This should ultimately be reassessed whe polishing the public API surface for kedro 2.0. 

#### :warning: To be discussed

The change is not fully backward compatible (and I don't see how I can make it fully backward compatible) because the postponing the resolution of the config after merging the different config (from the same folder, then from different environments - base and the other one chosen) leads to differents results, cf the following example: 

```yaml 
# conf/base/parameters.yml

param1: "${param2}
param2: "base"

# conf/local/parameters.yml
param2: "local"

```
leads to 
- ``{param1: "base", param2: "local"}`` with the current version of code (first resolved, then merged)
- ``{param1: "local", param2: "local"}`` with the proposed change in this PR (first merged, then resolved)

My intuition is that the proposed changed should the expected behaviour from a user point of view, but I was very surprised that there exist a test which suggest that the current behaviour is intended, see: 

https://github.com/kedro-org/kedro/blob/a578398dda3af9a35f5bc20312b34d5b2a05914c/tests/config/test_omegaconf_config.py#L736-L743

No matter what I think , this would be technically a breaking change and cannot be implemented as is. 

Can someone explain the context and *why* we choose this order of resolution ? Maybe @merelcht, @ankatiyar or @astrojuanlu who did most of the work on this topic IIRC? 

If someone has a clever idea to make this work I'd love to make this change merged. 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
