### PR TITLE
Pin cachetools to <7 to fix ParallelRunner multiprocessing regression

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ requires-python = ">=3.10"
 dependencies = [
     "attrs>=21.3",
     "build>=0.7.0",
-    "cachetools>=4.1,<7.0",
+    "cachetools>=4.1,<7.0", # Pinned because cachetools 7 breaks Kedro multiprocessing
     "click>=8.2",
     "cookiecutter>=2.1.1,<3.0",
     "dynaconf>=3.1.2,<4.0",


### PR DESCRIPTION
## Description

Resolves #5348 , and #5347 

Nightly CI unit tests started failing after the release of cachetools 7.0.0 on Feb 1st.

cachetools 7.0.0 introduces a [breaking internal change](https://github.com/tkem/cachetools/blob/master/CHANGELOG.rst)  by converting @cachedmethod wrappers to descriptors, as noted in the release notes. These descriptor wrappers are not picklable and break multiprocessing execution in Kedro’s ParallelRunner, causing hook events to be dropped and related tests to fail.

This change caps cachetools to <7 to restore CI stability while compatibility with cachetools 7 is investigated.

Also created a follow-up ticket to investigate longer term - https://github.com/kedro-org/kedro/issues/5351

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
