### PR TITLE
Fix `--checkout` flag warning popping up when it shouldnt.

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -826,7 +826,7 @@ def _make_cookiecutter_args_and_fetch_template(
     else:
         # Use the default template path for non PySpark or example options:
         starter_path = template_path
-        if checkout:
+        if checkout and template_path == str(TEMPLATE_PATH):
             warnings.warn(
                 "The --checkout flag has no effect when using the default template "
                 "without one of the following flags:"

--- a/tests/framework/cli/starters/test_new_from_cli_flags.py
+++ b/tests/framework/cli/starters/test_new_from_cli_flags.py
@@ -16,6 +16,7 @@ from tests.framework.cli.starters.utils import (
     _assert_name_ok,
     _assert_requirements_ok,
     _assert_template_ok,
+    _make_cli_prompt_input,
     _make_cli_prompt_input_without_name,
     _make_cli_prompt_input_without_tools,
 )
@@ -373,6 +374,56 @@ class TestCheckoutWithoutStarter:
         assert mock_cookiecutter.call_args[1]["template"] == str(TEMPLATE_PATH)
         assert mock_cookiecutter.call_args[1]["checkout"] == "my_checkout"
         assert any(
+            "The --checkout flag has no effect" in str(w.message)
+            for w in caught_warnings
+            if issubclass(w.category, UserWarning)
+        )
+
+    def test_no_warning_when_starter_used_without_checkout(
+        self, fake_kedro_cli, mock_determine_repo_dir, mock_cookiecutter
+    ):
+        """--starter without --checkout should not trigger the checkout warning.
+
+        checkout is auto-set to the kedro version when using an official starter,
+        which previously caused the warning to fire spuriously.
+        """
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            result = CliRunner().invoke(
+                fake_kedro_cli,
+                ["new", "--starter", "spaceflights-pandas"],
+                input=_make_cli_prompt_input(),
+            )
+        assert result.exit_code == 0, result.output
+        assert not any(
+            "The --checkout flag has no effect" in str(w.message)
+            for w in caught_warnings
+            if issubclass(w.category, UserWarning)
+        )
+
+    def test_no_warning_when_starter_used_with_explicit_checkout(
+        self, fake_kedro_cli, mock_determine_repo_dir, mock_cookiecutter
+    ):
+        """--starter with explicit --checkout should not trigger the checkout warning."""
+        import warnings
+
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            warnings.simplefilter("always")
+            result = CliRunner().invoke(
+                fake_kedro_cli,
+                [
+                    "new",
+                    "--starter",
+                    "spaceflights-pandas",
+                    "--checkout",
+                    "my_checkout",
+                ],
+                input=_make_cli_prompt_input(),
+            )
+        assert result.exit_code == 0, result.output
+        assert not any(
             "The --checkout flag has no effect" in str(w.message)
             for w in caught_warnings
             if issubclass(w.category, UserWarning)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Fix for https://github.com/kedro-org/kedro/issues/5503. Just changed the conditional for the warning to make sure it only pops when the default template is being used. `checkout` parameter will always have something in it because the starters logic puts the latest Kedro version in it if you don't set it yourself.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
