### PR TITLE
fix: escape Rich markup in node strings and use rich_format for catal...

### DIFF
--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -29,7 +29,6 @@ from kedro.io.core import (
 )
 from kedro.io.memory_dataset import MemoryDataset, _is_memory_dataset
 from kedro.io.shared_memory_dataset import SharedMemoryDataset
-from kedro.utils import _format_rich, _has_rich_handler
 
 if TYPE_CHECKING:
     from multiprocessing.managers import SyncManager
@@ -265,8 +264,6 @@ class DataCatalog(CatalogProtocol):
         self._load_versions, self._save_version = self._validate_versions(
             datasets, load_versions or {}, save_version
         )
-
-        self._use_rich_markup = _has_rich_handler()
 
         for ds_name in list(self._config_resolver.config):
             if ds_name in self._datasets:
@@ -1007,9 +1004,9 @@ class DataCatalog(CatalogProtocol):
 
         self._logger.info(
             "Saving data to %s (%s)...",
-            _format_rich(ds_name, "dark_orange") if self._use_rich_markup else ds_name,
+            ds_name,
             type(dataset).__name__,
-            extra={"markup": True},
+            extra={"rich_format": ["dark_orange"]},
         )
 
         dataset.save(data)
@@ -1047,9 +1044,9 @@ class DataCatalog(CatalogProtocol):
 
         self._logger.info(
             "Loading data from %s (%s)...",
-            _format_rich(ds_name, "dark_orange") if self._use_rich_markup else ds_name,
+            ds_name,
             type(dataset).__name__,
-            extra={"markup": True},
+            extra={"rich_format": ["dark_orange"]},
         )
 
         return dataset.load()

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -246,7 +246,7 @@ class Node:
 
     def __str__(self) -> str:
         def _set_to_str(xset: set | list[str]) -> str:
-            return f"[{';'.join(xset)}]"
+            return f"\[{';'.join(xset)}\]"
 
         out_str = _set_to_str(self.outputs) if self._outputs else "None"
         in_str = _set_to_str(self.inputs) if self._inputs else "None"

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -246,7 +246,7 @@ class Node:
 
     def __str__(self) -> str:
         def _set_to_str(xset: set | list[str]) -> str:
-            return f"\[{';'.join(xset)}\]"
+            return f"\\[{';'.join(xset)}\\]"
 
         out_str = _set_to_str(self.outputs) if self._outputs else "None"
         in_str = _set_to_str(self.inputs) if self._inputs else "None"

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -210,9 +210,8 @@ def test_logger_without_rich_markup():
 
     data = ("dummy",)
     catalog = DataCatalog.from_config({"dummy": {"type": "MemoryDataset"}})
-    catalog._use_rich_markup = False
 
-    # Add a custom handler
+    # Add a custom handler (non-RichHandler)
     custom_handler = CustomHandler()
     root_logger = logging.getLogger()
     root_logger.addHandler(custom_handler)
@@ -223,6 +222,8 @@ def test_logger_without_rich_markup():
     assert custom_handler.records
 
     for record in custom_handler.records:
+        # Markup should never appear in the message itself with the new approach
+        # Markup is handled via rich_format extra attribute, which is ignored by non-RichHandler
         assert "[dark_orange]" not in record.message
 
 

--- a/tests/pipeline/test_node.py
+++ b/tests/pipeline/test_node.py
@@ -49,7 +49,7 @@ class TestValidNode:
         assert test_node.func is decorated_identity
 
     def test_labelled(self):
