### PR TITLE
Make Kedro core lightweight by moving cookiecutter, gitpython, rich, and build out of core dependencies

### DIFF
--- a/kedro/framework/cli/_ephemeral.py
+++ b/kedro/framework/cli/_ephemeral.py
@@ -1,0 +1,92 @@
+"""Helper for ephemeral re-execution when optional tools are missing."""
+
+from __future__ import annotations
+
+import functools
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _have_all(modules: list[str]) -> bool:
+    """Check if all required modules are importable."""
+    return all(importlib.util.find_spec(m) for m in modules)
+
+
+def ensure_or_ephemeral(required_modules: list[str], argv: list[str]) -> None:
+    """If any required module is missing, re-exec the CLI via uvx ephemerally.
+
+    Args:
+        required_modules: List of module names to check (e.g., ["cookiecutter", "git"])
+        argv: Command-line arguments (sys.argv)
+
+    Raises:
+        SystemExit: If deps are missing and fallback is not possible/allowed
+    """
+    if _have_all(required_modules):
+        return  # All tools available, proceed normally
+
+    # Missing tools - check if ephemeral fallback is allowed
+    if os.environ.get("KEDRO_NO_UVX_FALLBACK"):
+        miss = [m for m in required_modules if not importlib.util.find_spec(m)]
+        raise SystemExit(
+            "Missing tools: " + ", ".join(miss) + "\n"
+            "Install locally, e.g.:\n"
+            f"  pip install {' '.join(miss)}\n"
+            "Or unset KEDRO_NO_UVX_FALLBACK to allow ephemeral fallback."
+        )
+
+    # Check if uvx is available
+    if not shutil.which("uvx"):
+        raise SystemExit(
+            "Missing tools and no uvx found.\n"
+            "Install tools locally OR install uv:\n"
+            "  pip install uv"
+        )
+
+    # Prevent infinite loop if uvx re-exec fails
+    if os.environ.get("KEDRO_UVX_REEXEC") == "1":
+        raise SystemExit("uvx re-exec loop detected; aborting.")
+
+    # Re-execute via uvx
+    env = {**os.environ, "KEDRO_UVX_REEXEC": "1"}
+    cmd = ["uvx", "--from", "kedro[create]", "kedro", *argv[1:]]
+    print(
+        "🔧 Missing tools — running ephemerally via uvx:\n  ",
+        " ".join(cmd),
+        file=sys.stderr,
+    )
+    raise SystemExit(subprocess.call(cmd, env=env))
+
+
+def ephemeral_if_missing(modules: list[str]) -> Callable:
+    """Decorator for Click commands that need extra tooling.
+
+    Args:
+        modules: List of module names required (e.g., ["cookiecutter", "git"])
+
+    Returns:
+        Decorator function
+
+    Example:
+        @cli.command()
+        @ephemeral_if_missing(["cookiecutter", "git"])
+        def new(...):
+            ...
+    """
+
+    def deco(func: Callable) -> Callable:
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
+            ensure_or_ephemeral(modules, sys.argv)
+            return func(*args, **kwargs)
+
+        return wrapper
+
+    return deco

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, NamedTuple
 import click
 
 import kedro
+from kedro.framework.cli._ephemeral import ephemeral_if_missing
 from kedro.framework.cli.utils import (
     KedroCliError,
     _clean_pycache,
@@ -100,6 +101,7 @@ def pipeline() -> None:
 )
 @env_option(help="Environment to create pipeline configuration in. Defaults to `base`.")
 @click.pass_obj  # this will pass the metadata as first argument
