### PR TITLE
Fix spark starter test

### DIFF
--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -545,9 +545,6 @@ def check_created_project_structure_from_tools(context, tools):
     if "data" in tools_list:  # data tool
         assert is_created("data"), "data directory does not exist"
 
-    if "pyspark" in tools_list:  # PySpark tool
-        assert is_created("conf/base/spark.yml"), "spark.yml does not exist"
-
     if "viz" in tools_list:  # viz tool
         expected_reporting_path = Path(
             f"src/{context.package_name}/pipelines/reporting"


### PR DESCRIPTION
## Description
Fix https://github.com/kedro-org/kedro-starters/issues/310

After we've changed the way Spark is installed for starters (https://github.com/kedro-org/kedro-starters/pull/303) `conf/base/spark.yml` does not exist no more.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
