### PR TITLE
Document stateful hook patterns in common use cases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,8 @@ NOTE: This session implementation is under active development and may occasional
 
 ## Community contributions
 
+* [jeevan6996](https://github.com/jeevan6996)
+
 
 # Release 1.3.1
 

--- a/docs/extend/hooks/common_use_cases.md
+++ b/docs/extend/hooks/common_use_cases.md
@@ -227,7 +227,7 @@ class RuntimeConfigHook:
             run_params["env"] = self._runtime_env
 ```
 
-This pattern is especially useful when migrating older projects that passed `context` through custom integrations, or when coordinating configuration and runtime behavior across multiple Hook points.
+This pattern is useful when migrating older projects that passed `context` through custom integrations, or when coordinating configuration and runtime behaviour across multiple Hook points.
 
 ## Use Hooks to read `metadata` from `DataCatalog`
 Use the `after_catalog_created` Hook to access `metadata` to extend Kedro.

--- a/docs/extend/hooks/common_use_cases.md
+++ b/docs/extend/hooks/common_use_cases.md
@@ -200,6 +200,35 @@ HOOKS = (AzureSecretsHook(),)
 !!! note
     `DefaultAzureCredential()` is Azure's recommended approach to authorise access to data in your storage accounts. For more information, consult the [documentation about how to authenticate to Azure and authorise access to blob data](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-python).
 
+## Use stateful Hooks to share context between Hook methods
+
+Hook implementations are classes, so you can store state on the Hook instance and reuse it in other Hook methods.
+This is useful when one Hook receives data that another Hook needs, for example saving `context` from `after_context_created` and reusing it in `before_pipeline_run`.
+
+```python
+from typing import Any
+
+from kedro.framework.hooks import hook_impl
+
+
+class RuntimeConfigHook:
+    def __init__(self):
+        self._runtime_env = None
+
+    @hook_impl
+    def after_context_created(self, context) -> None:
+        # Persist values from context for later Hooks
+        self._runtime_env = context.env
+
+    @hook_impl
+    def before_pipeline_run(self, run_params: dict[str, Any], pipeline, catalog) -> None:
+        # Reuse values captured in `after_context_created`
+        if self._runtime_env is not None:
+            run_params["env"] = self._runtime_env
+```
+
+This pattern is especially useful when migrating older projects that passed `context` through custom integrations, or when coordinating configuration and runtime behavior across multiple Hook points.
+
 ## Use Hooks to read `metadata` from `DataCatalog`
 Use the `after_catalog_created` Hook to access `metadata` to extend Kedro.
 

--- a/docs/extend/hooks/common_use_cases.md
+++ b/docs/extend/hooks/common_use_cases.md
@@ -202,8 +202,8 @@ HOOKS = (AzureSecretsHook(),)
 
 ## Use stateful Hooks to share context between Hook methods
 
-Hook implementations are classes, so you can store state on the Hook instance and reuse it in other Hook methods.
-This is useful when one Hook receives data that another Hook needs, for example saving `context` from `after_context_created` and reusing it in `before_pipeline_run`.
+Hook implementations are classes, so you can store state on the hook instance and reuse it in other hook methods.
+This is useful when one hook receives data that another hook needs, for example saving `context` from `after_context_created` and reusing it in `before_pipeline_run`.
 
 ```python
 from typing import Any

--- a/docs/extend/hooks/common_use_cases.md
+++ b/docs/extend/hooks/common_use_cases.md
@@ -202,8 +202,8 @@ HOOKS = (AzureSecretsHook(),)
 
 ## Use stateful Hooks to share context between Hook methods
 
-Hook implementations are classes, so you can store state on the hook instance and reuse it in other hook methods.
-This is useful when one hook receives data that another hook needs, for example saving `context` from `after_context_created` and reusing it in `before_pipeline_run`.
+Hooks are instantiated once per Kedro session, so instance attributes persist across hook calls.
+This lets you capture data from `after_context_created` and reuse it in hooks that do not receive the context (such as `before_pipeline_run` or `before_node_run`).
 
 ```python
 from typing import Any
@@ -228,6 +228,9 @@ class RuntimeConfigHook:
 ```
 
 This pattern is useful when migrating older projects that passed `context` through custom integrations, or when coordinating configuration and runtime behaviour across multiple Hook points.
+
+!!! note
+    Keep stored data small and treat it as read-only to avoid surprising side effects across hooks.
 
 ## Use Hooks to read `metadata` from `DataCatalog`
 Use the `after_catalog_created` Hook to access `metadata` to extend Kedro.


### PR DESCRIPTION
## Summary
- add a new "Use stateful Hooks to share context between Hook methods" section in the hooks common use cases guide
- include a concrete example showing how to persist values from `after_context_created` and reuse them in `before_pipeline_run`
- explain when this pattern is useful (migration and cross-hook runtime coordination)

Closes #2690