### PR TITLE
Update pandas version constraint in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
     "jupyter~=1.0",
     "kedro-datasets",
     "mypy~=1.0",
-    "pandas~=2.0",
+    "pandas>=2.0,<4.0",
     "pluggy>=1.0",
     "pre-commit>=2.9.2,<5.0",  # The hook `mypy` requires pre-commit version 2.9.2.
     "pytest-cov>=3,<8",


### PR DESCRIPTION
## Description

Ensure that Kedro is compatible with pandas 3.0.

Python 3.10 tests use pandas 2.3.3, while Python 3.11-3.13 use pandas 3.0.0.

## Development notes

Unlike [Kedro-Datasets](https://github.com/kedro-org/kedro-plugins/pull/1291), Kedro doesn't depend on pandas, so the changes are minimal/more of a sanity check.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
