### PR TITLE
Clarify MLflow catalog.yml file context in docs

### DIFF
--- a/docs/integrations-and-plugins/mlflow.md
+++ b/docs/integrations-and-plugins/mlflow.md
@@ -142,7 +142,8 @@ For example, if you have a dataset corresponding to a scikit-learn model,
 you can change it as follows:
 
 ```diff
- regressor:
+# conf/base/catalog.yml
+regressor:
 -  type: pickle.PickleDataset
 -  filepath: data/06_models/regressor.pickle
 -  versioned: true


### PR DESCRIPTION
## Description
In the MLflow integration docs, the YAML code snippets in the "Model registry" section did not indicate which file they belong to. This adds `# conf/base/catalog.yml` comments to those snippets, consistent with how the "Artifact tracking" section already does it. Fixes #5384

## Development notes
Added `# conf/base/catalog.yml` comments to three YAML code blocks in `docs/integrations-and-plugins/mlflow.md`:
- The model registry diff snippet
- The `registered_model_name` YAML block
- The runtime params YAML block

Documentation-only change, no code changes.

## Developer Certificate of Origin
All commits are signed off with `Signed-off-by`.

## Checklist
- [x] Read the contributing guidelines
- [x] Signed off each commit with a Developer Certificate of Origin (DCO)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the `RELEASE.md` file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team