### PR TITLE
Fix version path traversal

### DIFF
--- a/kedro/framework/cli/utils.py
+++ b/kedro/framework/cli/utils.py
@@ -507,7 +507,8 @@ def _split_load_versions(ctx: click.Context, param: Any, value: str) -> dict[str
         if _is_unsafe_version(version):
             raise KedroCliError(
                 f"Version string '{version}' is not allowed. "
-                "Version strings must not be absolute paths or contain '..' components."
+                "Version strings must be a single non-empty path component with no "
+                "path separators ('/' or '\\') and must not be '.' or '..'."
             )
         load_versions_dict[load_version_list[0]] = version
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -829,7 +829,8 @@ class AbstractVersionedDataset(AbstractDataset[_DI, _DO], abc.ABC):
         if _is_unsafe_version(version):
             raise DatasetError(
                 f"Version string '{version}' is not allowed. "
-                "Version strings must not be absolute paths or contain '..' components."
+                "Version strings must be a single non-empty path component with no "
+                "path separators ('/' or '\\') and must not be '.' or '..'."
             )
         return self._filepath / version / self._filepath.name
 

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -10,7 +10,7 @@ import re
 import warnings
 from collections.abc import Callable, Iterable
 from functools import wraps
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlsplit
 
@@ -314,16 +314,9 @@ def find_config_file(
 
 
 def _is_unsafe_version(version: str) -> bool:
-    """Return True if the version string contains path traversal or absolute path components.
+    """Return True if the version string is not a safe single path component.
 
-    Checks against both POSIX and Windows path semantics to ensure platform-independent
-    protection against directory traversal attacks.
+    A valid version must be a non-empty string with no path separators (``/`` or ``\\``)
+    and must not be a dot-only component (``.`` or ``..``).
     """
-    posix = PurePosixPath(version)
-    windows = PureWindowsPath(version)
-    return (
-        posix.is_absolute()
-        or ".." in posix.parts
-        or windows.is_absolute()
-        or ".." in windows.parts
-    )
+    return not version or "/" in version or "\\" in version or version in (".", "..")

--- a/tests/framework/cli/test_cli.py
+++ b/tests/framework/cli/test_cli.py
@@ -1038,6 +1038,10 @@ class TestRunCommand:
             "dataset1:..\\..\\..\\secrets",  # Windows traversal
             "dataset1:/absolute/path",  # POSIX absolute
             "dataset1:C:\\Users\\secrets",  # Windows absolute
+            "dataset1:.",  # single dot
+            "dataset1:..",  # double dot
+            "dataset1:foo/bar",  # subdirectory via POSIX separator
+            "dataset1:foo\\bar",  # subdirectory via Windows separator
         ],
     )
     def test_fail_split_load_versions_path_traversal(

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -743,12 +743,17 @@ class TestAbstractVersionedDataset:
             "..\\..\\..\\secrets",  # Windows traversal
             "/etc/passwd",  # POSIX absolute
             "C:\\Users\\secrets",  # Windows absolute
+            ".",  # single dot
+            "..",  # double dot
+            "",  # empty string
+            "foo/bar",  # subdirectory via POSIX separator
+            "foo\\bar",  # subdirectory via Windows separator
         ],
     )
     def test_get_versioned_path_rejects_unsafe_versions(
         self, my_versioned_dataset, unsafe_version
     ):
-        """Unsafe version strings (traversal or absolute) must raise DatasetError."""
+        """Unsafe version strings (traversal, absolute, dot, separator) must raise DatasetError."""
         with pytest.raises(DatasetError, match="not allowed"):
             my_versioned_dataset._get_versioned_path(unsafe_version)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -279,12 +279,11 @@ def test_find_config_file(tmp_path, monkeypatch, filename, expected_suffix):
 @pytest.mark.parametrize(
     "version",
     [
-        # POSIX traversal
+        # Traversal via POSIX separators
         "../../../secrets",
         "../../etc/passwd",
-        "..",
         "valid/../../../escape",
-        # Windows backslash traversal
+        # Traversal via Windows separators
         "..\\..\\..\\secrets",
         "valid\\..\\..\\escape",
         # POSIX absolute
@@ -294,6 +293,14 @@ def test_find_config_file(tmp_path, monkeypatch, filename, expected_suffix):
         "C:\\Users\\secrets",
         "C:/Users/secrets",
         "\\\\server\\share",
+        # Dot components
+        "..",
+        ".",
+        # Empty string
+        "",
+        # Subdirectory creation via separators
+        "foo/bar",
+        "foo\\bar",
     ],
 )
 def test_is_unsafe_version_rejects(version):


### PR DESCRIPTION
## Description

Added checks to validate safe versions

## Development notes

- Added a check for filtering unsafe versions
- Raises respective error messages incase of an unsafe version
- Updated tests 


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
