### PR TITLE
Add kedro server

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -98,6 +98,7 @@ def info() -> None:
         "package": "kedro.framework.cli.project.package",
         "jupyter": "kedro.framework.cli.jupyter.jupyter",
         "pipeline": "kedro.framework.cli.pipeline.pipeline",
+        "server": "kedro.framework.cli.server.server_group",
     },
 )
 def project_commands() -> None:

--- a/kedro/framework/cli/server.py
+++ b/kedro/framework/cli/server.py
@@ -1,0 +1,116 @@
+"""CLI commands for Kedro server."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import click
+
+from kedro.framework.cli.utils import CONTEXT_SETTINGS, KedroCliError
+from kedro.framework.startup import bootstrap_project
+from kedro.server.config import DEFAULT_HOST, DEFAULT_PORT, KEDRO_PROJECT_PATH_ENV
+from kedro.utils import find_kedro_project
+
+if TYPE_CHECKING:
+    from kedro.framework.startup import ProjectMetadata
+
+
+@click.group(name="server")
+def server_group() -> None:
+    """Commands for running Kedro as an HTTP server."""
+    pass
+
+
+@server_group.command(name="start", context_settings=CONTEXT_SETTINGS)
+@click.option(
+    "--host",
+    "-h",
+    type=str,
+    default=DEFAULT_HOST,
+    help=f"Host to bind the server to. Default: {DEFAULT_HOST}",
+)
+@click.option(
+    "--port",
+    "-p",
+    type=int,
+    default=DEFAULT_PORT,
+    help=f"Port to bind the server to. Default: {DEFAULT_PORT}",
+)
+@click.option(
+    "--reload",
+    is_flag=True,
+    default=False,
+    help="Enable auto-reload for development. Server restarts on code changes.",
+)
+@click.option(
+    "--debug",
+    is_flag=True,
+    default=False,
+    help="Enable debug mode. Includes stack traces in error responses.",
+)
+@click.pass_obj
+def start(
+    metadata: ProjectMetadata | None,
+    host: str,
+    port: int,
+    reload: bool,
+    debug: bool,
+) -> None:
+    """Start the Kedro HTTP server.
+
+    The server exposes pipeline execution via HTTP endpoints, allowing
+    external systems to trigger Kedro pipelines programmatically.
+
+    \b
+    Endpoints:
+      GET  /health  - Health check
+      POST /run     - Execute a pipeline
+
+    \b
+    Examples:
+      kedro server start
+      kedro server start --host 0.0.0.0 --port 8080
+      kedro server start --reload --debug
+    """
+    try:
+        import uvicorn
+    except ImportError as exc:
+        raise KedroCliError(
+            "Kedro server requires 'uvicorn' and 'fastapi' packages. "
+            "Install them with: pip install uvicorn fastapi"
+        ) from exc
+
+    # Resolve project path
+    if metadata:
+        project_path = metadata.project_path
+    else:
+        project_path = find_kedro_project()
+        if not project_path:
+            raise KedroCliError(
+                "Could not find a Kedro project. "
+                "Make sure you're in a Kedro project directory."
+            )
+        # Bootstrap if we found the project ourselves
+        bootstrap_project(project_path)
+
+    # Set environment variables for the server process
+    os.environ[KEDRO_PROJECT_PATH_ENV] = str(project_path)
+
+    if debug:
+        os.environ["KEDRO_SERVER_DEBUG"] = "1"
+
+    click.echo(f"Starting Kedro server for project at: {project_path}")
+    click.echo(f"Server running at: http://{host}:{port}")
+    click.echo("Press CTRL+C to stop")
+    click.echo()
+
+    # Start uvicorn programmatically
+    uvicorn.run(
+        "kedro.server.app:create_app",
+        factory=True,
+        host=host,
+        port=port,
+        reload=reload,
+        log_level="info",
+    )

--- a/kedro/server/__init__.py
+++ b/kedro/server/__init__.py
@@ -1,0 +1,12 @@
+"""Kedro server module for HTTP API access to pipeline execution."""
+
+from __future__ import annotations
+
+__all__ = ["create_app"]
+
+
+def create_app():
+    """Lazy import to avoid loading FastAPI when not needed."""
+    from kedro.server.app import create_app as _create_app
+
+    return _create_app()

--- a/kedro/server/app.py
+++ b/kedro/server/app.py
@@ -1,0 +1,188 @@
+"""FastAPI application factory and route definitions for Kedro server."""
+
+from __future__ import annotations
+
+import logging
+import time
+import traceback
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+from typing import TYPE_CHECKING
+
+from fastapi import FastAPI, HTTPException
+
+from kedro import __version__ as kedro_version
+from kedro.framework.session import KedroSession
+from kedro.framework.startup import bootstrap_project
+from kedro.server.config import get_project_path, is_debug_mode
+from kedro.server.models import (
+    ErrorDetail,
+    HealthResponse,
+    RunRequest,
+    RunResponse,
+)
+from kedro.utils import load_obj
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
+    """Lifespan context manager for FastAPI application.
+
+    Bootstraps the Kedro project on startup.
+    """
+    project_path = get_project_path()
+    logger.info("Bootstrapping Kedro project at: %s", project_path)
+    bootstrap_project(project_path)
+    logger.info("Kedro server started successfully")
+    yield
+    # Cleanup on shutdown (if needed in future)
+    logger.info("Kedro server shutting down")
+
+
+def create_app() -> FastAPI:
+    """Create and configure the FastAPI application.
+
+    Returns:
+        Configured FastAPI application instance.
+    """
+    app = FastAPI(
+        title="Kedro Server",
+        description="HTTP API for running Kedro pipelines",
+        version=kedro_version,
+        lifespan=lifespan,
+    )
+
+    @app.get("/health", response_model=HealthResponse, tags=["health"])
+    async def health() -> HealthResponse:
+        """Health check endpoint.
+
+        Returns server status and Kedro version information.
+        """
+        try:
+            project_path = get_project_path()
+            return HealthResponse(
+                status="healthy",
+                kedro_version=kedro_version,
+                project_path=str(project_path),
+            )
+        except Exception:
+            return HealthResponse(
+                status="healthy",
+                kedro_version=kedro_version,
+                project_path=None,
+            )
+
+    @app.post("/run", response_model=RunResponse, tags=["pipeline"])
+    async def run_pipeline(request: RunRequest) -> RunResponse:
+        """Execute a Kedro pipeline.
+
+        This endpoint mirrors the behavior of `kedro run` CLI command.
+        Each request creates a fresh KedroSession and executes the pipeline
+        synchronously.
+
+        Args:
+            request: Pipeline execution parameters.
+
+        Returns:
+            RunResponse with run_id, status, duration, and optional error details.
+        """
+        project_path = get_project_path()
+        start_time = time.perf_counter()
+        run_id: str | None = None
+        debug_mode = is_debug_mode()
+
+        # Validate that pipeline and pipelines are not both set
+        if request.pipeline and request.pipelines:
+            raise HTTPException(
+                status_code=400,
+                detail="Cannot specify both 'pipeline' and 'pipelines'. Use one or the other.",
+            )
+
+        try:
+            # Load runner class (default to SequentialRunner if not specified)
+            runner_name = request.runner or "SequentialRunner"
+            runner_class = load_obj(runner_name, "kedro.runner")
+            runner_obj = runner_class(is_async=request.is_async)
+
+            # Create a fresh session for this request
+            with KedroSession.create(
+                project_path=project_path,
+                env=request.env,
+                conf_source=request.conf_source,
+                runtime_params=request.params,
+            ) as session:
+                run_id = session.session_id
+
+                logger.info(
+                    "Starting pipeline run %s (pipeline=%s, env=%s)",
+                    run_id,
+                    request.pipeline or "__default__",
+                    request.env,
+                )
+
+                # Execute the pipeline with all provided parameters
+                session.run(
+                    pipeline_name=request.pipeline,
+                    pipeline_names=request.pipelines,
+                    tags=tuple(request.tags) if request.tags else None,
+                    runner=runner_obj,
+                    node_names=tuple(request.node_names)
+                    if request.node_names
+                    else None,
+                    from_nodes=request.from_nodes,
+                    to_nodes=request.to_nodes,
+                    from_inputs=request.from_inputs,
+                    to_outputs=request.to_outputs,
+                    load_versions=request.load_versions,
+                    namespaces=request.namespaces,
+                    only_missing_outputs=request.only_missing_outputs,
+                )
+
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            logger.info(
+                "Pipeline run %s completed successfully in %.2fms", run_id, duration_ms
+            )
+
+            return RunResponse(
+                run_id=run_id,
+                status="success",
+                duration_ms=duration_ms,
+            )
+
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start_time) * 1000
+            exc_type = type(exc)
+            exc_module = (
+                [] if exc_type.__module__ == "builtins" else [exc_type.__module__]
+            )
+            exc_module.append(exc_type.__qualname__)
+
+            logger.error(
+                "Pipeline run %s failed after %.2fms: %s",
+                run_id or "unknown",
+                duration_ms,
+                str(exc),
+                exc_info=True,
+            )
+
+            error_detail = ErrorDetail(
+                type=".".join(exc_module),
+                message=str(exc),
+                traceback=traceback.format_tb(exc.__traceback__)
+                if debug_mode
+                else None,
+            )
+
+            return RunResponse(
+                run_id=run_id or "unknown",
+                status="failed",
+                duration_ms=duration_ms,
+                error=error_detail,
+            )
+
+    return app

--- a/kedro/server/config.py
+++ b/kedro/server/config.py
@@ -1,0 +1,64 @@
+"""Server configuration and settings resolution."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+# Environment variable name for project path
+KEDRO_PROJECT_PATH_ENV = "KEDRO_PROJECT_PATH"
+
+# Default server settings
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 8000
+
+
+class ServerSettingsError(Exception):
+    """Raised when server settings are invalid or missing."""
+
+    pass
+
+
+def get_project_path() -> Path:
+    """Resolve the Kedro project path from environment variable.
+
+    The server must be started via `kedro server start` which sets
+    KEDRO_PROJECT_PATH. This ensures the server is always associated
+    with a valid Kedro project.
+
+    Returns:
+        Path to the Kedro project root.
+
+    Raises:
+        ServerSettingsError: If KEDRO_PROJECT_PATH is not set.
+    """
+    project_path = os.environ.get(KEDRO_PROJECT_PATH_ENV)
+
+    if not project_path:
+        raise ServerSettingsError(
+            f"Environment variable '{KEDRO_PROJECT_PATH_ENV}' is not set. "
+            "The Kedro server must be started using 'kedro server start' command "
+            "from within a Kedro project directory."
+        )
+
+    path = Path(project_path).resolve()
+
+    if not path.exists():
+        raise ServerSettingsError(
+            f"Project path '{path}' does not exist. "
+            "Make sure you're running the server from a valid Kedro project."
+        )
+
+    return path
+
+
+def is_debug_mode() -> bool:
+    """Check if server is running in debug mode.
+
+    Debug mode enables additional error information like stack traces.
+
+    Returns:
+        True if KEDRO_SERVER_DEBUG is set to a truthy value.
+    """
+    debug_env = os.environ.get("KEDRO_SERVER_DEBUG", "").lower()
+    return debug_env in ("1", "true", "yes")

