### PR TITLE
Test `review-kedro-pr`

### DIFF
--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13, 3.14" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       os: ${{ matrix.os }}

--- a/.github/workflows/all-checks.yml
+++ b/.github/workflows/all-checks.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13, 3.14" ]
     uses: ./.github/workflows/unit-tests.yml
     with:
       os: ${{ matrix.os }}
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         os: [ windows-latest, ubuntu-latest ]
-        python-version: [ "3.10", "3.11", "3.12", "3.13" ]
+        python-version: [ "3.10", "3.11", "3.12", "3.13", "3.14" ]
     uses: ./.github/workflows/e2e-tests.yml
     with:
       os: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-[![Python version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg)](https://pypi.org/project/kedro/)
+[![Python version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg)](https://pypi.org/project/kedro/)
 [![PyPI version](https://badge.fury.io/py/kedro.svg)](https://pypi.org/project/kedro/)
 [![Conda version](https://img.shields.io/conda/vn/conda-forge/kedro.svg)](https://anaconda.org/conda-forge/kedro)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/kedro-org/kedro/blob/main/LICENSE.md)

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 
 ## Major features and improvements
+* * Add official support for Python 3.14.
 * Added the first iteration of the `KedroServiceSession`, a new session implementation that allows for multiple runs and data injection.
 NOTE: This session implementation is under active development and may occasionally contain bugs or breaking changes. We encourage users to try it out and share their feedback with us.
 * Added inspection API to get project snapshot.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,6 @@
 # Upcoming Release
 
 ## Major features and improvements
-* * Add official support for Python 3.14.
 * Added the first iteration of the `KedroServiceSession`, a new session implementation that allows for multiple runs and data injection.
 NOTE: This session implementation is under active development and may occasionally contain bugs or breaking changes. We encourage users to try it out and share their feedback with us.
 * Added inspection API to get project snapshot.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 
 ## Major features and improvements
+* Added support for Python 3.14, including compatibility with the new forkserver multiprocessing start method on Linux.
 * Added the first iteration of the `KedroServiceSession`, a new session implementation that allows for multiple runs and data injection.
 NOTE: This session implementation is under active development and may occasionally contain bugs or breaking changes. We encourage users to try it out and share their feedback with us.
 * Added inspection API to get project snapshot.

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -39,7 +39,7 @@ For the `ParallelRunner`, it is possible to manually select which multiprocessin
 
 - `fork`: The child process is created as a copy of the parent process. This is fast but can cause issues with libraries that use threads or manage internal state. Default on Linux up to Python 3.13.
 
-- `forkserver`: A pre-spawned server process forks new workers on demand. Avoids the threading hazards of `fork` while being faster to start than `spawn`. Default on Linux from Python 3.14 onwards.
+- `forkserver`: A pre-spawned server process forks new workers on demand. Default on Linux on Python 3.14 and above.
 
 - `spawn`: The child process starts fresh, importing the main module and inheriting the necessary resources. This is safer and more compatible with several libraries, but requires all objects to be pickleable. Default on Windows and macOS.
 

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -37,11 +37,13 @@ kedro run --runner=ParallelRunner
 
 For the `ParallelRunner`, it is possible to manually select which multiprocessing start method is going to be used.
 
-- `fork`: The child process is created as a copy of the parent process. This is fast but can cause issues with libraries that use threads or manage internal state. Default on most Unix systems.
+- `fork`: The child process is created as a copy of the parent process. This is fast but can cause issues with libraries that use threads or manage internal state. Default on Linux up to Python 3.13.
 
-- `spawn`: The child process starts fresh, importing the main module and inheriting the necessary resources. This is safer and more compatible with several libraries, but requires all objects to be pickleable. Default on Windows and macOS (Python 3.8+).
+- `forkserver`: A pre-spawned server process forks new workers on demand. Avoids the threading hazards of `fork` while being faster to start than `spawn`. Default on Linux from Python 3.14 onwards.
 
-To control which multiprocessing start method is going to be used by `ParallelRunner`, you can set the value `spawn` or `fork` to the `KEDRO_MP_CONTEXT` environment variable. If neither of those is set, the runner will use the system's default.
+- `spawn`: The child process starts fresh, importing the main module and inheriting the necessary resources. This is safer and more compatible with several libraries, but requires all objects to be pickleable. Default on Windows and macOS.
+
+To control which multiprocessing start method is used by `ParallelRunner`, set `KEDRO_MP_CONTEXT` to `fork`, `forkserver`, or `spawn`. If the variable is not set, the runner uses the system default.
 
 #### Multithreading
 While `ParallelRunner` uses multiprocessing, you can also run the pipeline with multithreading for concurrent execution by specifying `ThreadRunner` as follows:

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -1,7 +1,7 @@
 # Set up Kedro
 
 ## Installation prerequisites
-* **Python**: Kedro works on macOS, Linux, and Windows and requires Python 3.9+. You should create a new virtual environment for *each* new Kedro project you work on to isolate its Python dependencies from those of other projects.
+* **Python**: Kedro works on macOS, Linux, and Windows and requires Python 3.10+. You should create a new virtual environment for *each* new Kedro project you work on to isolate its Python dependencies from those of other projects.
 
 * **git**: You must install `git` onto your machine if you do not already have it. Type `git -v` into your terminal window to confirm it is installed; it will return the version of `git` available or an error message. [You can download `git` from the official website](https://git-scm.com/).
 
@@ -355,7 +355,7 @@ kedro --version
 ## Summary
 
 * Kedro can be used on Windows, macOS or Linux.
-* Installation prerequisites include a Python 3.9+ and `git`.
+* Installation prerequisites include a Python 3.10+ and `git`.
 * The simplest way to get started with Kedro is to create a new project using our starters.
 * `uv` is a great choice for managing Kedro projects, but you can use other tools such as `pip`, `Poetry`, `conda`, and more.
 

--- a/docs/overrides/welcome.html
+++ b/docs/overrides/welcome.html
@@ -206,7 +206,7 @@
                     <img src="https://img.shields.io/badge/license-Apache%202.0-blue.svg" alt="License is Apache 2.0">
                 </a>
                 <a href="https://pypi.org/project/kedro/" target="_blank" rel="noopener">
-                    <img src="https://img.shields.io/badge/3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13-blue.svg" alt="Python version 3.10, 3.11, 3.12, 3.13">
+                    <img src="https://img.shields.io/badge/3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue.svg" alt="Python version 3.10, 3.11, 3.12, 3.13, 3.14">
                 </a>
                 <a href="https://pypi.org/project/kedro/" target="_blank" rel="noopener">
                     <img src="https://badge.fury.io/py/kedro.svg" alt="PyPI package version">

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -28,7 +28,7 @@ if not sys.warnoptions:
     warnings.simplefilter("default", KedroDeprecationWarning)
     warnings.simplefilter("error", KedroPythonVersionWarning)
 
-if sys.version_info >= (3, 14):
+if sys.version_info >= (3, 15):
     warnings.warn(
         """Kedro is not yet fully compatible with this Python version.
 To proceed at your own risk and ignore this warning,

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -118,7 +118,7 @@ class ParallelRunner(AbstractRunner):
 
     def _get_executor(self, max_workers: int) -> Executor:
         context = os.environ.get("KEDRO_MP_CONTEXT")
-        if context and context not in {"fork", "spawn"}:
+        if context and context not in {"fork", "spawn", "forkserver"}:
             context = None
         ctx = get_context(context)
         return ProcessPoolExecutor(max_workers=max_workers, mp_context=ctx)

--- a/kedro/runner/task.py
+++ b/kedro/runner/task.py
@@ -129,7 +129,10 @@ class Task:
             The node argument.
 
         """
-        if multiprocessing.get_start_method() == "spawn" and package_name:
+        if (
+            multiprocessing.get_start_method() in ("spawn", "forkserver")
+            and package_name
+        ):
             Task._bootstrap_subprocess(package_name, logging_config)
 
         hook_manager = _create_hook_manager()

--- a/kedro/validation/type_extractor.py
+++ b/kedro/validation/type_extractor.py
@@ -19,6 +19,18 @@ logger = logging.getLogger(__name__)
 _PARAMS_PREFIX = "params:"
 
 
+def _type_name(tp: type) -> str:
+    """Return a human-readable name for a type, using str() for union types.
+
+    In Python 3.14, types.UnionType gained __name__ == "Union", so
+    getattr(tp, "__name__", str(tp)) would return "Union" instead of
+    the full representation like "list[str] | int".
+    """
+    if isinstance(tp, types.UnionType) or get_origin(tp) is Union:
+        return str(tp)
+    return getattr(tp, "__name__", str(tp))
+
+
 def _unwrap_optional(tp: type) -> type:
     """Unwrap ``Optional[X]`` / ``X | None`` to ``X``.
 
@@ -70,10 +82,10 @@ class TypeExtractor:
                             "%s (existing) vs %s (from pipeline '%s'). "
                             "Using %s.",
                             key,
-                            getattr(existing_type, "__name__", str(existing_type)),
-                            getattr(new_type, "__name__", str(new_type)),
+                            _type_name(existing_type),
+                            _type_name(new_type),
                             pipeline_name,
-                            getattr(new_type, "__name__", str(new_type)),
+                            _type_name(new_type),
                         )
 
             all_type_requirements.update(pipeline_type_requirements)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 dynamic = ["readme", "version"]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ discover them automatically. More info here:
 https://docs.pytest.org/en/latest/fixture.html
 """
 
+import multiprocessing
 import os
 import sys
 
@@ -12,6 +13,15 @@ import pandas as pd
 import pytest
 
 from kedro.io.core import AbstractDataset
+
+# Python 3.14 changed the default multiprocessing start method on Linux from
+# "fork" to "forkserver". The "forkserver" method is incompatible with
+# pytest-cov because coverage's sitecustomize injection fails in the forkserver
+# subprocess (os.path.realpath('.') raises FileNotFoundError). Use "spawn"
+# instead, which coverage handles correctly and which matches the behaviour
+# already tested on Windows/macOS.
+if sys.version_info >= (3, 14) and multiprocessing.get_start_method() == "forkserver":
+    multiprocessing.set_start_method("spawn", force=True)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/framework/session/test_session_extension_hooks.py
+++ b/tests/framework/session/test_session_extension_hooks.py
@@ -30,11 +30,12 @@ from tests.framework.session.conftest import (
     assert_exceptions_equal,
 )
 
-# Window and MacOS(Python>3.7) default with `spawn` process which reload modules
-# and cause test fails
+# Windows and macOS use `spawn` by default; Python 3.14+ Linux uses `forkserver`.
+# Both methods don't inherit file descriptors, so log records from subprocesses
+# can't reach the test's QueueHandler, causing hook count assertions to fail.
 SKIP_ON_WINDOWS_AND_MACOS = pytest.mark.skipif(
-    multiprocessing.get_start_method() == "spawn",
-    reason="Due to bug in parallel runner",
+    multiprocessing.get_start_method() in ("spawn", "forkserver"),
+    reason="Due to bug in parallel runner with non-fork start methods",
 )
 
 logger = logging.getLogger("tests.framework.session.conftest")

--- a/tests/runner/test_parallel_runner.py
+++ b/tests/runner/test_parallel_runner.py
@@ -456,7 +456,7 @@ class TestMultiprocessingGetExecutorContextSelection:
         assert isinstance(executor, ProcessPoolExecutor)
         assert hasattr(executor, "_mp_context")
 
-    @pytest.mark.parametrize("context", ["fork", "spawn"])
+    @pytest.mark.parametrize("context", ["fork", "spawn", "forkserver"])
     def test_get_executor_valid_context(self, mocker, context):
         if sys.platform == "win32":
             pytest.skip("fork context is not available on Windows")

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -4,8 +4,8 @@ import kedro
 
 
 def test_import_kedro_with_no_official_support_raise_error(mocker):
-    """Test importing kedro with python>=3.14 should fail"""
-    mocker.patch("kedro.sys.version_info", (3, 14))
+    """Test importing kedro with python>=3.15 should fail"""
+    mocker.patch("kedro.sys.version_info", (3, 15))
 
     # We use the parent class to avoid issues with `exec_module`
     with pytest.raises(UserWarning) as excinfo:
@@ -15,8 +15,8 @@ def test_import_kedro_with_no_official_support_raise_error(mocker):
 
 
 def test_import_kedro_with_no_official_support_emits_warning(mocker):
-    """Test importing kedro python>=3.14 and controlled warnings should work"""
-    mocker.patch("kedro.sys.version_info", (3, 14))
+    """Test importing kedro python>=3.15 and controlled warnings should work"""
+    mocker.patch("kedro.sys.version_info", (3, 15))
     mocker.patch("kedro.sys.warnoptions", ["default:Kedro is not yet fully compatible"])
 
     # We use the parent class to avoid issues with `exec_module`


### PR DESCRIPTION
## Description
Adds Python 3.14 support to Kedro.

The most significant change here is that Python 3.14 changed the default multiprocessing start method on Linux from fork to forkserver.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
