### PR TITLE
Fixing inspection layer security recommendations

### DIFF
--- a/kedro/inspection/models.py
+++ b/kedro/inspection/models.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
+
+# Matches URI credentials
+_CREDENTIAL_RE = re.compile(r"(://)[^@\s]*:[^@\s]*(@)")
 
 
 @dataclass
@@ -37,10 +41,13 @@ class DatasetSnapshot:
     @classmethod
     def from_config(cls, name: str, config: dict) -> DatasetSnapshot:
         """Construct a ``DatasetSnapshot`` from a raw catalog config entry."""
+        filepath = config.get("filepath")
+        if filepath:
+            filepath = _CREDENTIAL_RE.sub(r"\1<redacted>\2", filepath)
         return cls(
             name=name,
             type=config.get("type", ""),
-            filepath=config.get("filepath"),
+            filepath=filepath,
         )
 
 

--- a/kedro/inspection/snapshot.py
+++ b/kedro/inspection/snapshot.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -24,6 +25,9 @@ from kedro.inspection.models import (
 if TYPE_CHECKING:
     from kedro.framework.startup import ProjectMetadata
     from kedro.pipeline.node import Node
+
+
+_ENV_RE = re.compile(r"^[A-Za-z0-9_-]+$")
 
 
 def _build_project_metadata_snapshot(
@@ -58,7 +62,8 @@ def _build_dataset_snapshots(
     return {
         ds_name: DatasetSnapshot.from_config(ds_name, ds_config)
         for ds_name, ds_config in catalog_config.items()
-        if not ds_name.startswith("_")  # skip YAML interpolation anchors
+        if not ds_name.startswith("_")
+        and isinstance(ds_config, dict)  # skip YAML anchors and non-dict entries
     }
 
 
@@ -122,7 +127,12 @@ def _build_project_snapshot(
     Returns:
         A fully populated ``ProjectSnapshot``.
     """
-    project_path = Path(project_path)
+    project_path = Path(project_path).resolve()
+
+    if env is not None and not _ENV_RE.match(env):
+        raise ValueError(
+            f"Invalid env value {env!r}: must contain only letters, digits, hyphens, and underscores."
+        )
 
     metadata = bootstrap_project(project_path)
     config_loader = _make_config_loader(project_path, env=env)

--- a/tests/inspection/test_dataset_snapshot.py
+++ b/tests/inspection/test_dataset_snapshot.py
@@ -105,3 +105,59 @@ class TestBuildDatasetSnapshots:
         )
         assert "{namespace}.{name}" in snapshots
         assert snapshots["{namespace}.{name}"].type == "pandas.CSVDataset"
+
+    def test_non_dict_entry_excluded(self):
+        snapshots = _build_dataset_snapshots(
+            {
+                "companies": {"type": "pandas.CSVDataset", "filepath": "companies.csv"},
+                "bad_entry": "some_string_value",
+            }
+        )
+        assert "bad_entry" not in snapshots
+        assert "companies" in snapshots
+
+    def test_none_entry_excluded(self):
+        snapshots = _build_dataset_snapshots(
+            {
+                "companies": {"type": "pandas.CSVDataset"},
+                "null_entry": None,
+            }
+        )
+        assert "null_entry" not in snapshots
+        assert "companies" in snapshots
+
+
+class TestDatasetSnapshotCredentialScrubbing:
+    @pytest.mark.parametrize(
+        "raw_filepath, expected",
+        [
+            (
+                "s3://access_key:secret_key@my-bucket/data/file.csv",  # pragma: allowlist secret
+                "s3://<redacted>@my-bucket/data/file.csv",
+            ),
+            (
+                "postgresql://user:password@db-host:5432/mydb",  # pragma: allowlist secret
+                "postgresql://<redacted>@db-host:5432/mydb",
+            ),
+            (
+                "gs://svc_account:token123@bucket/path/file.parquet",  # pragma: allowlist secret
+                "gs://<redacted>@bucket/path/file.parquet",
+            ),
+        ],
+    )
+    def test_from_config_scrubs_embedded_credentials(self, raw_filepath, expected):
+        snapshot = DatasetSnapshot.from_config(
+            "ds", {"type": "pandas.CSVDataset", "filepath": raw_filepath}
+        )
+        assert snapshot.filepath == expected
+
+    def test_plain_filepath_is_unchanged(self):
+        filepath = "data/01_raw/companies.csv"
+        snapshot = DatasetSnapshot.from_config(
+            "ds", {"type": "pandas.CSVDataset", "filepath": filepath}
+        )
+        assert snapshot.filepath == filepath
+
+    def test_none_filepath_is_unchanged(self):
+        snapshot = DatasetSnapshot.from_config("ds", {"type": "kedro.io.MemoryDataset"})
+        assert snapshot.filepath is None

--- a/tests/inspection/test_project_snapshot.py
+++ b/tests/inspection/test_project_snapshot.py
@@ -254,3 +254,21 @@ class TestBuildProjectSnapshot:
         )
         _build_project_snapshot(self.project_path)
         assert captured == [{}]
+
+    def test_project_path_is_resolved_before_bootstrap(self):
+        """Path with '..' segments is resolved before being passed to bootstrap_project."""
+        unresolved = self.project_path / "subdir" / ".."
+        expected = unresolved.resolve()
+        _build_project_snapshot(unresolved)
+        self.mock_bootstrap.assert_called_once_with(expected)
+
+    @pytest.mark.parametrize("env", ["staging/prod", "../prod", "bad env", "env!", ""])
+    def test_invalid_env_raises_value_error(self, env):
+        with pytest.raises(ValueError, match="Invalid env value"):
+            _build_project_snapshot(self.project_path, env=env)
+
+    @pytest.mark.parametrize(
+        "env", ["staging", "prod", "local", "staging-1", "my_env", "env2", None]
+    )
+    def test_valid_env_does_not_raise(self, env):
+        _build_project_snapshot(self.project_path, env=env)


### PR DESCRIPTION
## Description

**Fixed below recommendations in the inspection layer:**

1. (High — fix before any service exposure) Canonicalise project_path with .resolve() and validate env with a regex allowlist (snapshot.py:125, helper.py:34).
2. (Medium) Scrub or redact credential-like patterns from DatasetSnapshot.filepath before storing (models.py:43).
3. (Low) Add a isinstance(ds_config, dict) guard in _build_dataset_snapshots (snapshot.py:59).

## Development notes

Added above stated fix recommendations and relevant tests


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