--- a/kedro/server/models.py
+++ b/kedro/server/models.py
@@ -1,0 +1,115 @@
+"""Pydantic models for Kedro server request/response schemas."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class RunRequest(BaseModel):
+    """Request model for pipeline execution.
+
+    Mirrors the parameters available in `kedro run` CLI command.
+    Parameter order matches the CLI definition in project.py.
+    """
+
+    # Pipeline selection
+    from_inputs: list[str] | None = Field(
+        default=None,
+        description="A list of dataset names which should be used as a starting point.",
+    )
+    to_outputs: list[str] | None = Field(
+        default=None,
+        description="A list of dataset names which should be used as an end point.",
+    )
+    from_nodes: list[str] | None = Field(
+        default=None,
+        description="A list of node names which should be used as a starting point.",
+    )
+    to_nodes: list[str] | None = Field(
+        default=None,
+        description="A list of node names which should be used as an end point.",
+    )
+    node_names: list[str] | None = Field(
+        default=None,
+        description="Run only nodes with specified names.",
+    )
+    runner: str | None = Field(
+        default=None,
+        description="Runner to use. Options: 'SequentialRunner', 'ParallelRunner', 'ThreadRunner'.",
+    )
+    is_async: bool = Field(
+        default=False,
+        description="Load and save node inputs and outputs asynchronously with threads.",
+    )
+    env: str | None = Field(
+        default=None,
+        description="Kedro configuration environment to use.",
+    )
+    tags: list[str] | None = Field(
+        default=None,
+        description="Construct the pipeline using only nodes which have this tag attached.",
+    )
+    load_versions: dict[str, str] | None = Field(
+        default=None,
+        description="Specify a particular dataset version (timestamp) for loading.",
+    )
+    pipeline: str | None = Field(
+        default=None,
+        description="Name of the registered pipeline to run. If not set, '__default__' pipeline is run.",
+    )
+    pipelines: list[str] | None = Field(
+        default=None,
+        description="List of registered pipeline names to run. Cannot be used together with 'pipeline'.",
+    )
+    namespaces: list[str] | None = Field(
+        default=None,
+        description="Run only nodes within these namespaces.",
+    )
+    conf_source: str | None = Field(
+        default=None,
+        description="Path of a directory where project configuration is stored.",
+    )
+    params: dict[str, Any] | None = Field(
+        default=None,
+        description="Extra parameters to pass to the context initialiser.",
+    )
+    only_missing_outputs: bool = Field(
+        default=False,
+        description="Run only nodes with missing outputs. Skip nodes whose outputs already exist and are persisted.",
+    )
+
+
+class ErrorDetail(BaseModel):
+    """Structured error information."""
+
+    type: str = Field(description="Exception type name.")
+    message: str = Field(description="Error message.")
+    traceback: list[str] | None = Field(
+        default=None,
+        description="Stack trace lines (only included in debug mode).",
+    )
+
+
+class RunResponse(BaseModel):
+    """Response model for pipeline execution."""
+
+    run_id: str = Field(description="Unique identifier for this pipeline run.")
+    status: str = Field(description="Run status: 'success' or 'failed'.")
+    duration_ms: float = Field(description="Total execution time in milliseconds.")
+    error: ErrorDetail | None = Field(
+        default=None,
+        description="Error details if status is 'failed'.",
+    )
+
+
+class HealthResponse(BaseModel):
+    """Response model for health check endpoint."""
+
+    status: str = Field(default="healthy", description="Server health status.")
+    kedro_version: str = Field(description="Kedro version.")
+    project_path: str | None = Field(
+        default=None,
+        description="Path to the Kedro project being served.",
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,7 +97,11 @@ jupyter = [
 benchmark = [
     "asv"
 ]
-all = [ "kedro[test,docs,jupyter,benchmark]" ]
+server = [
+    "fastapi>=0.100.0",
+    "uvicorn>=0.20.0",
+]
+all = [ "kedro[test,docs,jupyter,benchmark,server]" ]
 
 [project.urls]
 Homepage = "https://kedro.org"


### PR DESCRIPTION
## Summary

This PR introduces a built-in HTTP API server for Kedro, allowing pipelines to be executed via HTTP requests instead of (or alongside) the CLI. The server is implemented as an **optional, zero-cost addition** to Kedro core — it adds no new hard dependencies and does not affect existing CLI or library usage.

Closes #5263 

## Motivation

### Why an HTTP API?

Kedro pipelines are currently triggered exclusively via the CLI (`kedro run`) or programmatic Python calls. Many production and integration scenarios require HTTP-based execution.

### Why in core vs. a plugin?


The team agreed to name the module `kedro-server` and discussed to include this in core rather than as a separate plugin because:

1. **Shared execution engine** — The HTTP layer calls the exact same `KedroSession.create() → session.run()` path as the CLI. Keeping it in core ensures it stays in sync with CLI changes automatically.
2. **First-class citizen** — Server support should feel like a native Kedro capability, not an afterthought.
3. **Discoverability** — `kedro server start` is easier to find than `pip install kedro-server && kedro server start`.
4. **Zero cost if unused** — FastAPI and Uvicorn are optional extras. Users who don't need the server pay nothing.

## Architecture

### Design Principle: "One execution engine, multiple callers"

```
kedro run --pipeline=X       →  KedroSession.create() → session.run()
POST /run {"pipeline": "X"}  →  KedroSession.create() → session.run()
```

Both the CLI and HTTP endpoints are thin layers that parse user input, create a `KedroSession`, and call `session.run()` with the appropriate parameters. There is no separate execution path.

### Phase 1 Semantics

- **Synchronous**: Each HTTP request blocks until the pipeline completes
- **One session per request**: A fresh `KedroSession` is created for each `/run` call
- **No queueing or async execution**: Keeps the initial implementation simple and predictable
- **Full parameter parity with CLI**: Every `kedro run` flag is available as a JSON field

## Files Changed

### New Files

| File | Purpose |
|------|---------|
| `kedro/server/__init__.py` | Module entry point with lazy import to avoid loading FastAPI when not needed |
| `kedro/server/app.py` | FastAPI app factory + `/health` and `/run` endpoints |
| `kedro/server/models.py` | Pydantic request/response schemas (`RunRequest`, `RunResponse`, `HealthResponse`, `ErrorDetail`) |
| `kedro/server/config.py` | Internal runtime config — env var resolution, defaults, constants |
| `kedro/framework/cli/server.py` | `kedro server start` CLI command with `--host`, `--port`, `--reload`, `--debug` options |

### Modified Files

| File | Change |
|------|--------|
| `kedro/framework/cli/cli.py` | Added `"server"` to `lazy_subcommands` dict so `kedro server` is discovered automatically |
| `pyproject.toml` | Added `server = ["fastapi>=0.100.0", "uvicorn>=0.20.0"]` optional dependency group; added `server` to `all` extras |

## Usage

### Installation

```bash
pip install kedro[server]
```

### Starting the server

```bash
cd my-kedro-project
kedro server start
kedro server start --host 0.0.0.0 --port 8080
kedro server start --reload --debug
```

### Executing a pipeline

```bash
# Health check
curl http://127.0.0.1:8000/health

# Run the default pipeline
curl -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{}'

# Run a specific pipeline with parameters
curl -X POST http://127.0.0.1:8000/run \
  -H "Content-Type: application/json" \
  -d '{
    "pipeline": "data_processing",
    "env": "base",
    "runner": "SequentialRunner",
    "params": {"key": "value"},
    "tags": ["tag1"],
    "node_names": ["node1", "node2"],
    "is_async": false
  }'
```

### API Documentation

When the server is running, interactive API docs are available at:

- Swagger UI: `http://127.0.0.1:8000/docs`
- ReDoc: `http://127.0.0.1:8000/redoc`

## RunRequest Fields (Full CLI Parity)

| Field | Type | Default | CLI Equivalent |
|-------|------|---------|----------------|
| `tags` | `list[str]` | `[]` | `--tags` |
| `env` | `str \| null` | `null` | `--env` |
| `pipeline` | `str \| null` | `null` | `--pipeline` |
| `pipelines` | `list[str]` | `[]` | `--pipelines` |
| `runner` | `str \| null` | `null` | `--runner` |
| `is_async` | `bool` | `false` | `--async` |
| `node_names` | `list[str]` | `[]` | `--nodes` |
| `from_nodes` | `list[str]` | `[]` | `--from-nodes` |
| `to_nodes` | `list[str]` | `[]` | `--to-nodes` |
| `from_inputs` | `list[str]` | `[]` | `--from-inputs` |
| `to_outputs` | `list[str]` | `[]` | `--to-outputs` |
| `load_versions` | `dict[str, str]` | `{}` | `--load-version` |
| `params` | `dict[str, Any]` | `{}` | `--params` |
| `conf_source` | `str \| null` | `null` | `--conf-source` |
| `namespaces` | `list[str]` | `[]` | `--namespace` |
| `only_missing_outputs` | `bool` | `false` | `--only-missing-outputs` |

## Constraints & Limitations (Phase 1)

- **Synchronous only** — Long-running pipelines will block the HTTP response. Clients must set appropriate timeouts.
- **Single worker by default** — Uvicorn runs with one worker. Concurrent requests are handled sequentially.
- **No authentication** — Phase 1 has no auth. Intended for trusted networks / local development.
- **No run history or status polling** — Each request is fire-and-forget. Status tracking is planned for Phase 2.

## Testing

```bash
# Install with server extras
pip install -e ".[server]"

# Start server against any Kedro project
cd /path/to/kedro-project
kedro server start --debug

# In another terminal
curl http://127.0.0.1:8000/health
curl -X POST http://127.0.0.1:8000/run -H "Content-Type: application/json" -d '{}'
```
