### PR TITLE
Add validation to logging class for `logging.yml` configuration

### DIFF
--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -31,6 +31,12 @@ IMPORT_ERROR_MESSAGE = (
     "defined therein will be returned by 'find_pipelines'.\n\n{tb_exc}"
 )
 
+_LOGGING_BASE_CLASSES = (
+    logging.Handler,
+    logging.Formatter,
+    logging.Filter,
+)
+
 
 def _get_default_class(class_import_path: str) -> Any:
     module, _, class_name = class_import_path.rpartition(".")
@@ -285,11 +291,6 @@ class _ProjectLogging(UserDict):
         Raises:
             ValueError: If the class cannot be imported or is not a logging base class.
         """
-        _LOGGING_BASE_CLASSES = (
-            logging.Handler,
-            logging.Formatter,
-            logging.Filter,
-        )
 
         module_path, _, class_name = class_path.rpartition(".")
         if not module_path:
@@ -311,11 +312,10 @@ class _ProjectLogging(UserDict):
             )
 
         if not (isinstance(cls, type) and issubclass(cls, _LOGGING_BASE_CLASSES)):
-              raise ValueError(                                                                                                                                                                                                                                
-      f"Invalid logging class '{class_path}'. "                                                                                                                                                                                                    
-      f"Must be a subclass of logging.Handler, logging.Formatter, or logging.Filter. "                                                                                                                                                             
-      f"Got {type(cls).__name__!r}."                                                                                                                                                                                                               
-  )   
+            raise ValueError(
+                f"Invalid logging class '{class_path}'. "
+                f"Must be a subclass of logging.Handler, logging.Formatter, or logging.Filter. "
+                f"Got {type(cls).__name__!r}."
             )
 
     def _validate_logging_config(self, config: Any) -> Any:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -311,12 +311,11 @@ class _ProjectLogging(UserDict):
             )
 
         if not (isinstance(cls, type) and issubclass(cls, _LOGGING_BASE_CLASSES)):
-            raise ValueError(
-                f"Invalid logging class '{class_path}'. "
-                f"Classes used in logging configuration must be subclasses of "
-                f"'logging.Handler', 'logging.Formatter', or 'logging.Filter'. "
-                f"Got '{cls}' instead. If you need a "
-                f"custom logging class, ensure it inherits from one of these base classes."
+              raise ValueError(                                                                                                                                                                                                                                
+      f"Invalid logging class '{class_path}'. "                                                                                                                                                                                                    
+      f"Must be a subclass of logging.Handler, logging.Formatter, or logging.Filter. "                                                                                                                                                             
+      f"Got {type(cls).__name__!r}."                                                                                                                                                                                                               
+  )   
             )
 
     def _validate_logging_config(self, config: Any) -> Any:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -274,13 +274,62 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
         logger.info(msg)
 
+    def _validate_logging_class(self, class_path: str) -> None:
+        """Validate that a class referenced in logging configuration is a legitimate
+        logging class (i.e. a subclass of logging.Handler, logging.Formatter, or
+        logging.Filter).
+
+        Args:
+            class_path: Dotted import path to the class, e.g. ``logging.StreamHandler``.
+
+        Raises:
+            ValueError: If the class cannot be imported or is not a logging base class.
+        """
+        _LOGGING_BASE_CLASSES = (
+            logging.Handler,
+            logging.Formatter,
+            logging.Filter,
+        )
+
+        module_path, _, class_name = class_path.rpartition(".")
+        if not module_path:
+            # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
+            return
+
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError as exc:
+            raise ValueError(
+                f"Cannot import module '{module_path}' specified as a logging class: {exc}"
+            ) from exc
+
+        cls = getattr(module, class_name, None)
+        if cls is None:
+            raise ValueError(
+                f"Class '{class_name}' not found in module '{module_path}' "
+                f"as specified in logging configuration."
+            )
+
+        if not (isinstance(cls, type) and issubclass(cls, _LOGGING_BASE_CLASSES)):
+            raise ValueError(
+                f"Invalid logging class '{class_path}'. "
+                f"Classes used in logging configuration must be subclasses of "
+                f"'logging.Handler', 'logging.Formatter', or 'logging.Filter'. "
+                f"Got '{cls}' instead. If you need a "
+                f"custom logging class, ensure it inherits from one of these base classes."
+            )
+
     def _validate_logging_config(self, config: Any) -> Any:
-        """Recursively check the logging configuration and raise an error if dangerous '()' factory keys are encountered."""
+        """Recursively check the logging configuration and raise an error if dangerous
+        '()' factory keys are encountered or if any 'class' value is not a legitimate
+        logging class."""
         if isinstance(config, dict):
             if "()" in config:
                 raise ValueError(
                     "The '()' key is not allowed in logging configuration as it poses a security risk."
                 )
+            if "class" in config:
+                self._validate_logging_class(config["class"])
             validated = {}
             for k, v in config.items():
                 validated[k] = self._validate_logging_config(v)

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -333,6 +333,91 @@ def test_validate_safe_config():
 
 
 @pytest.mark.parametrize(
+    "class_path",
+    [
+        "logging.StreamHandler",
+        "logging.FileHandler",
+        "logging.handlers.RotatingFileHandler",
+        "logging.Formatter",
+        "logging.Filter",
+        "kedro.logging.RichHandler",
+    ],
+)
+def test_validate_logging_class_allows_legitimate_classes(class_path):
+    """Legitimate logging classes must pass validation without error."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    # Should not raise
+    logging_instance._validate_logging_class(class_path)
+
+
+@pytest.mark.parametrize(
+    "class_path",
+    [
+        "subprocess.Popen",
+        "os.system",
+        "builtins.eval",
+        "builtins.exec",
+    ],
+)
+def test_validate_logging_class_blocks_non_logging_classes(class_path):
+    """Non-logging classes (e.g. subprocess.Popen) must be rejected."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Invalid logging class"):
+        logging_instance._validate_logging_class(class_path)
+
+
+def test_validate_logging_class_blocks_nonexistent_class():
+    """A class that doesn't exist in its module must be rejected."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="not found in module"):
+        logging_instance._validate_logging_class("logging.NonExistentHandler")
+
+
+def test_validate_logging_class_blocks_nonexistent_module():
+    """A class from a non-importable module must be rejected."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Cannot import module"):
+        logging_instance._validate_logging_class("totally.fake.module.Handler")
+
+
+def test_validate_logging_class_bare_name_passes():
+    """A bare class name with no module prefix must pass (logging resolves it)."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    logging_instance._validate_logging_class("StreamHandler")  # should not raise
+
+
+def test_validate_config_blocks_rce_via_class():
+    """The subprocess.Popen RCE vector via the 'class' key must be blocked."""
+    from kedro.framework.project import _ProjectLogging
+
+    malicious_config = {
+        "version": 1,
+        "handlers": {
+            "rce": {
+                "class": "subprocess.Popen",
+                "args": "id",
+                "shell": True,
+            }
+        },
+        "root": {"handlers": ["rce"]},
+    }
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Invalid logging class"):
+        logging_instance.configure(malicious_config)
+
+
+@pytest.mark.parametrize(
     "input_config",
     [
         # Simple dict with '()' key


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Changes `_validate_logging_config()` to limit valid logging classes to ones that are subclasses of `logging.Handler`, `logging.Formatter`, and `logging.Filter`.  This is to prevent it from accepting arbitrary classes as custom loggers, which offers a risk or malicious code execution.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
