### PR TITLE
Remove outdated `TRANSCODING_SEPARATOR` alias

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,8 @@ NOTE: This session implementation is under active development and may occasional
 * Added inspection API to get project snapshot.
 
 ## Bug fixes and other changes
+* Removed outdated `TRANSCODING_SEPARATOR` alias from `kedro.pipeline.pipeline`.
+
 ## Documentation changes
 ## Community contributions
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -25,22 +25,6 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Set
 
 
-def __getattr__(name: str) -> Any:
-    if name == "TRANSCODING_SEPARATOR":
-        import warnings
-
-        from kedro.pipeline.transcoding import TRANSCODING_SEPARATOR
-
-        warnings.warn(
-            f"{name!r} has been moved to 'kedro.pipeline.transcoding', "
-            f"and the alias will be removed in Kedro 1.0.0.",
-            kedro.KedroDeprecationWarning,
-            stacklevel=2,
-        )
-        return TRANSCODING_SEPARATOR
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
 class PipelineError(Exception):
     """Raised when a pipeline is not adapted and integrated
     appropriately using the helper.

--- a/tests/pipeline/test_pipeline.py
+++ b/tests/pipeline/test_pipeline.py
@@ -4,7 +4,6 @@ from itertools import chain
 import pytest
 
 import kedro
-from kedro import KedroDeprecationWarning
 from kedro.pipeline import GroupedNodes, node, pipeline
 from kedro.pipeline.pipeline import (
     CircularDependencyError,
@@ -14,13 +13,6 @@ from kedro.pipeline.pipeline import (
 )
 from kedro.pipeline.transcoding import _strip_transcoding, _transcode_split
 from tests.test_utils import biconcat, constant_output, identity, triconcat
-
-
-def test_deprecation():
-    with pytest.warns(
-        KedroDeprecationWarning, match="'TRANSCODING_SEPARATOR' has been moved"
-    ):
-        from kedro.pipeline.pipeline import TRANSCODING_SEPARATOR  # noqa: F401
 
 
 class TestTranscodeHelpers:


### PR DESCRIPTION
## Description

The `TRANSCODING_SEPARATOR` constant was moved to `kedro.pipeline.transcoding` before Kedro 1.0.0, but the backwards-compatible alias in `kedro.pipeline.pipeline` (with a deprecation warning targeting 1.0.0) was never cleaned up.

## Development notes
- Removed the module-level `__getattr__` shim in `kedro/pipeline/pipeline.py`
- Removed the corresponding `test_deprecation` test
- Updated release notes

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