+@ephemeral_if_missing(["build", "cookiecutter", "git", "rich"])
 def create_pipeline(
     metadata: ProjectMetadata,
     /,
@@ -109,7 +111,11 @@ def create_pipeline(
     env: str,
     **kwargs: Any,
 ) -> None:
-    """Create a new modular pipeline by providing a name."""
+    """Create a new modular pipeline by providing a name.
+
+    If cookiecutter isn't installed, Kedro will automatically use uvx to run
+    pipeline creation ephemerally (no local install needed).
+    """
     package_dir = metadata.source_dir / metadata.package_name
     project_root = metadata.project_path / metadata.project_name
     conf_source = settings.CONF_SOURCE

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -23,6 +23,7 @@ from attrs import define, field
 
 import kedro
 from kedro import __version__ as version
+from kedro.framework.cli._ephemeral import ephemeral_if_missing
 from kedro.framework.cli.utils import (
     CONTEXT_SETTINGS,
     KedroCliError,
@@ -296,6 +297,7 @@ def starter() -> None:
     help=TELEMETRY_ARG_HELP,
     type=click.Choice(["yes", "no", "y", "n"], case_sensitive=False),
 )
+@ephemeral_if_missing(["build", "cookiecutter", "git", "rich"])
 def new(  # noqa: PLR0913
     config_path: str,
     starter_alias: str,
@@ -307,7 +309,11 @@ def new(  # noqa: PLR0913
     telemetry_consent: str,
     **kwargs: Any,
 ) -> None:
-    """Create a new kedro project."""
+    """Create a new kedro project.
+
+    If cookiecutter or gitpython aren't installed, Kedro will automatically
+    use uvx to run project creation ephemerally (no local install needed).
+    """
     flag_inputs = {
         "config": config_path,
         "starter": starter_alias,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,21 +12,19 @@ authors = [
 description = "Kedro helps you build production-ready data and analytics pipelines"
 requires-python = ">=3.10"
 dependencies = [
+    # Runtime-only dependencies (project creation tools moved to [project.optional-dependencies.create])
     "attrs>=21.3",
-    "build>=0.7.0",
     "cachetools>=4.1",
     "click>=8.2",
-    "cookiecutter>=2.1.1,<3.0",
     "dynaconf>=3.1.2,<4.0",
     "fsspec>=2021.4",
-    "gitpython>=3.0",
     "kedro-telemetry>=0.5.0",
     "more_itertools>=8.14.0",
     "omegaconf>=2.1.1",
     "parse>=1.19.0",
     "pluggy>=1.0",
     "PyYAML>=4.2,<7.0",
-    "rich>=12.0,<15.0",
+   
     "tomli>=1.1.0;python_version<'3.11'",  # tomllib is part of the standard library in Python 3.11+
     "tomli-w",
     "typing_extensions>=4.0",
@@ -96,7 +94,14 @@ jupyter = [
 benchmark = [
     "asv"
 ]
-all = [ "kedro[test,docs,jupyter,benchmark]" ]
+create = [
+    # Project creation dependencies (optional; kedro new falls back to uvx if missing)
+    "cookiecutter>=2.1.1,<3.0",
+    "gitpython>=3.0",
+    "build>=0.7.0",
+    "rich>=12.0,<15.0",
+]
+all = [ "kedro[test,docs,jupyter,benchmark,create]" ]
 
 [project.urls]
 Homepage = "https://kedro.org"


### PR DESCRIPTION
## Description

**NOTE - Please don’t look too closely at the code... this was a quick experiment written with AI code assist. The main thing to review is the flow, particularly how project creation dependencies are invoked ephemerally in a non-breaking way**.

This update makes Kedro’s core installation lighter by removing dependencies that are only needed during project creation. 

Cookiecutter, gitpython, rich, and build are no longer part of Kedro’s default dependencies. They’re now grouped under a new optional extra called [create] and installed only when needed.

When users run `kedro new` or` kedro pipeline create` without these extras installed, Kedro automatically falls back to using uvx to temporarily install the required tools for that command.

All other Kedro commands (like kedro run or kedro viz) continue to work as before — with no new dependencies added to the runtime environment.

## Development Notes

- Removes cookiecutter, gitpython, rich, and build from Kedro’s core dependencies.
- Adds a new optional extra:
  [project.optional-dependencies]
  create = ["cookiecutter", "gitpython", "rich", "build"]
- Adds a fallback so `kedro new` and `kedro pipeline create` automatically run via uvx if the create extra isn’t installed.
- Keeps Kedro’s runtime environment smaller and faster to install.

Also, In this PR, I’ve shown how rich could be installed ephemerally, but to truly make it optional we’d need some changes to the logging setup (to handle missing imports gracefully). technically, that would let us remove rich from core dependencies and move it under an optional extra like kedro[rich].


## QA Notes

Before testing, install this dev build: `pip install -e .`

  ### 1. Project creation

```kedro new --starter=<starter>```
 Should automatically use uvx to install the create dependencies and create the project successfully.

 ### 2. Immediately after project creation

Open the generated project’s conf/logging.yml.

Comment out the rich handler section and replace the root handlers with console.

It should look like this:
```
# rich:
#   class: kedro.logging.RichHandler
#   rich_tracebacks: True
#   # Advanced options for customisation.
#   # See https://docs.kedro.org/en/stable/logging/logging.html#project-side-logging-configuration
#   # tracebacks_show_locals: False

root:
  handlers: [console, info_file_handler]
```

### 3. Pipeline creation

`kedro pipeline create <name>`
Should also work through the same uvx fallback if cookiecutter, gitpython, rich, or build are not installed locally.

### 4. Run the project

`kedro run`
Logs should display normally in the console using the console handler.




## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
