### PR TITLE
fix: prevent false --checkout warning when using official starters

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -826,7 +826,7 @@ def _make_cookiecutter_args_and_fetch_template(
     else:
         # Use the default template path for non PySpark or example options:
         starter_path = template_path
-        if checkout:
+        if checkout and template_path == str(TEMPLATE_PATH):
             warnings.warn(
                 "The --checkout flag has no effect when using the default template "
                 "without one of the following flags:"


### PR DESCRIPTION
## Summary
Running `kedro new --starter spaceflights-pandas` (without `--checkout`) incorrectly shows a warning: "The --checkout flag has no effect when using the default template..."

This happens because when an official starter alias is used, `checkout` gets auto-populated with the current version string via `_select_checkout_branch_for_cookiecutter()`. The warning then fires because `checkout` is truthy, even though the user never passed `--checkout`.

## Changes
Added a check to only show the warning when `template_path` equals the default `TEMPLATE_PATH`, meaning the user is actually using the default template without a starter.

Closes #5503

Assisted-by: GLM 5.1