### PR TITLE
Add benchmark tests for KedroSession

### DIFF
--- a/kedro_benchmarks/benchmark_session.py
+++ b/kedro_benchmarks/benchmark_session.py
@@ -4,13 +4,9 @@
 import logging
 import os
 import shutil
-import sys
 from pathlib import Path
 
-if sys.version_info >= (3, 11):
-    import tomllib
-else:
-    import tomli as tomllib
+import tomllib
 
 from kedro.framework.cli.cli import KedroCLI
 from kedro.framework.session import KedroSession


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/issues/5279

Adds benchmark tests for the KedroSession class.

Tests create a dummy Kedro project using the KedroCLI and run the following tests:
- Time how long just the session startup takes.
- Time how long the session startup + load_context() takes
- Time how long it takes to load and run 5 pipelines
- Time how long it takes to load and run a single pipeline.

The nodes on these pipelines, for now, are dummy nodes that do a very small task, and save it to a MemoryDataset.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
