### PR TITLE
Remove test dependency on 3rd-party `toml` library

### DIFF
--- a/features/windows_reqs.txt
+++ b/features/windows_reqs.txt
@@ -5,6 +5,5 @@ behave==1.3.1
 pandas~=1.3
 psutil~=7.0
 requests~=2.32
-toml~=0.10.1
 PyYAML>=4.2, <7.0
 packaging>=20.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,6 @@ test = [
     "pytest>=7.2,<9.0",
     "requests_mock",
     "s3fs>=2021.4,<2025.8",
-    "toml",  # TODO(deepyaman): Migrate `kedro-telemetry` or add `toml` to the plugin's dependencies
     # mypy related dependencies
     "pandas-stubs",
     "types-PyYAML",


### PR DESCRIPTION
## Description
Remove unnecessary test dependency

## Development notes
Tested in CI

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
