### PR TITLE
Remove duplicate headings, and further standardise

### DIFF
--- a/docs/api/framework/kedro.framework.cli.md
+++ b/docs/api/framework/kedro.framework.cli.md
@@ -4,7 +4,6 @@
       members: false
       show_source: false
 
-
 | Submodule                          | Description                                                                 |
 |------------------------------------|-----------------------------------------------------------------------------|
 | [`kedro.framework.cli.catalog`](#kedro.framework.cli.catalog) | A collection of CLI commands for working with Kedro catalog.               |
@@ -16,6 +15,7 @@
 | [`kedro.framework.cli.registry`](#kedro.framework.cli.registry) | A collection of CLI commands for working with registered Kedro pipelines.  |
 | [`kedro.framework.cli.starters`](#kedro.framework.cli.starters) | `kedro` is a CLI for managing Kedro projects.                               |
 | [`kedro.framework.cli.utils`](#kedro.framework.cli.utils)     | Utilities for use with click.                                              |
+
 
 ::: kedro.framework.cli.catalog
     options:

--- a/docs/api/framework/kedro.framework.hooks.md
+++ b/docs/api/framework/kedro.framework.hooks.md
@@ -11,19 +11,16 @@
 | [`kedro.framework.hooks.specs`](#kedro.framework.hooks.specs)     | Contains specifications for all callable hooks in Kedro's execution timeline. |
 
 
-## kedro.framework.hooks.manager
 ::: kedro.framework.hooks.manager
     options:
       members: true
       show_source: true
 
-## kedro.framework.hooks.markers
 ::: kedro.framework.hooks.markers
     options:
       members: true
       show_source: true
 
-## kedro.framework.hooks.specs
 ::: kedro.framework.hooks.specs
     options:
       members: true

--- a/docs/api/framework/kedro.framework.md
+++ b/docs/api/framework/kedro.framework.md
@@ -4,7 +4,6 @@
       members: false
       show_source: false
 
-
 | Module                          | Description                                                                 |
 |---------------------------------|-----------------------------------------------------------------------------|
 | [`kedro.framework.cli`](kedro.framework.cli.md) | Implements commands available from Kedro's CLI.                          |


### PR DESCRIPTION
## Description
I noticed duplicate headings while perusing the docs on hooks

<img width="1512" height="945" alt="image" src="https://github.com/user-attachments/assets/8c75f63a-03c4-4c23-a481-e675737bd0f0" />

## Development notes
See https://kedro--5084.org.readthedocs.build/en/5084/api/framework/kedro.framework.hooks/, compared to https://docs.kedro.org/en/1.0.0/api/framework/kedro.framework.hooks/

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
