### PR TITLE
feat(deps): add optional kedro[pydantic] dependency extra

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
 * Added the first iteration of the `KedroServiceSession`, a new session implementation that allows for multiple runs and data injection.
 NOTE: This session implementation is under active development and may occasionally contain bugs or breaking changes. We encourage users to try it out and share their feedback with us.
 ## Bug fixes and other changes
+* Added `pydantic` optional dependency extra. Users can now install Pydantic support via `pip install "kedro[pydantic]"`.
+
 ## Documentation changes
 ## Community contributions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ NOTE: This session implementation is under active development and may occasional
 * Added inspection API to get project snapshot.
 
 ## Bug fixes and other changes
-* Added `pydantic` optional dependency extra. Users can now install Pydantic support via `pip install "kedro[pydantic]"`.
+* Added an optional `pydantic` dependency extra, allowing users to enable Pydantic support with `pip install "kedro[pydantic]"`.
 
 ## Documentation changes
 ## Community contributions

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@ NOTE: This session implementation is under active development and may occasional
 ## Community contributions
 
 * [jeevan6996](https://github.com/jeevan6996)
+* [Rahul Bansod](https://github.com/rahulbansod519)
 
 
 # Release 1.3.1

--- a/docs/configure/parameter_validation.md
+++ b/docs/configure/parameter_validation.md
@@ -10,7 +10,7 @@ This feature is **opt-in**: add a type hint to enable validation for that parame
 
 Parameter validation supports two kinds of typed objects:
 
-- **Pydantic models** (v2+): Full validation with field constraints, nested models, and custom validators. Requires `pip install "kedro[pydantic]`.
+- **Pydantic models** (v2+): Full validation with field constraints, nested models, and custom validators. Requires `pip install "kedro[pydantic]"`.
 - **Dataclasses**: Basic type checking using Python's built-in `dataclasses` module. No extra dependencies needed.
 
 !!! note

--- a/docs/configure/parameter_validation.md
+++ b/docs/configure/parameter_validation.md
@@ -10,7 +10,7 @@ This feature is **opt-in**: add a type hint to enable validation for that parame
 
 Parameter validation supports two kinds of typed objects:
 
-- **Pydantic models** (v2+): Full validation with field constraints, nested models, and custom validators. Requires `pip install pydantic`.
+- **Pydantic models** (v2+): Full validation with field constraints, nested models, and custom validators. Requires `pip install "kedro[pydantic]`.
 - **Dataclasses**: Basic type checking using Python's built-in `dataclasses` module. No extra dependencies needed.
 
 !!! note
@@ -72,7 +72,7 @@ Kedro validates `params` against `TrainingParams` even though the hint is `Train
 
 There are two approaches to parameter validation:
 
-- **With Pydantic models**: Provides field constraints, nested model support, and custom validators. Requires installing Pydantic (`pip install pydantic`).
+- **With Pydantic models**: Provides field constraints, nested model support, and custom validators. Requires installing Pydantic (`pip install "kedro[pydantic]`).
 - **With dataclasses**: Uses Python's built-in `dataclasses` module with no extra dependencies, but without constraint validation.
 
 The sections below cover Pydantic first, then [dataclasses](#use-dataclasses).

--- a/docs/configure/parameter_validation.md
+++ b/docs/configure/parameter_validation.md
@@ -72,7 +72,7 @@ Kedro validates `params` against `TrainingParams` even though the hint is `Train
 
 There are two approaches to parameter validation:
 
-- **With Pydantic models**: Provides field constraints, nested model support, and custom validators. Requires installing Pydantic (`pip install "kedro[pydantic]`).
+- **With Pydantic models**: Provides field constraints, nested model support, and custom validators. Requires installing Pydantic (`pip install "kedro[pydantic]"`).
 - **With dataclasses**: Uses Python's built-in `dataclasses` module with no extra dependencies, but without constraint validation.
 
 The sections below cover Pydantic first, then [dataclasses](#use-dataclasses).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,9 @@ jupyter = [
 benchmark = [
     "asv"
 ]
+
+pydantic = ["pydantic>=2.0"]
+
 all = [ "kedro[test,docs,jupyter,benchmark]" ]
 
 [project.urls]


### PR DESCRIPTION
## Description
Fixes #5476
Adds a `pydantic` extras group so users can install Pydantic support via:
```
pip install "kedro[pydantic]"
```
Previously, users had to install Pydantic separately (`pip install pydantic`).

## Development notes

- Added `pydantic = ["pydantic>=2.0"]` to `[project.optional-dependencies]` in `pyproject.toml`
- Updated `docs/configure/parameter_validation.md` to reference `pip install "kedro[pydantic]"`
- Added entry to `RELEASE.md.`


## Developer Certificate of Origin
All commits are signed off with `-s ' as per the DCO.

We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
