### PR TITLE
(docs): UK spelling - Change behavior to behaviour everywhere

### DIFF
--- a/.github/styles/Kedro/ukspelling.yml
+++ b/.github/styles/Kedro/ukspelling.yml
@@ -12,6 +12,7 @@ tokens:
   - '(?:\w+)log'
   - '(?:\w+)lor'
   - '(?:\w+)lyze'
+  - 'behavior'
 exceptions:
     - backlog
     - blog

--- a/docs/integrations-and-plugins/great_expectations.md
+++ b/docs/integrations-and-plugins/great_expectations.md
@@ -208,7 +208,7 @@ class DataValidationHooks:
 1. **Configuration**: The `EXPECTATIONS` dictionary maps dataset names to lists of expectations
 2. **Automatic triggering**: Before/after each node runs, the hooks check if any inputs/outputs need validation
 3. **Selective validation**: Only validates datasets you've explicitly configured
-4. **Fail-fast behavior**: If validation fails, the pipeline stops immediately with a clear error message
+4. **Fail-fast behaviour**: If validation fails, the pipeline stops immediately with a clear error message
 
 Register your custom hook in `src/spaceflights_great_expectations/settings.py`:
 

--- a/docs/integrations-and-plugins/pandera.md
+++ b/docs/integrations-and-plugins/pandera.md
@@ -289,7 +289,7 @@ def validate_datasets(companies: pd.DataFrame, shuttles: pd.DataFrame, reviews: 
             schema.validate(df, lazy=True)
         except SchemaErrors:
             # Re-raise so Kedro stops the pipeline; you can customize logging or
-            # aggregate results before raising if you prefer non-eager behavior.
+            # aggregate results before raising if you prefer non-eager behaviour.
             raise
 ```
 
@@ -312,18 +312,18 @@ def create_pipeline(**kwargs) -> Pipeline:
 
 - Use a validation node when you want the validation step visible in the DAG and to create explicit validated outputs (you can also make validation nodes pass data through by returning validated data).
 - Prefer loading schemas from the `schemas` module (as shown) or from config; avoid hardcoding rules inside hook/node bodies.
-- Decide on eager vs. lazy behavior: this example uses `lazy=True` to collect all errors; you can switch to `lazy=False` for fail-fast behavior.
+- Decide on eager vs. lazy behaviour: this example uses `lazy=True` to collect all errors; you can switch to `lazy=False` for fail-fast behaviour.
 
 ## Advanced use cases
 
-### Controlling validation behavior with environment variables
+### Controlling validation behaviour with environment variables
 
-You can control validation behavior without modifying code by using environment variables.
+You can control validation behaviour without modifying code by using environment variables.
 
 Create configuration helpers in `src/spaceflights_pandera/schemas/__init__.py`:
 
 ```python
-"""Configuration helpers for validation behavior."""
+"""Configuration helpers for validation behaviour."""
 import os
 
 
@@ -423,7 +423,7 @@ class PanderaValidationHook:
         return {**inputs, **validated_inputs}
 ```
 
-Now you can control validation behavior:
+Now you can control validation behaviour:
 
 ```bash
 # Disable validation entirely (for quick debugging)


### PR DESCRIPTION
## Description
Our guidelines state we use UK spelling, but occurrences of `behavior` aren't caught. They are now and I changed them all to UK spelling `behaviour`.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
