### PR TITLE
Fix typo in documentation on minimal Kedro project

### DIFF
--- a/docs/create/minimal_kedro_project.md
+++ b/docs/create/minimal_kedro_project.md
@@ -93,12 +93,11 @@ kedro_init_version = "0.19.9"
 source_dir = "."
 ```
 
-At this point, your workingn directory should look like this:
+At this point, your working directory should look like this:
 ```bash
 .
 ├── pyproject.toml
 ```
-
 
 !!! note
     Note we define `source_dir = "."`, usually we keep our source code inside a directory called `src`.


### PR DESCRIPTION
## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