-        assert "labeled_node: <lambda>([input1]) -> [output1]" in str(
+        assert r"labeled_node: <lambda>(\[input1\]) -> \[output1\]" in str(
             node(lambda x: None, "input1", "output1", name="labeled_node")
         )
 
@@ -82,12 +82,12 @@ class TestValidNode:
         assert actual == {"output": "hellohello"}
 
     def test_no_input(self):
-        assert "constant_output(None) -> [output1]" in str(
+        assert r"constant_output(None) -> \[output1\]" in str(
             node(constant_output, None, "output1")
         )
 
     def test_no_output(self):
-        assert "<lambda>([input1]) -> None" in str(node(lambda x: None, "input1", None))
+        assert r"<lambda>(\[input1\]) -> None" in str(node(lambda x: None, "input1", None))
 
     def test_inputs_none(self):
         dummy_node = node(constant_output, None, "output")
@@ -394,7 +394,7 @@ class TestTag:
 class TestNames:
     def test_named(self):
         n = node(identity, ["in"], ["out"], name="name")
-        assert str(n) == "name: identity([in]) -> [out]"
+        assert str(n) == r"name: identity(\[in\]) -> \[out\]"
         assert n.name == "name"
         assert n.short_name == "name"
 
@@ -410,7 +410,7 @@ class TestNames:
 
     def test_namespaced(self):
         n = node(identity, ["in"], ["out"], namespace="namespace")
-        assert str(n) == "identity([in]) -> [out]"
+        assert str(n) == r"identity(\[in\]) -> \[out\]"
         assert re.match(r"^namespace\.identity__[0-9a-f]{8}$", n.name)
         assert n.short_name == "Identity"
 
@@ -427,31 +427,31 @@ class TestNames:
 
     def test_named_and_namespaced(self):
         n = node(identity, ["in"], ["out"], name="name", namespace="namespace")
-        assert str(n) == "name: identity([in]) -> [out]"
+        assert str(n) == r"name: identity(\[in\]) -> \[out\]"
         assert n.name == "namespace.name"
         assert n.short_name == "name"
 
     def test_function(self):
         n = node(identity, ["in"], ["out"])
-        assert str(n) == "identity([in]) -> [out]"
+        assert str(n) == r"identity(\[in\]) -> \[out\]"
         assert re.match(r"^identity__[0-9a-f]{8}$", n.name)
         assert n.short_name == "Identity"
 
     def test_lambda(self):
         n = node(lambda a: a, ["in"], ["out"])
-        assert str(n) == "<lambda>([in]) -> [out]"
+        assert str(n) == r"<lambda>(\[in\]) -> \[out\]"
         assert re.match(r"^<lambda>__[0-9a-f]{8}$", n.name)
         assert n.short_name == "<Lambda>"
 
     def test_partial(self):
         n = node(partial(identity), ["in"], ["out"])
-        assert str(n) == "<partial>([in]) -> [out]"
+        assert str(n) == r"<partial>(\[in\]) -> \[out\]"
         assert re.match(r"^partial\(identity\)__[0-9a-f]{8}$", n.name)
         assert n.short_name == "<Partial>"
 
     def test_updated_partial(self):
         n = node(update_wrapper(partial(identity), identity), ["in"], ["out"])
-        assert str(n) == "identity([in]) -> [out]"
+        assert str(n) == r"identity(\[in\]) -> \[out\]"
         assert re.match(r"^partial\(identity\)__[0-9a-f]{8}$", n.name)
         assert n.short_name == "Identity"
 
@@ -461,7 +461,7 @@ class TestNames:
             {"input2": "in2"},
             ["out"],
         )
-        assert str(n) == "biconcat([in2]) -> [out]"
+        assert str(n) == r"biconcat(\[in2\]) -> \[out\]"
         assert re.match(r"^partial\(biconcat\)__[0-9a-f]{8}$", n.name)
         assert n.short_name == "Biconcat"
 


### PR DESCRIPTION
Fixes #5199

## Description

This PR fixes two issues with Rich logging integration that were causing unexpected behavior in console and file logs:

1. **Console log issue**: Brackets around node inputs/outputs (e.g., `[companies]`) were being swallowed by RichHandler because they were interpreted as Rich markup tags.

2. **File log issue**: Rich markup tags like `[dark_orange]X_train[/dark_orange]` were leaking into file logs because the markup was being added directly to the log message, which was then sent to all handlers including non-Rich file handlers.

## Development notes

### Changes made:

1. **`kedro/pipeline/node.py`**: Escape brackets in `Node.__str__` using `\[` and `\]` so that RichHandler renders them as literal brackets instead of interpreting them as markup.

2. **`kedro/io/data_catalog.py`**:
   - Use the `rich_format` extra attribute instead of manually adding markup to log messages
   - Remove the `_use_rich_markup` attribute and unused imports (`_format_rich`, `_has_rich_handler`)
   - The `rich_format` mechanism is handled by Kedro's custom `RichHandler`, which formats only the specified arguments with colors, while non-Rich handlers receive the unformatted message

3. **Tests updated**:
   - `tests/pipeline/test_node.py`: Updated to expect escaped brackets in node string representation
   - `tests/framework/project/test_logging.py`: Updated test to reflect the new approach where markup is never in the message itself

### How it works:

- When `Node.__str__` returns `identity(\[in\]) -> \[out\]`, RichHandler with `markup=True` renders this as `identity([in]) -> [out]` (correct display)
- When DataCatalog logs use `extra={"rich_format": ["dark_orange"]}`, only RichHandler applies the color formatting, while file handlers receive the plain dataset name

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team

```
 kedro/io/data_catalog.py                | 11 ++++-------
 kedro/pipeline/node.py                  |  2 +-
 tests/framework/project/test_logging.py |  5 +++--
 tests/pipeline/test_node.py             | 22 +++++++++++-----------
 4 files changed, 19 insertions(+), 21 deletions(-)
```