### PR TITLE
Remove the temporary kedro-plugin branch installs on CI

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -33,8 +33,6 @@ jobs:
           activate-environment: true
       - name: Install dependencies
         run: |
-          # TEMP: For passing tests, will be removed before merge
-          uv pip install "git+https://github.com/kedro-org/kedro-plugins.git@fix/remove-cachetools-deps#subdirectory=kedro-datasets"
           make install-test-requirements
           uv pip install pip
           make install-pre-commit

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -30,8 +30,6 @@ jobs:
           activate-environment: true
       - name: Install dependencies
         run: |
-            # TEMP: For passing tests, will be removed before merge
-            uv pip install "git+https://github.com/kedro-org/kedro-plugins.git@fix/remove-cachetools-deps#subdirectory=kedro-datasets"
             make install-test-requirements
             make install-pre-commit
       - name: pip freeze


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Revert the temporary fix that was introduced in: https://github.com/kedro-org/kedro/pull/5352

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
