### PR TITLE
Check for cookiecutter runtime and call uvx if missing

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -13,6 +13,7 @@ import stat
 import sys
 import tempfile
 import warnings
+from importlib.util import find_spec
 from itertools import groupby
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -324,6 +325,21 @@ def new(  # noqa: PLR0913
 
     _validate_flag_inputs(flag_inputs)
     starters_dict = _get_starters_dict()
+
+    if find_spec("cookiecutter") is None or find_spec("git") is None:
+        uvx_path = shutil.which("uvx")
+        if not uvx_path:
+            raise KedroCliError(
+                "Creating a new Kedro project requires `uvx` or `kedro[new]`. Please install one to continue."
+            )
+        uvx_command = [
+            uvx_path,
+            "--from",
+            f"kedro[new]@{version}",
+            "kedro",
+            *sys.argv[1:],
+        ]
+        os.execv(uvx_path, uvx_command)  # noqa: S606
 
     if starter_alias in starters_dict:
         if directory:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,10 @@ classifiers = [
 dynamic = ["readme", "version"]
 
 [project.optional-dependencies]
+new = [
+    "cookiecutter>=2.1.1,<3.0",
+    "gitpython>=3.0",
+]
 test = [
     "behave>=1.2.6,<2.0",
     "coverage[toml]",
@@ -97,7 +101,7 @@ jupyter = [
 benchmark = [
     "asv"
 ]
-all = [ "kedro[test,docs,jupyter,benchmark]" ]
+all = [ "kedro[new,test,docs,jupyter,benchmark]" ]
 
 [project.urls]
 Homepage = "https://kedro.org"


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

https://github.com/kedro-org/kedro/issues/3967

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
