### PR TITLE
Use much-faster OmegaConf.unsafe_merge over .merge

### DIFF
--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -373,11 +373,12 @@ class OmegaConfigLoader(AbstractConfigLoader):
         if key == "parameters":
             # Merge with runtime parameters only for "parameters"
             return OmegaConf.to_container(
-                OmegaConf.merge(*aggregate_config, self.runtime_params), resolve=True
+                OmegaConf.unsafe_merge(*aggregate_config, self.runtime_params),
+                resolve=True,
             )
 
         merged_config_container = OmegaConf.to_container(
-            OmegaConf.merge(*aggregate_config), resolve=True
+            OmegaConf.unsafe_merge(*aggregate_config), resolve=True
         )
         return {
             k: v for k, v in merged_config_container.items() if not k.startswith("_")
@@ -588,7 +589,7 @@ class OmegaConfigLoader(AbstractConfigLoader):
         config: dict[str, Any], env_config: dict[str, Any], env_path: str | None = None
     ) -> Any:
         # Soft merge the two env dirs. The chosen env will override base if keys clash.
-        return OmegaConf.to_container(OmegaConf.merge(config, env_config))
+        return OmegaConf.to_container(OmegaConf.unsafe_merge(config, env_config))
 
     def _is_hidden(self, path_str: str) -> bool:
         """Check if path contains any hidden directory or is a hidden file"""


### PR DESCRIPTION
## Description

From https://omegaconf.readthedocs.io/en/latest/usage.html#omegaconf-unsafe-merge:

> OmegaConf offers a second faster function to merge config objects:
> 
> `conf = OmegaConf.unsafe_merge(base_cfg, model_cfg, optimizer_cfg, dataset_cfg)`
> Unlike OmegaConf.merge(), unsafe_merge() is destroying the input configs and they should no longer be used after this call. The upside is that it’s substantially faster.

`OmegaConfigLoader` loads/constructs the inputs to `OmegaConf.merge`, so they don't need to be preserved.

## Development notes

Testing by making sure it passes the existing test suite. Beyond that, I read the code for `OmegaConfigLoader`, and don't think there should be an issue.

It's definitely faster, although I don't know about _much_ faster:

```bash
(kedro) deepyaman@Deepyamans-MacBook-Pro kedro % asv run main~1..deepyaman-patch-1 -b ocl
· Creating environments
· Discovering benchmarks
·· Uninstalling from virtualenv-py3.13-kedro-datasets[pandas]
·· Installing b15a530a <deepyaman-patch-1> into virtualenv-py3.13-kedro-datasets[pandas].
· Running 14 total benchmarks (2 commits * 1 environments * 7 benchmarks)
[ 0.00%] · For Kedro commit b15a530a <deepyaman-patch-1>:
[ 0.00%] ·· Benchmarking virtualenv-py3.13-kedro-datasets[pandas]
[ 3.57%] ··· Running (benchmark_ocl.TimeOmegaConfigLoader.time_loading_catalog--).......
[28.57%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_catalog                                                                                                                                         388±6ms
[32.14%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_globals                                                                                                                                         100±1ms
[35.71%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_parameters                                                                                                                                      104±1ms
[39.29%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_parameters_runtime                                                                                                                              104±1ms
[42.86%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_merge_soft_strategy                                                                                                                                    604±10ms
[46.43%] ··· benchmark_ocl.TimeOmegaConfigLoaderAdvanced.time_loading_catalog                                                                                                                                 603±9ms
[50.00%] ··· benchmark_ocl.TimeOmegaConfigLoaderAdvanced.time_loading_parameters                                                                                                                           37.5±0.6ms
[50.00%] · For Kedro commit 37ec20e7 <main>:
[50.00%] ·· Building for virtualenv-py3.13-kedro-datasets[pandas].
[50.00%] ·· Benchmarking virtualenv-py3.13-kedro-datasets[pandas]
[53.57%] ··· Running (benchmark_ocl.TimeOmegaConfigLoader.time_loading_catalog--).......
[78.57%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_catalog                                                                                                                                         482±6ms
[82.14%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_globals                                                                                                                                         124±2ms
[85.71%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_parameters                                                                                                                                      128±6ms
[89.29%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_loading_parameters_runtime                                                                                                                              127±2ms
[92.86%] ··· benchmark_ocl.TimeOmegaConfigLoader.time_merge_soft_strategy                                                                                                                                    736±20ms
[96.43%] ··· benchmark_ocl.TimeOmegaConfigLoaderAdvanced.time_loading_catalog                                                                                                                                692±20ms
[100.00%] ··· benchmark_ocl.TimeOmegaConfigLoaderAdvanced.time_loading_parameters                                                                                                                           38.2±0.3ms
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
