### PR TITLE
[WIP] Selective loading of pipelines

### DIFF
--- a/docs/on_demand_dependency_loading.md
+++ b/docs/on_demand_dependency_loading.md
@@ -1,0 +1,759 @@
+# On-Demand Project Dependency Loading
+
+**Spike:** [#5406](https://github.com/kedro-org/kedro/issues/5406)
+**Branch:** `spike/dep_free`
+**Goal:** Eliminate unnecessary pipeline dependency imports across CLI commands, targeted runs, and inspection workflows.
+
+---
+
+## Table of Contents
+
+1. [Problem Statement](#1-problem-statement)
+2. [Current Architecture](#2-current-architecture)
+3. [Root Cause Analysis](#3-root-cause-analysis)
+4. [The Two-Step Strategy](#4-the-two-step-strategy)
+5. [Step 1 — Load Only Required Pipelines](#5-step-1--load-only-required-pipelines)
+   - [Piece 1a: Wire Selective Loading Through the Run Path](#piece-1a-wire-selective-loading-through-the-run-path)
+   - [Piece 1b: Lightweight Pipeline Name Discovery](#piece-1b-lightweight-pipeline-name-discovery)
+   - [Piece 1c: Wire Other CLI Commands to Declare Their Needs](#piece-1c-wire-other-cli-commands-to-declare-their-needs)
+6. [Step 2 — Lazy Dependency Resolution at Node Level](#6-step-2--lazy-dependency-resolution-at-node-level)
+   - [Piece 2a: Defer `inspect.signature()` to Execution Time](#piece-2a-defer-inspectsignature-to-execution-time)
+   - [Piece 2b: String Function References in Node](#piece-2b-string-function-references-in-node)
+7. [CLI Command Benefit Matrix](#7-cli-command-benefit-matrix)
+8. [Implementation Roadmap](#8-implementation-roadmap)
+
+---
+
+## 1. Problem Statement
+
+Kedro currently requires **all** pipeline dependencies to be installed before executing any project-specific CLI command — even when targeting a single pipeline or performing read-only inspection.
+
+```
+kedro run --pipeline data_science
+```
+
+This command today imports and instantiates **every** pipeline in the project, including `data_engineering`, `feature_engineering`, `reporting` — none of which are relevant to the run.
+
+### Real-World Impact
+
+| Scenario | Current Behavior | Desired Behavior |
+|----------|-----------------|------------------|
+| `kedro run --pipeline data_science` | All pipeline modules imported | Only `data_science` imports loaded |
+| `kedro registry list` | All Pipeline objects constructed | Directory scan only — no imports |
+| `kedro catalog describe-datasets -p reporting` | All pipelines loaded | Only `reporting` pipeline loaded |
+| CI/CD lint/metadata check | Full dependency footprint required | Near-zero dependency footprint |
+| New developer onboarding | Must install all deps to run anything | Install only the pipeline they work on |
+
+---
+
+## 2. Current Architecture
+
+### How a `kedro run` Triggers Full Dependency Loading Today
+
+```mermaid
+sequenceDiagram
+    participant CLI as kedro run --pipeline data_science
+    participant Session as KedroSession.run()
+    participant Pipelines as _ProjectPipelines
+    participant LoadData as _load_data()
+    participant Registry as register_pipelines()
+    participant Find as find_pipelines()
+    participant Modules as All Pipeline Modules
+
+    CLI->>Session: session.run(pipeline_names=["data_science"])
+    Session->>Pipelines: pipelines["data_science"]  ← triggers _load_data_wrapper
+    Pipelines->>LoadData: _load_data()
+    LoadData->>Registry: register_pipelines()  ← NO filter passed
+    Registry->>Find: find_pipelines()  ← NO pipelines_to_find
+    Find->>Modules: import data_engineering.pipeline
+    Find->>Modules: import feature_engineering.pipeline
+    Find->>Modules: import data_science.pipeline  ← actually needed
+    Find->>Modules: import reporting.pipeline
+    Modules-->>Find: All Nodes created + inspect.signature() called on EVERY function
+    Find-->>Registry: {all 4 pipelines}
+    Registry-->>LoadData: {all 4 pipelines}
+    LoadData-->>Pipelines: _content = {all 4 pipelines}
+    Pipelines-->>Session: returns data_science pipeline
+    Session->>Session: Pipeline.filter()  ← filtering AFTER full load
+```
+
+### Pipeline Loading Call Stack
+
+```mermaid
+flowchart TD
+    A["CLI: kedro run / registry list / catalog describe"] --> B["bootstrap_project()\nconfigure_project(package_name)"]
+    B --> C["pipelines.configure(pipelines_module)\n_is_data_loaded = False"]
+    C --> D["First dict access:\npipelines[name] / iter(pipelines) / len(pipelines)"]
+    D --> E["_load_data_wrapper → _load_data()"]
+    E --> F["register_pipelines()\n← user-defined or default"]
+    F --> G["find_pipelines()\n← pipelines_to_find=None today"]
+    G --> H["importlib.import_module()\nfor EVERY pipeline directory"]
+    H --> I["_create_pipeline(module)\n→ Pipeline([node(...), ...])"]
+    I --> J["Node.__init__(func, inputs, outputs)\n→ _validate_inputs(func, inputs)"]
+    J --> K["inspect.signature(func).bind(...)\n← imports func's module here"]
+
+    style K fill:#ff6b6b,color:#fff
+    style G fill:#ffa500,color:#fff
+    style H fill:#ffa500,color:#fff
+```
+
+---
+
+## 3. Root Cause Analysis
+
+There are **two distinct bottlenecks** at different layers of the stack:
+
+### Bottleneck 1: `_ProjectPipelines._load_data()` — Pipeline Level
+
+```python
+# kedro/framework/project/__init__.py:211-225
+def _load_data(self) -> None:
+    if self._pipelines_module is None or self._is_data_loaded:
+        return
+
+    register_pipelines = self._get_pipelines_registry_callable(
+        self._pipelines_module
+    )
+    # ❌ No filter passed — always loads EVERYTHING
+    project_pipelines = register_pipelines()
+
+    self._content = project_pipelines
+    self._is_data_loaded = True
+```
+
+The selective loading capability **already exists** in `find_pipelines(pipelines_to_find=...)` from PR #5401, but `_load_data()` never passes a filter through.
+
+### Bottleneck 2: `Node.__init__._validate_inputs()` — Function Level
+
+```python
+# kedro/pipeline/node.py:155
+self._validate_inputs(func, inputs)  # called eagerly in __init__
+
+# kedro/pipeline/node.py:683-701
+def _validate_inputs(self, func, inputs):
+    if not inspect.isbuiltin(func):
+        # ❌ Requires func to be a live callable — the module must already be imported
+        inspect.signature(func, follow_wrapped=False).bind(*args, **kwargs)
+```
+
+Every `node(my_function, ...)` call in every `create_pipeline()` body triggers `inspect.signature()`, which forces the module containing `my_function` to be fully imported.
+
+### The Gap Visualised
+
+```mermaid
+flowchart LR
+    subgraph "What Exists"
+        A["find_pipelines(pipelines_to_find=['data_science'])"]
+        B["KedroSession.run(pipeline_names=['data_science'])"]
+    end
+
+    subgraph "The Gap"
+        C["_load_data() calls register_pipelines()\nwith NO filter"]
+        D["Node.__init__ calls inspect.signature()\nat construction time"]
+    end
+
+    subgraph "What We Need"
+        E["_load_data() forwards the requested\npipeline names to register_pipelines()"]
+        F["Node defers signature validation\nto execution time"]
+    end
+
+    A -.->|"never wired"| C
+    B -.->|"never wired"| C
+    C -->|"fix"| E
+    D -->|"fix"| F
+```
+
+---
+
+## 4. The Two-Step Strategy
+
+```mermaid
+flowchart TD
+    P["Problem: All pipelines load on every CLI command"]
+
+    P --> S1["Step 1: Load Only Required Pipelines\n(Pipeline-level granularity)"]
+    P --> S2["Step 2: Lazy Dependency Resolution\n(Function-level granularity)"]
+
+    S1 --> P1a["Piece 1a\nWire selective loading\nthrough the run path"]
+    S1 --> P1b["Piece 1b\nLightweight pipeline\nname discovery"]
+    S1 --> P1c["Piece 1c\nWire CLI commands\nto declare their needs"]
+
+    S2 --> P2a["Piece 2a\nDefer inspect.signature()\nto execution time"]
+    S2 --> P2b["Piece 2b\nString function references\nin Node (future)"]
+
+    style P1a fill:#4caf50,color:#fff
+    style P1b fill:#4caf50,color:#fff
+    style P1c fill:#2196f3,color:#fff
+    style P2a fill:#2196f3,color:#fff
+    style P2b fill:#9c27b0,color:#fff
+```
+
+**Step 1** eliminates the need to import unrelated pipeline *modules* entirely.
+**Step 2** eliminates the need to import a function's *module* at pipeline definition time.
+
+Both steps are independent and additive — Step 1 gives the biggest wins with least risk, Step 2 unlocks further gains.
+
+---
+
+## 5. Step 1 — Load Only Required Pipelines
+
+### Piece 1a: Wire Selective Loading Through the Run Path
+
+**Goal:** Activate the already-existing `find_pipelines(pipelines_to_find=...)` parameter from end to end.
+
+**What changes:**
+
+#### 1. Add `set_requested()` to `_ProjectPipelines`
+
+```python
+# kedro/framework/project/__init__.py
+
+class _ProjectPipelines(MutableMapping):
+    def __init__(self) -> None:
+        self._pipelines_module: str | None = None
+        self._is_data_loaded = False
+        self._content: dict[str, Pipeline] = {}
+        self._requested_pipelines: list[str] | None = None  # NEW
+
+    def set_requested(self, pipeline_names: list[str] | None) -> None:
+        """Hint which pipelines will be needed before first data access.
+
+        Must be called before any dict-access on this object. If the filter
+        changes after data has been loaded, the cache is invalidated.
+        """
+        if self._requested_pipelines != pipeline_names:
+            self._is_data_loaded = False
+            self._content = {}
+        self._requested_pipelines = pipeline_names
+
+    def _load_data(self) -> None:
+        if self._pipelines_module is None or self._is_data_loaded:
+            return
+
+        register_pipelines = self._get_pipelines_registry_callable(
+            self._pipelines_module
+        )
+        # Pass the hint as an optional kwarg — default register_pipelines
+        # forwards it to find_pipelines(); custom ones can ignore it safely.
+        try:
+            project_pipelines = register_pipelines(
+                pipelines_to_find=self._requested_pipelines
+            )
+        except TypeError:
+            # Fallback: custom register_pipelines doesn't accept kwargs
+            project_pipelines = register_pipelines()
+
+        self._content = project_pipelines
+        self._is_data_loaded = True
+```
+
+#### 2. Wire `KedroSession.run()` to set the hint before pipeline access
+
+```python
+# kedro/framework/session/session.py
+
+def run(self, pipeline_names: list[str] | None = None, ...) -> dict[str, Any]:
+    ...
+    names = pipeline_names or ["__default__"]
+
+    # NEW: inform the pipeline registry which pipelines are needed
+    # before the first dict access so _load_data() can filter selectively
+    pipelines.set_requested(names)
+
+    combined_pipelines = Pipeline([])
+    for name in names:
+        try:
+            combined_pipelines += pipelines[name]  # only loads requested ones
+        except KeyError as exc:
+            ...
+```
+
+#### Before / After Flow
+
+```mermaid
+sequenceDiagram
+    participant CLI as kedro run --pipeline data_science
+    participant Session as KedroSession.run()
+    participant Pipelines as _ProjectPipelines
+    participant Find as find_pipelines()
+    participant Modules as Pipeline Modules
+
+    Note over CLI,Modules: AFTER Piece 1a
+
+    CLI->>Session: session.run(pipeline_names=["data_science"])
+    Session->>Pipelines: pipelines.set_requested(["data_science"])  ← NEW
+    Session->>Pipelines: pipelines["data_science"]
+    Pipelines->>Find: find_pipelines(pipelines_to_find=["data_science"])
+    Find->>Modules: import data_science.pipeline  ← ONLY this one
+    Find-->>Pipelines: {"data_science": <Pipeline>}
+    Pipelines-->>Session: data_science Pipeline object
+```
+
+**Impact:**
+- `kedro run --pipeline data_science` imports only `data_science` module → unrelated packages (e.g. `torch`, `sklearn`) never imported
+- Zero changes to the existing `find_pipelines()` implementation
+- Fully backwards-compatible: custom `register_pipelines` that ignores kwargs works unchanged
+
+---
+
+### Piece 1b: Lightweight Pipeline Name Discovery
+
+**Goal:** Let `kedro registry list` return pipeline names without importing any pipeline module.
+
+Today `registry list` triggers a full pipeline load:
+
+```python
+# kedro/framework/cli/registry.py:26
+click.echo(yaml.dump(sorted(pipelines)))  # iterating triggers _load_data()
+```
+
+This constructs every `Pipeline` object, instantiates every `Node`, and calls `inspect.signature()` on every node function — just to print a list of names.
+
+**Proposed addition to `_ProjectPipelines`:**
+
+```python
+# kedro/framework/project/__init__.py
+
+def list_names(self) -> list[str]:
+    """Return pipeline names from directory structure without importing modules.
+
+    For projects using the default modular layout, this scans the pipelines
+    package directory and returns folder names — no imports, no Node objects.
+    Falls back to full load if the project uses a custom layout.
+    """
+    if PACKAGE_NAME is None:
+        return []
+
+    try:
+        pipelines_package = importlib.resources.files(
+            f"{PACKAGE_NAME}.pipelines"
+        )
+    except ModuleNotFoundError:
+        # Non-standard layout — fall back to full load
+        return list(self.keys())
+
+    names = []
+    for entry in pipelines_package.iterdir():
+        if (
+            entry.is_dir()
+            and not entry.name.startswith(".")
+            and entry.name != "__pycache__"
+        ):
+            names.append(entry.name)
+
+    # Always include __default__ as it's implicitly registered
+    return sorted(["__default__", *names])
+```
+
+**Updated `registry list` command:**
+
+```python
+# kedro/framework/cli/registry.py
+
+@registry.command("list")
+def list_registered_pipelines() -> None:
+    """List all pipelines defined in your pipeline_registry.py file."""
+    # Use lightweight name discovery — no pipeline modules imported
+    click.echo(yaml.dump(pipelines.list_names()))
+```
+
+**`registry describe` still needs the full pipeline** (it shows node names and functions), so it keeps using `pipelines.get(name)` — but with Piece 1a wired, it will only load the one requested pipeline:
+
+```python
+@registry.command("describe")
+@click.argument("name", default="__default__")
+def describe_registered_pipeline(metadata, name, **kwargs):
+    pipelines.set_requested([name])   # NEW — only load what's described
+    pipeline_obj = pipelines.get(name)
+    ...
+```
+
+#### Comparison
+
+```mermaid
+flowchart LR
+    subgraph "Today: kedro registry list"
+        A1["Scan pipelines/ dir"] --> B1["import data_engineering"]
+        A1 --> B2["import feature_engineering"]
+        A1 --> B3["import data_science"]
+        A1 --> B4["import reporting"]
+        B1 & B2 & B3 & B4 --> C1["Build all Pipeline objects\nand all Node objects"]
+        C1 --> D1["Return sorted names"]
+    end
+
+    subgraph "After Piece 1b: kedro registry list"
+        A2["Scan pipelines/ dir names\nNo imports"] --> D2["Return sorted names"]
+    end
+
+    style C1 fill:#ff6b6b,color:#fff
+    style A2 fill:#4caf50,color:#fff
+    style D2 fill:#4caf50,color:#fff
+```
+
+---
+
+### Piece 1c: Wire Other CLI Commands to Declare Their Needs
+
+**Goal:** Every CLI command that takes a `--pipeline` argument should set the filter on `pipelines` before the first access, so only relevant pipeline modules are imported.
+
+#### `kedro catalog describe-datasets --pipeline reporting`
+
+Today this loads all pipelines to resolve dataset information for one pipeline.
+
+```python
+# kedro/framework/cli/catalog.py — CURRENT
+def describe_datasets(metadata, pipeline, env):
+    session = _create_session(metadata.package_name, env=env)
+    context = session.load_context()
+    p = pipeline or None
+    datasets_dict = context.catalog.describe_datasets(p)  # pipelines accessed inside
+    secho(yaml.dump(datasets_dict))
+```
+
+The fix is a single line before session creation:
+
+```python
+# kedro/framework/cli/catalog.py — AFTER Piece 1c
+def describe_datasets(metadata, pipeline, env):
+    if pipeline:
+        from kedro.framework.project import pipelines as _pipelines
+        _pipelines.set_requested(pipeline)  # pipeline is already a list via split_string
+
+    session = _create_session(metadata.package_name, env=env)
+    context = session.load_context()
+    p = pipeline or None
+    datasets_dict = context.catalog.describe_datasets(p)
+    secho(yaml.dump(datasets_dict))
+```
+
+#### `kedro catalog resolve-patterns --pipeline X`
+
+Same pattern:
+
+```python
+def resolve_patterns(metadata, pipeline, env):
+    if pipeline:
+        from kedro.framework.project import pipelines as _pipelines
+        _pipelines.set_requested(pipeline)
+
+    session = _create_session(metadata.package_name, env=env)
+    ...
+```
+
+#### Commands That Need No Pipelines At All
+
+| Command | Needs Pipelines? | Action |
+|---------|-----------------|--------|
+| `kedro info` | No | No change needed — never accesses `pipelines` |
+| `kedro package` | No | No change needed |
+| `kedro catalog list-patterns` | No | No change needed |
+| `kedro pipeline list` / `kedro pipeline pull` | Discovery only | Use `list_names()` from Piece 1b |
+
+#### Commands That Need Specific Pipelines
+
+| Command | Filter | Implementation |
+|---------|--------|----------------|
+| `kedro run --pipeline X` | `["X"]` | Piece 1a (`session.run` wires it) |
+| `kedro run --pipelines X,Y` | `["X", "Y"]` | Piece 1a (`session.run` wires it) |
+| `kedro registry describe X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
+| `kedro catalog describe-datasets -p X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
+| `kedro catalog resolve-patterns -p X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
+
+#### Commands That Need All Pipelines
+
+| Command | Reason | Notes |
+|---------|--------|-------|
+| `kedro run` (no `--pipeline`) | Runs `__default__` which merges all | Full load required |
+| `kedro registry list` | Lists all names | Use `list_names()` for names only |
+| Inspection API `get_project_snapshot()` | Full project snapshot | See below |
+
+#### Inspection API Fix
+
+The inspection API currently loads all pipelines without any filter:
+
+```python
+# kedro/inspection/snapshot.py:136 — CURRENT
+pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))  # full load
+```
+
+With an optional `pipeline_names` param:
+
+```python
+# kedro/inspection/snapshot.py — AFTER Piece 1c
+
+def _build_project_snapshot(
+    project_path: str | Path,
+    env: str | None = None,
+    pipeline_names: list[str] | None = None,  # NEW
+) -> ProjectSnapshot:
+    ...
+    if pipeline_names:
+        pipelines.set_requested(pipeline_names)
+
+    pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))
+    ...
+```
+
+---
+
+## 6. Step 2 — Lazy Dependency Resolution at Node Level
+
+Step 1 avoids loading unrelated pipelines. Step 2 goes further: even for the pipeline(s) being loaded, it avoids importing the actual function modules until execution time.
+
+This matters when pipeline definitions (`create_pipeline()`) import functions at the top of `pipeline.py`:
+
+```python
+# my_project/pipelines/data_science/pipeline.py
+from my_project.pipelines.data_science.nodes import (  # ← import at module load
+    split_data,
+    train_model,
+    evaluate_model,
+)
+
+def create_pipeline(**kwargs):
+    return pipeline([
+        node(split_data, ...),
+        node(train_model, ...),   # sklearn imported here
+        node(evaluate_model, ...) # sklearn imported here
+    ])
+```
+
+Importing this pipeline module imports `sklearn`, `torch`, etc. immediately.
+
+---
+
+### Piece 2a: Defer `inspect.signature()` to Execution Time
+
+**Goal:** Move `_validate_inputs()` out of `Node.__init__()` and into `Node.run()`.
+
+#### Current: eager validation at construction
+
+```python
+# kedro/pipeline/node.py:155 — CURRENT
+def __init__(self, func, inputs, outputs, ...):
+    ...
+    self._validate_inputs(func, inputs)  # ← runs immediately
+    self._func = func
+    ...
+
+def _validate_inputs(self, func, inputs):
+    if not inspect.isbuiltin(func):
+        args, kwargs = self._process_inputs_for_bind(inputs)
+        # ❌ Forces the module containing func to already be imported
+        inspect.signature(func, follow_wrapped=False).bind(*args, **kwargs)
+```
+
+#### After: deferred validation at first run
+
+```python
+# kedro/pipeline/node.py — AFTER Piece 2a
+
+def __init__(self, func, inputs, outputs, ...):
+    ...
+    # Store func and inputs without calling inspect.signature
+    self._func = func
+    self._inputs = inputs
+    self._inputs_validated = False  # NEW
+    ...
+    # Structural validations that don't need imports still run eagerly:
+    self._validate_unique_outputs()
+    self._validate_inputs_dif_than_outputs()
+
+def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+    # Validate on first execution — this is when the function's
+    # module is guaranteed to be loaded anyway
+    if not self._inputs_validated:
+        self._validate_inputs(self._func, self._inputs)
+        self._inputs_validated = True
+    ...
+```
+
+Alternatively, expose it as an explicit `validate()` method for use in contexts that want eager validation (e.g. `kedro run --dry-run`):
+
+```python
+def validate(self) -> None:
+    """Explicitly validate node inputs against the function signature.
+
+    Called automatically on first ``run()``. Can be called earlier for
+    eager validation, e.g. during a dry-run or test suite setup.
+    """
+    self._validate_inputs(self._func, self._inputs)
+    self._inputs_validated = True
+```
+
+#### What This Unlocks
+
+```mermaid
+flowchart TD
+    subgraph "Step 1 only — after Piece 1a/1b/1c"
+        A1["kedro run --pipeline data_science"] --> B1["Only data_science/pipeline.py imported"]
+        B1 --> C1["from data_science.nodes import train_model\n← sklearn imported HERE at module load"]
+        C1 --> D1["Node(train_model, ...) → inspect.signature()"]
+    end
+
+    subgraph "Step 1 + Step 2 — after Piece 2a"
+        A2["kedro run --pipeline data_science"] --> B2["Only data_science/pipeline.py imported"]
+        B2 --> C2["Node(train_model, ...) → NO inspect.signature() yet"]
+        C2 --> D2["node.run(inputs) → inspect.signature() called\nsklearn imported only NOW"]
+    end
+
+    style C1 fill:#ffa500,color:#fff
+    style D2 fill:#4caf50,color:#fff
+```
+
+**Note:** Step 2a alone doesn't remove the `from nodes import train_model` at the top of `pipeline.py`. The module is still imported at pipeline construction. The full benefit requires also lazy imports in pipeline definitions (user-side change) or Piece 2b.
+
+---
+
+### Piece 2b: String Function References in Node
+
+**Goal:** Accept `"mypackage.pipelines.data_science.nodes.train_model"` as the `func` argument, deferring both the import and signature inspection until execution.
+
+> This is the most impactful but also most disruptive change. It is a **potential breaking API change** and requires careful design.
+
+#### Proposed Design
+
+```python
+# kedro/pipeline/node.py — Piece 2b (future)
+
+class Node:
+    def __init__(self, func: Callable | str, inputs, outputs, ...):
+        if isinstance(func, str):
+            # Store as string — don't import yet
+            self._func_path = func
+            self._func: Callable | None = None
+        else:
+            self._func_path = None
+            self._func = func
+            self._validate_inputs(func, inputs)  # still eager for live callables
+
+    @property
+    def func(self) -> Callable:
+        """Resolve the function, importing its module on first access."""
+        if self._func is None:
+            module_path, func_name = self._func_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            self._func = getattr(module, func_name)
+        return self._func
+
+    def run(self, inputs):
+        # .func resolves the callable — imports the module here
+        result = self.func(...)
+```
+
+#### Usage in a Pipeline Definition
+
+```python
+# BEFORE — eager import
+from my_project.pipelines.data_science.nodes import train_model
+
+def create_pipeline(**kwargs):
+    return pipeline([
+        node(train_model, inputs="X_train", outputs="model"),
+    ])
+
+# AFTER — lazy via string reference
+def create_pipeline(**kwargs):
+    return pipeline([
+        node(
+            "my_project.pipelines.data_science.nodes.train_model",
+            inputs="X_train",
+            outputs="model",
+        ),
+    ])
+```
+
+#### Key Design Questions for Piece 2b
+
+| Question | Consideration |
+|----------|---------------|
+| Backwards compatibility | `node(func, ...)` with live callables must continue to work unchanged |
+| Error surfacing | Import errors for string paths surface at `node.run()` not at `Pipeline()` construction — need clear error messages |
+| `node.name` auto-derivation | Today derived from `func.__name__` — needs fallback for string paths |
+| IDE / type-checking support | String paths lose IDE navigation and refactoring support |
+| `kedro-viz` / inspection | Tools that introspect `node._func_name` must handle both forms |
+
+---
+
+## 7. CLI Command Benefit Matrix
+
+```mermaid
+block-beta
+    columns 5
+    CMD["CLI Command"] STEP1A["Piece 1a\nSelective Run"] STEP1B["Piece 1b\nName Discovery"] STEP1C["Piece 1c\nCLI Wiring"] STEP2A["Piece 2a\nLazy Signatures"]
+
+    R1["kedro run --pipeline X"] B1["✅ Only X loaded"] B2["-"] B3["-"] B4["✅ No sig check\nat build time"]
+    R2["kedro run (default)"] B5["-"] B6["-"] B7["-"] B8["✅ No sig check\nat build time"]
+    R3["kedro registry list"] B9["-"] B10["✅ Zero imports"] B11["-"] B12["-"]
+    R4["kedro registry describe X"] B13["✅ Only X loaded"] B14["-"] B15["✅ Wired"] B16["✅ No sig check\nat build time"]
+    R5["kedro catalog describe-datasets -p X"] B17["✅ Only X loaded"] B18["-"] B19["✅ Wired"] B20["✅ No sig check\nat build time"]
+    R6["kedro catalog resolve-patterns -p X"] B21["✅ Only X loaded"] B22["-"] B23["✅ Wired"] B24["✅ No sig check\nat build time"]
+    R7["inspection: get_project_snapshot(pipelines=[X])"] B25["✅ Only X loaded"] B26["-"] B27["✅ Wired"] B28["✅ No sig check\nat build time"]
+```
+
+| CLI Command | Today | After Step 1 | After Step 1+2 |
+|-------------|-------|-------------|----------------|
+| `kedro run --pipeline data_science` | All 4 pipelines + all node functions imported | Only `data_science` module imported | `data_science` module imported; function modules deferred to run |
+| `kedro run --pipelines X,Y` | All pipelines imported | Only X and Y imported | X and Y imported; function modules deferred |
+| `kedro run` (default) | All pipelines imported | All pipelines imported (unchanged) | All pipelines imported; function modules deferred |
+| `kedro registry list` | All Pipeline objects + Node objects created | Directory scan only — zero imports | Same as Step 1 |
+| `kedro registry describe X` | All pipelines imported | Only X imported | Only X imported; no sig check at build |
+| `kedro catalog describe-datasets -p X` | All pipelines imported | Only X imported | Only X; function modules deferred |
+| `kedro catalog resolve-patterns -p X` | All pipelines imported | Only X imported | Only X; function modules deferred |
+| `get_project_snapshot(pipeline_names=["X"])` | All pipelines imported | Only X imported | Only X; function modules deferred |
+
+---
+
+## 8. Implementation Roadmap
+
+```mermaid
+gantt
+    title On-Demand Dependency Loading — Implementation Phases
+    dateFormat  YYYY-MM-DD
+    section Step 1 — Pipeline Level
+    Piece 1a: Wire selective loading (run path)     :p1a, 2026-04-20, 5d
+    Piece 1b: Lightweight name discovery            :p1b, after p1a, 3d
+    Piece 1c: Wire remaining CLI commands           :p1c, after p1b, 4d
+    section Step 2 — Function Level
+    Piece 2a: Defer inspect.signature() to run()   :p2a, after p1c, 5d
+    Piece 2b: String function references (future)  :p2b, after p2a, 10d
+```
+
+### Piece Dependency Graph
+
+```mermaid
+flowchart LR
+    P1a["Piece 1a\nWire selective loading\nthrough run path\n(KedroSession + _ProjectPipelines)"]
+    P1b["Piece 1b\nLightweight pipeline\nname discovery\n(list_names() method)"]
+    P1c["Piece 1c\nWire CLI commands\n(catalog, registry, inspection)"]
+    P2a["Piece 2a\nDefer inspect.signature()\nin Node.__init__"]
+    P2b["Piece 2b\nString function references\nin Node (future)"]
+
+    P1a --> P1c
+    P1b --> P1c
+    P1a --> P2a
+    P2a --> P2b
+
+    style P1a fill:#4caf50,color:#fff
+    style P1b fill:#4caf50,color:#fff
+    style P1c fill:#2196f3,color:#fff
+    style P2a fill:#2196f3,color:#fff
+    style P2b fill:#9c27b0,color:#fff
+```
+
+### Risk Assessment
+
+| Piece | Risk | Mitigation |
+|-------|------|-----------|
+| **1a** — Selective loading via run path | Low — activates already-existing `find_pipelines(pipelines_to_find=...)` | `TypeError` fallback for custom `register_pipelines` that doesn't accept kwargs |
+| **1b** — Lightweight name discovery | Low — purely additive new method | Falls back to full load for non-standard layouts |
+| **1c** — Wire CLI commands | Low — single line additions | No logic change, just earlier hint-setting |
+| **2a** — Defer signature inspection | Medium — changes when `TypeError` is raised (at run, not at pipeline construction) | Expose explicit `node.validate()` for test suites and dry-runs |
+| **2b** — String function references | High — API change, affects IDE tooling, kedro-viz | Gate behind feature flag; maintain full backwards compatibility |
+
+### What Stays Unchanged
+
+- `register_pipelines()` signature in user projects (kwargs are optional)
+- `find_pipelines()` public API
+- `node(func, ...)` with live callables (Piece 2a defers but doesn't remove validation)
+- All existing tests — the filtering is strictly additive

--- a/docs/on_demand_dependency_loading.md
+++ b/docs/on_demand_dependency_loading.md
@@ -1,26 +1,8 @@
 # On-Demand Project Dependency Loading
 
 **Spike:** [#5406](https://github.com/kedro-org/kedro/issues/5406)
-**Branch:** `spike/dep_free`
+
 **Goal:** Eliminate unnecessary pipeline dependency imports across CLI commands, targeted runs, and inspection workflows.
-
----
-
-## Table of Contents
-
-1. [Problem Statement](#1-problem-statement)
-2. [Current Architecture](#2-current-architecture)
-3. [Root Cause Analysis](#3-root-cause-analysis)
-4. [The Two-Step Strategy](#4-the-two-step-strategy)
-5. [Step 1 — Load Only Required Pipelines](#5-step-1--load-only-required-pipelines)
-   - [Piece 1a: Wire Selective Loading Through the Run Path](#piece-1a-wire-selective-loading-through-the-run-path)
-   - [Piece 1b: Lightweight Pipeline Name Discovery](#piece-1b-lightweight-pipeline-name-discovery)
-   - [Piece 1c: Wire Other CLI Commands to Declare Their Needs](#piece-1c-wire-other-cli-commands-to-declare-their-needs)
-6. [Step 2 — Lazy Dependency Resolution at Node Level](#6-step-2--lazy-dependency-resolution-at-node-level)
-   - [Piece 2a: Defer `inspect.signature()` to Execution Time](#piece-2a-defer-inspectsignature-to-execution-time)
-   - [Piece 2b: String Function References in Node](#piece-2b-string-function-references-in-node)
-7. [CLI Command Benefit Matrix](#7-cli-command-benefit-matrix)
-8. [Implementation Roadmap](#8-implementation-roadmap)
 
 ---
 
@@ -51,51 +33,35 @@ This command today imports and instantiates **every** pipeline in the project, i
 ### How a `kedro run` Triggers Full Dependency Loading Today
 
 ```mermaid
-sequenceDiagram
-    participant CLI as kedro run --pipeline data_science
-    participant Session as KedroSession.run()
-    participant Pipelines as _ProjectPipelines
-    participant LoadData as _load_data()
-    participant Registry as register_pipelines()
-    participant Find as find_pipelines()
-    participant Modules as All Pipeline Modules
-
-    CLI->>Session: session.run(pipeline_names=["data_science"])
-    Session->>Pipelines: pipelines["data_science"]  ← triggers _load_data_wrapper
-    Pipelines->>LoadData: _load_data()
-    LoadData->>Registry: register_pipelines()  ← NO filter passed
-    Registry->>Find: find_pipelines()  ← NO pipelines_to_find
-    Find->>Modules: import data_engineering.pipeline
-    Find->>Modules: import feature_engineering.pipeline
-    Find->>Modules: import data_science.pipeline  ← actually needed
-    Find->>Modules: import reporting.pipeline
-    Modules-->>Find: All Nodes created + inspect.signature() called on EVERY function
-    Find-->>Registry: {all 4 pipelines}
-    Registry-->>LoadData: {all 4 pipelines}
-    LoadData-->>Pipelines: _content = {all 4 pipelines}
-    Pipelines-->>Session: returns data_science pipeline
-    Session->>Session: Pipeline.filter()  ← filtering AFTER full load
-```
-
-### Pipeline Loading Call Stack
-
-```mermaid
 flowchart TD
-    A["CLI: kedro run / registry list / catalog describe"] --> B["bootstrap_project()\nconfigure_project(package_name)"]
-    B --> C["pipelines.configure(pipelines_module)\n_is_data_loaded = False"]
-    C --> D["First dict access:\npipelines[name] / iter(pipelines) / len(pipelines)"]
-    D --> E["_load_data_wrapper → _load_data()"]
-    E --> F["register_pipelines()\n← user-defined or default"]
-    F --> G["find_pipelines()\n← pipelines_to_find=None today"]
-    G --> H["importlib.import_module()\nfor EVERY pipeline directory"]
-    H --> I["_create_pipeline(module)\n→ Pipeline([node(...), ...])"]
-    I --> J["Node.__init__(func, inputs, outputs)\n→ _validate_inputs(func, inputs)"]
-    J --> K["inspect.signature(func).bind(...)\n← imports func's module here"]
+    A["CLI\nkedro run --pipeline data_science"]
+    B["KedroSession.run()\npipeline_names=['data_science']"]
+    C["_ProjectPipelines\npipelines['data_science']"]
+    D["_load_data()\nregister_pipelines()  ← no filter passed"]
+    E["find_pipelines()\npipelines_to_find=None"]
 
-    style K fill:#ff6b6b,color:#fff
-    style G fill:#ffa500,color:#fff
-    style H fill:#ffa500,color:#fff
+    F1["import data_engineering.pipeline\n+ all its deps"]
+    F2["import feature_engineering.pipeline\n+ all its deps"]
+    F3["import data_science.pipeline\n← the only one needed"]
+    F4["import reporting.pipeline\n+ all its deps"]
+
+    G["Node.__init__() for every node\ninspect.signature(func) on every function"]
+    H["return data_science pipeline\n— after loading everything else"]
+
+    A --> B --> C --> D --> E
+    E --> F1 & F2 & F3 & F4
+    F1 & F2 & F3 & F4 --> G
+    G --> H
+
+    style F1 fill:#ff6b6b,color:#fff
+    style F2 fill:#ff6b6b,color:#fff
+    style F4 fill:#ff6b6b,color:#fff
+    style G fill:#ff6b6b,color:#fff
+    style F3 fill:#4caf50,color:#fff
+    style E fill:#ffa500,color:#fff
 ```
+
+**Key problem:** `find_pipelines()` receives no filter, so it imports every pipeline directory and calls `inspect.signature()` on every node function — even though only `data_science` was requested. The unused pipelines (red) are fully loaded before the result is returned.
 
 ---
 
@@ -165,49 +131,21 @@ flowchart LR
 
 ---
 
-## 4. The Two-Step Strategy
+## 4. Solutions
 
-```mermaid
-flowchart TD
-    P["Problem: All pipelines load on every CLI command"]
-
-    P --> S1["Step 1: Load Only Required Pipelines\n(Pipeline-level granularity)"]
-    P --> S2["Step 2: Lazy Dependency Resolution\n(Function-level granularity)"]
-
-    S1 --> P1a["Piece 1a\nWire selective loading\nthrough the run path"]
-    S1 --> P1b["Piece 1b\nLightweight pipeline\nname discovery"]
-    S1 --> P1c["Piece 1c\nWire CLI commands\nto declare their needs"]
-
-    S2 --> P2a["Piece 2a\nDefer inspect.signature()\nto execution time"]
-    S2 --> P2b["Piece 2b\nString function references\nin Node (future)"]
-
-    style P1a fill:#4caf50,color:#fff
-    style P1b fill:#4caf50,color:#fff
-    style P1c fill:#2196f3,color:#fff
-    style P2a fill:#2196f3,color:#fff
-    style P2b fill:#9c27b0,color:#fff
-```
-
-**Step 1** eliminates the need to import unrelated pipeline *modules* entirely.
-**Step 2** eliminates the need to import a function's *module* at pipeline definition time.
-
-Both steps are independent and additive — Step 1 gives the biggest wins with least risk, Step 2 unlocks further gains.
+The gap diagram above identifies two independent problems. Each has its own fix, and both can be shipped and applied without the other.
 
 ---
 
-## 5. Step 1 — Load Only Required Pipelines
+### Gap 1 — Wire the filter through `_load_data()`
 
-### Piece 1a: Wire Selective Loading Through the Run Path
+**Problem recap:** `_load_data()` calls `register_pipelines()` with no filter, so `find_pipelines()` imports every pipeline directory even when only one is needed. The `find_pipelines(pipelines_to_find=...)` parameter already exists but is never passed in.
 
-**Goal:** Activate the already-existing `find_pipelines(pipelines_to_find=...)` parameter from end to end.
+**Fix:** Add `set_requested()` to `_ProjectPipelines` so callers can declare which pipelines they need before the first dict access. `_load_data()` then forwards those names to `register_pipelines()` as the `pipelines_to_find` kwarg.
 
-**What changes:**
-
-#### 1. Add `set_requested()` to `_ProjectPipelines`
+#### a. Add `set_requested()` and update `_load_data()` — `kedro/framework/project/__init__.py`
 
 ```python
-# kedro/framework/project/__init__.py
-
 class _ProjectPipelines(MutableMapping):
     def __init__(self) -> None:
         self._pipelines_module: str | None = None
@@ -233,11 +171,9 @@ class _ProjectPipelines(MutableMapping):
         register_pipelines = self._get_pipelines_registry_callable(
             self._pipelines_module
         )
-        # Pass the hint as an optional kwarg — default register_pipelines
-        # forwards it to find_pipelines(); custom ones can ignore it safely.
         try:
             project_pipelines = register_pipelines(
-                pipelines_to_find=self._requested_pipelines
+                pipelines_to_find=self._requested_pipelines  # NEW — pass the filter
             )
         except TypeError:
             # Fallback: custom register_pipelines doesn't accept kwargs
@@ -247,381 +183,165 @@ class _ProjectPipelines(MutableMapping):
         self._is_data_loaded = True
 ```
 
-#### 2. Wire `KedroSession.run()` to set the hint before pipeline access
+#### b. Wire `KedroSession.run()` to call `set_requested()` before any dict access — `kedro/framework/session/session.py`
 
 ```python
-# kedro/framework/session/session.py
-
 def run(self, pipeline_names: list[str] | None = None, ...) -> dict[str, Any]:
     ...
     names = pipeline_names or ["__default__"]
 
-    # NEW: inform the pipeline registry which pipelines are needed
-    # before the first dict access so _load_data() can filter selectively
-    pipelines.set_requested(names)
+    pipelines.set_requested(names)  # NEW — must happen before pipelines[name]
 
     combined_pipelines = Pipeline([])
     for name in names:
-        try:
-            combined_pipelines += pipelines[name]  # only loads requested ones
-        except KeyError as exc:
-            ...
+        combined_pipelines += pipelines[name]  # only loads requested ones
 ```
 
-#### Before / After Flow
+With these two changes, `kedro run --pipeline data_science` imports only `data_science/pipeline.py` — `data_engineering`, `feature_engineering`, and `reporting` are never touched.
 
-```mermaid
-sequenceDiagram
-    participant CLI as kedro run --pipeline data_science
-    participant Session as KedroSession.run()
-    participant Pipelines as _ProjectPipelines
-    participant Find as find_pipelines()
-    participant Modules as Pipeline Modules
+#### c. Wire CLI commands that take `--pipeline` to call `set_requested()`
 
-    Note over CLI,Modules: AFTER Piece 1a
+Every CLI command that accepts a `--pipeline` argument should call `set_requested()` before any pipeline access, so `_load_data()` has the filter ready. `kedro registry list` is special — it only needs names, so it gets a zero-import `list_names()` method instead.
 
-    CLI->>Session: session.run(pipeline_names=["data_science"])
-    Session->>Pipelines: pipelines.set_requested(["data_science"])  ← NEW
-    Session->>Pipelines: pipelines["data_science"]
-    Pipelines->>Find: find_pipelines(pipelines_to_find=["data_science"])
-    Find->>Modules: import data_science.pipeline  ← ONLY this one
-    Find-->>Pipelines: {"data_science": <Pipeline>}
-    Pipelines-->>Session: data_science Pipeline object
-```
+| Command | Change | Result |
+|---------|--------|--------|
+| `kedro run --pipeline X` | `set_requested()` called inside `KedroSession.run()` (section b above) | Only X loaded |
+| `kedro catalog describe-datasets -p X` | `set_requested(["X"])` before session creation | Only X loaded |
+| `kedro catalog resolve-patterns -p X` | `set_requested(["X"])` before session creation | Only X loaded |
+| `kedro registry describe X` | `set_requested(["X"])` before `pipelines.get(name)` | Only X loaded |
+| `kedro registry list` | Use new `list_names()` — directory scan, no imports | Zero imports |
+| `inspection: get_project_snapshot(pipeline_names=["X"])` | `set_requested(["X"])` before pipeline dict access | Only X loaded |
+| `kedro info`, `kedro package`, `kedro catalog list-patterns` | No change needed — never access `pipelines` | Unchanged |
 
-**Impact:**
-- `kedro run --pipeline data_science` imports only `data_science` module → unrelated packages (e.g. `torch`, `sklearn`) never imported
-- Zero changes to the existing `find_pipelines()` implementation
-- Fully backwards-compatible: custom `register_pipelines` that ignores kwargs works unchanged
-
----
-
-### Piece 1b: Lightweight Pipeline Name Discovery
-
-**Goal:** Let `kedro registry list` return pipeline names without importing any pipeline module.
-
-Today `registry list` triggers a full pipeline load:
+The pattern is identical for every command that takes `--pipeline`. Using `kedro catalog describe-datasets` as the representative example:
 
 ```python
-# kedro/framework/cli/registry.py:26
-click.echo(yaml.dump(sorted(pipelines)))  # iterating triggers _load_data()
+# kedro/framework/cli/catalog.py — BEFORE
+def describe_datasets(metadata, pipeline, env):
+    session = _create_session(metadata.package_name, env=env)
+    datasets_dict = context.catalog.describe_datasets(pipeline or None)
+    secho(yaml.dump(datasets_dict))
+
+# kedro/framework/cli/catalog.py — AFTER
+def describe_datasets(metadata, pipeline, env):
+    if pipeline:
+        from kedro.framework.project import pipelines as _pipelines
+        _pipelines.set_requested(pipeline)  # one line before session creation
+    session = _create_session(metadata.package_name, env=env)
+    datasets_dict = context.catalog.describe_datasets(pipeline or None)
+    secho(yaml.dump(datasets_dict))
 ```
 
-This constructs every `Pipeline` object, instantiates every `Node`, and calls `inspect.signature()` on every node function — just to print a list of names.
-
-**Proposed addition to `_ProjectPipelines`:**
+`kedro registry list` uses `list_names()` instead — a pure filesystem scan with zero imports
 
 ```python
 # kedro/framework/project/__init__.py
 
 def list_names(self) -> list[str]:
-    """Return pipeline names from directory structure without importing modules.
+    """Return pipeline names by scanning the filesystem — no imports."""
+    spec = importlib.util.find_spec(PACKAGE_NAME)
+    if spec is None or spec.origin is None:
+        return list(self.keys())  # fallback to full load
 
-    For projects using the default modular layout, this scans the pipelines
-    package directory and returns folder names — no imports, no Node objects.
-    Falls back to full load if the project uses a custom layout.
-    """
-    if PACKAGE_NAME is None:
-        return []
+    pipelines_path = Path(spec.origin).parent / "pipelines"
+    if not pipelines_path.is_dir():
+        return list(self.keys())  # non-standard layout — fallback
 
-    try:
-        pipelines_package = importlib.resources.files(
-            f"{PACKAGE_NAME}.pipelines"
-        )
-    except ModuleNotFoundError:
-        # Non-standard layout — fall back to full load
-        return list(self.keys())
-
-    names = []
-    for entry in pipelines_package.iterdir():
-        if (
-            entry.is_dir()
-            and not entry.name.startswith(".")
-            and entry.name != "__pycache__"
-        ):
-            names.append(entry.name)
-
-    # Always include __default__ as it's implicitly registered
+    names = [
+        d.name for d in pipelines_path.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and d.name != "__pycache__"
+    ]
     return sorted(["__default__", *names])
 ```
 
-**Updated `registry list` command:**
-
 ```python
-# kedro/framework/cli/registry.py
-
+# kedro/framework/cli/registry.py — AFTER
 @registry.command("list")
 def list_registered_pipelines() -> None:
-    """List all pipelines defined in your pipeline_registry.py file."""
-    # Use lightweight name discovery — no pipeline modules imported
-    click.echo(yaml.dump(pipelines.list_names()))
+    click.echo(yaml.dump(pipelines.list_names()))  # zero imports
 ```
 
-**`registry describe` still needs the full pipeline** (it shows node names and functions), so it keeps using `pipelines.get(name)` — but with Piece 1a wired, it will only load the one requested pipeline:
-
-```python
-@registry.command("describe")
-@click.argument("name", default="__default__")
-def describe_registered_pipeline(metadata, name, **kwargs):
-    pipelines.set_requested([name])   # NEW — only load what's described
-    pipeline_obj = pipelines.get(name)
-    ...
-```
-
-#### Comparison
-
-```mermaid
-flowchart LR
-    subgraph "Today: kedro registry list"
-        A1["Scan pipelines/ dir"] --> B1["import data_engineering"]
-        A1 --> B2["import feature_engineering"]
-        A1 --> B3["import data_science"]
-        A1 --> B4["import reporting"]
-        B1 & B2 & B3 & B4 --> C1["Build all Pipeline objects\nand all Node objects"]
-        C1 --> D1["Return sorted names"]
-    end
-
-    subgraph "After Piece 1b: kedro registry list"
-        A2["Scan pipelines/ dir names\nNo imports"] --> D2["Return sorted names"]
-    end
-
-    style C1 fill:#ff6b6b,color:#fff
-    style A2 fill:#4caf50,color:#fff
-    style D2 fill:#4caf50,color:#fff
-```
+> **Limitation — custom `register_pipelines` that constructs all pipelines unconditionally**
+>
+> This fix only delivers selective loading for projects using the default `find_pipelines()` layout. Projects with a hand-written `register_pipelines` that eagerly constructs every pipeline at the top of the function receive no benefit:
+>
+> ```python
+> def register_pipelines() -> Dict[str, Pipeline]:
+>     ingestion_pipeline = di.create_pipeline()    # ← imports di + all its deps
+>     feature_pipeline   = fe.create_pipeline()    # ← imports fe + all its deps
+>     modelling_pipeline = mod.create_pipeline()   # ← imports sklearn etc.
+>     reporting_pipeline = rep.create_pipeline()   # ← imports matplotlib etc.
+>     return {"data_ingestion": ingestion_pipeline, ...}
+> ```
+>
+> Two reasons it fails for this pattern:
+> 1. The function doesn't accept `pipelines_to_find`, so `_load_data()` hits `TypeError` and falls back to `register_pipelines()` with no filter — same behaviour as today.
+> 2. Even if the kwarg were accepted, all pipeline modules are already imported unconditionally before any filter could be applied.
+>
+> **Options for affected projects:**
+> - Switch to the default `find_pipelines()` layout (recommended for new projects).
+> - Rely on the Gap 2 fix (lazy `inspect.signature` / string node references), which defers function-module imports regardless of how `register_pipelines` is structured.
 
 ---
 
-### Piece 1c: Wire Other CLI Commands to Declare Their Needs
+### Gap 2 — Defer `inspect.signature()` to execution time
 
-**Goal:** Every CLI command that takes a `--pipeline` argument should set the filter on `pipelines` before the first access, so only relevant pipeline modules are imported.
+**Problem recap:** `Node.__init__()` calls `_validate_inputs()` immediately, which calls `inspect.signature(func)`. This forces the module containing `func` to be fully imported at pipeline construction time — even when running a completely different pipeline or just listing pipeline names.
 
-#### `kedro catalog describe-datasets --pipeline reporting`
+**Fix:** Move signature validation out of `__init__()` and into `run()`, where the function's module is guaranteed to already be loaded.
 
-Today this loads all pipelines to resolve dataset information for one pipeline.
-
-```python
-# kedro/framework/cli/catalog.py — CURRENT
-def describe_datasets(metadata, pipeline, env):
-    session = _create_session(metadata.package_name, env=env)
-    context = session.load_context()
-    p = pipeline or None
-    datasets_dict = context.catalog.describe_datasets(p)  # pipelines accessed inside
-    secho(yaml.dump(datasets_dict))
-```
-
-The fix is a single line before session creation:
+#### a. Defer `_validate_inputs()` to `Node.run()` — `kedro/pipeline/node.py`
 
 ```python
-# kedro/framework/cli/catalog.py — AFTER Piece 1c
-def describe_datasets(metadata, pipeline, env):
-    if pipeline:
-        from kedro.framework.project import pipelines as _pipelines
-        _pipelines.set_requested(pipeline)  # pipeline is already a list via split_string
-
-    session = _create_session(metadata.package_name, env=env)
-    context = session.load_context()
-    p = pipeline or None
-    datasets_dict = context.catalog.describe_datasets(p)
-    secho(yaml.dump(datasets_dict))
-```
-
-#### `kedro catalog resolve-patterns --pipeline X`
-
-Same pattern:
-
-```python
-def resolve_patterns(metadata, pipeline, env):
-    if pipeline:
-        from kedro.framework.project import pipelines as _pipelines
-        _pipelines.set_requested(pipeline)
-
-    session = _create_session(metadata.package_name, env=env)
-    ...
-```
-
-#### Commands That Need No Pipelines At All
-
-| Command | Needs Pipelines? | Action |
-|---------|-----------------|--------|
-| `kedro info` | No | No change needed — never accesses `pipelines` |
-| `kedro package` | No | No change needed |
-| `kedro catalog list-patterns` | No | No change needed |
-| `kedro pipeline list` / `kedro pipeline pull` | Discovery only | Use `list_names()` from Piece 1b |
-
-#### Commands That Need Specific Pipelines
-
-| Command | Filter | Implementation |
-|---------|--------|----------------|
-| `kedro run --pipeline X` | `["X"]` | Piece 1a (`session.run` wires it) |
-| `kedro run --pipelines X,Y` | `["X", "Y"]` | Piece 1a (`session.run` wires it) |
-| `kedro registry describe X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
-| `kedro catalog describe-datasets -p X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
-| `kedro catalog resolve-patterns -p X` | `["X"]` | `pipelines.set_requested(["X"])` before access |
-
-#### Commands That Need All Pipelines
-
-| Command | Reason | Notes |
-|---------|--------|-------|
-| `kedro run` (no `--pipeline`) | Runs `__default__` which merges all | Full load required |
-| `kedro registry list` | Lists all names | Use `list_names()` for names only |
-| Inspection API `get_project_snapshot()` | Full project snapshot | See below |
-
-#### Inspection API Fix
-
-The inspection API currently loads all pipelines without any filter:
-
-```python
-# kedro/inspection/snapshot.py:136 — CURRENT
-pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))  # full load
-```
-
-With an optional `pipeline_names` param:
-
-```python
-# kedro/inspection/snapshot.py — AFTER Piece 1c
-
-def _build_project_snapshot(
-    project_path: str | Path,
-    env: str | None = None,
-    pipeline_names: list[str] | None = None,  # NEW
-) -> ProjectSnapshot:
-    ...
-    if pipeline_names:
-        pipelines.set_requested(pipeline_names)
-
-    pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))
-    ...
-```
-
----
-
-## 6. Step 2 — Lazy Dependency Resolution at Node Level
-
-Step 1 avoids loading unrelated pipelines. Step 2 goes further: even for the pipeline(s) being loaded, it avoids importing the actual function modules until execution time.
-
-This matters when pipeline definitions (`create_pipeline()`) import functions at the top of `pipeline.py`:
-
-```python
-# my_project/pipelines/data_science/pipeline.py
-from my_project.pipelines.data_science.nodes import (  # ← import at module load
-    split_data,
-    train_model,
-    evaluate_model,
-)
-
-def create_pipeline(**kwargs):
-    return pipeline([
-        node(split_data, ...),
-        node(train_model, ...),   # sklearn imported here
-        node(evaluate_model, ...) # sklearn imported here
-    ])
-```
-
-Importing this pipeline module imports `sklearn`, `torch`, etc. immediately.
-
----
-
-### Piece 2a: Defer `inspect.signature()` to Execution Time
-
-**Goal:** Move `_validate_inputs()` out of `Node.__init__()` and into `Node.run()`.
-
-#### Current: eager validation at construction
-
-```python
-# kedro/pipeline/node.py:155 — CURRENT
+# BEFORE — eager validation at construction
 def __init__(self, func, inputs, outputs, ...):
     ...
-    self._validate_inputs(func, inputs)  # ← runs immediately
+    self._validate_inputs(func, inputs)  # ← runs immediately, imports func's module
     self._func = func
-    ...
 
-def _validate_inputs(self, func, inputs):
-    if not inspect.isbuiltin(func):
-        args, kwargs = self._process_inputs_for_bind(inputs)
-        # ❌ Forces the module containing func to already be imported
-        inspect.signature(func, follow_wrapped=False).bind(*args, **kwargs)
-```
-
-#### After: deferred validation at first run
-
-```python
-# kedro/pipeline/node.py — AFTER Piece 2a
-
+# AFTER — deferred validation at first run
 def __init__(self, func, inputs, outputs, ...):
     ...
-    # Store func and inputs without calling inspect.signature
     self._func = func
     self._inputs = inputs
     self._inputs_validated = False  # NEW
-    ...
-    # Structural validations that don't need imports still run eagerly:
+    # Structural checks that don't need imports still run eagerly:
     self._validate_unique_outputs()
     self._validate_inputs_dif_than_outputs()
 
 def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
-    # Validate on first execution — this is when the function's
-    # module is guaranteed to be loaded anyway
     if not self._inputs_validated:
-        self._validate_inputs(self._func, self._inputs)
+        self._validate_inputs(self._func, self._inputs)  # func's module loaded by now
         self._inputs_validated = True
     ...
 ```
 
-Alternatively, expose it as an explicit `validate()` method for use in contexts that want eager validation (e.g. `kedro run --dry-run`):
+For contexts that want eager validation (e.g. `kedro run --dry-run` or test suites), expose an explicit method:
 
 ```python
 def validate(self) -> None:
-    """Explicitly validate node inputs against the function signature.
+    """Validate node inputs against the function signature.
 
-    Called automatically on first ``run()``. Can be called earlier for
+    Called automatically on first run(). Can be called earlier for
     eager validation, e.g. during a dry-run or test suite setup.
     """
     self._validate_inputs(self._func, self._inputs)
     self._inputs_validated = True
 ```
 
-#### What This Unlocks
+#### b. String function references in `Node` (future)
 
-```mermaid
-flowchart TD
-    subgraph "Step 1 only — after Piece 1a/1b/1c"
-        A1["kedro run --pipeline data_science"] --> B1["Only data_science/pipeline.py imported"]
-        B1 --> C1["from data_science.nodes import train_model\n← sklearn imported HERE at module load"]
-        C1 --> D1["Node(train_model, ...) → inspect.signature()"]
-    end
-
-    subgraph "Step 1 + Step 2 — after Piece 2a"
-        A2["kedro run --pipeline data_science"] --> B2["Only data_science/pipeline.py imported"]
-        B2 --> C2["Node(train_model, ...) → NO inspect.signature() yet"]
-        C2 --> D2["node.run(inputs) → inspect.signature() called\nsklearn imported only NOW"]
-    end
-
-    style C1 fill:#ffa500,color:#fff
-    style D2 fill:#4caf50,color:#fff
-```
-
-**Note:** Step 2a alone doesn't remove the `from nodes import train_model` at the top of `pipeline.py`. The module is still imported at pipeline construction. The full benefit requires also lazy imports in pipeline definitions (user-side change) or Piece 2b.
-
----
-
-### Piece 2b: String Function References in Node
-
-**Goal:** Accept `"mypackage.pipelines.data_science.nodes.train_model"` as the `func` argument, deferring both the import and signature inspection until execution.
-
-> This is the most impactful but also most disruptive change. It is a **potential breaking API change** and requires careful design.
-
-#### Proposed Design
+Accept a dotted string path as `func`, deferring both the import and signature inspection until execution:
 
 ```python
-# kedro/pipeline/node.py — Piece 2b (future)
+# kedro/pipeline/node.py — future
 
 class Node:
     def __init__(self, func: Callable | str, inputs, outputs, ...):
         if isinstance(func, str):
-            # Store as string — don't import yet
             self._func_path = func
             self._func: Callable | None = None
+            # No import, no inspect.signature — deferred entirely
         else:
             self._func_path = None
             self._func = func
@@ -637,123 +357,37 @@ class Node:
         return self._func
 
     def run(self, inputs):
-        # .func resolves the callable — imports the module here
-        result = self.func(...)
+        result = self.func(...)  # .func resolves + imports here
 ```
 
-#### Usage in a Pipeline Definition
+Usage:
 
 ```python
-# BEFORE — eager import
+# BEFORE — eager import at module load
 from my_project.pipelines.data_science.nodes import train_model
 
 def create_pipeline(**kwargs):
-    return pipeline([
-        node(train_model, inputs="X_train", outputs="model"),
-    ])
+    return pipeline([node(train_model, inputs="X_train", outputs="model")])
 
-# AFTER — lazy via string reference
+# AFTER — deferred via string reference
 def create_pipeline(**kwargs):
     return pipeline([
         node(
             "my_project.pipelines.data_science.nodes.train_model",
             inputs="X_train",
             outputs="model",
-        ),
+        )
     ])
 ```
 
-#### Key Design Questions for Piece 2b
+> This is a **potential breaking API change**. Key design questions: backwards compatibility with live callables (must be unchanged), error surfacing (import errors surface at `node.run()` not at `Pipeline()` construction — needs clear messages), `node.name` auto-derivation (today from `func.__name__`, needs a fallback), IDE/type-checking support (string paths lose navigation), and `kedro-viz`/inspection tool compatibility.
 
-| Question | Consideration |
-|----------|---------------|
-| Backwards compatibility | `node(func, ...)` with live callables must continue to work unchanged |
-| Error surfacing | Import errors for string paths surface at `node.run()` not at `Pipeline()` construction — need clear error messages |
-| `node.name` auto-derivation | Today derived from `func.__name__` — needs fallback for string paths |
-| IDE / type-checking support | String paths lose IDE navigation and refactoring support |
-| `kedro-viz` / inspection | Tools that introspect `node._func_name` must handle both forms |
+**What each fix defers:**
 
----
+| Fix applied | `kedro run --pipeline X` | Non-run commands (e.g. `registry describe X`) |
+|-------------|--------------------------|-----------------------------------------------|
+| Gap 1 only | Only X's `pipeline.py` loaded; X's deps (e.g. `sklearn`) still import at construction | Same — only X's deps needed; other pipelines' deps not required |
+| Gap 1 + Gap 2a | Only X's `pipeline.py` loaded; X's deps still import at construction; `inspect.signature()` deferred to `node.run()` | Only X's deps needed; `inspect.signature()` **never runs at all** (nodes are never executed) |
+| Gap 1 + Gap 2a + Gap 2b | Nothing loads until `node.run()` — X's deps deferred to execution | X's deps never load for commands that don't execute nodes |
 
-## 7. CLI Command Benefit Matrix
-
-```mermaid
-block-beta
-    columns 5
-    CMD["CLI Command"] STEP1A["Piece 1a\nSelective Run"] STEP1B["Piece 1b\nName Discovery"] STEP1C["Piece 1c\nCLI Wiring"] STEP2A["Piece 2a\nLazy Signatures"]
-
-    R1["kedro run --pipeline X"] B1["✅ Only X loaded"] B2["-"] B3["-"] B4["✅ No sig check\nat build time"]
-    R2["kedro run (default)"] B5["-"] B6["-"] B7["-"] B8["✅ No sig check\nat build time"]
-    R3["kedro registry list"] B9["-"] B10["✅ Zero imports"] B11["-"] B12["-"]
-    R4["kedro registry describe X"] B13["✅ Only X loaded"] B14["-"] B15["✅ Wired"] B16["✅ No sig check\nat build time"]
-    R5["kedro catalog describe-datasets -p X"] B17["✅ Only X loaded"] B18["-"] B19["✅ Wired"] B20["✅ No sig check\nat build time"]
-    R6["kedro catalog resolve-patterns -p X"] B21["✅ Only X loaded"] B22["-"] B23["✅ Wired"] B24["✅ No sig check\nat build time"]
-    R7["inspection: get_project_snapshot(pipelines=[X])"] B25["✅ Only X loaded"] B26["-"] B27["✅ Wired"] B28["✅ No sig check\nat build time"]
-```
-
-| CLI Command | Today | After Step 1 | After Step 1+2 |
-|-------------|-------|-------------|----------------|
-| `kedro run --pipeline data_science` | All 4 pipelines + all node functions imported | Only `data_science` module imported | `data_science` module imported; function modules deferred to run |
-| `kedro run --pipelines X,Y` | All pipelines imported | Only X and Y imported | X and Y imported; function modules deferred |
-| `kedro run` (default) | All pipelines imported | All pipelines imported (unchanged) | All pipelines imported; function modules deferred |
-| `kedro registry list` | All Pipeline objects + Node objects created | Directory scan only — zero imports | Same as Step 1 |
-| `kedro registry describe X` | All pipelines imported | Only X imported | Only X imported; no sig check at build |
-| `kedro catalog describe-datasets -p X` | All pipelines imported | Only X imported | Only X; function modules deferred |
-| `kedro catalog resolve-patterns -p X` | All pipelines imported | Only X imported | Only X; function modules deferred |
-| `get_project_snapshot(pipeline_names=["X"])` | All pipelines imported | Only X imported | Only X; function modules deferred |
-
----
-
-## 8. Implementation Roadmap
-
-```mermaid
-gantt
-    title On-Demand Dependency Loading — Implementation Phases
-    dateFormat  YYYY-MM-DD
-    section Step 1 — Pipeline Level
-    Piece 1a: Wire selective loading (run path)     :p1a, 2026-04-20, 5d
-    Piece 1b: Lightweight name discovery            :p1b, after p1a, 3d
-    Piece 1c: Wire remaining CLI commands           :p1c, after p1b, 4d
-    section Step 2 — Function Level
-    Piece 2a: Defer inspect.signature() to run()   :p2a, after p1c, 5d
-    Piece 2b: String function references (future)  :p2b, after p2a, 10d
-```
-
-### Piece Dependency Graph
-
-```mermaid
-flowchart LR
-    P1a["Piece 1a\nWire selective loading\nthrough run path\n(KedroSession + _ProjectPipelines)"]
-    P1b["Piece 1b\nLightweight pipeline\nname discovery\n(list_names() method)"]
-    P1c["Piece 1c\nWire CLI commands\n(catalog, registry, inspection)"]
-    P2a["Piece 2a\nDefer inspect.signature()\nin Node.__init__"]
-    P2b["Piece 2b\nString function references\nin Node (future)"]
-
-    P1a --> P1c
-    P1b --> P1c
-    P1a --> P2a
-    P2a --> P2b
-
-    style P1a fill:#4caf50,color:#fff
-    style P1b fill:#4caf50,color:#fff
-    style P1c fill:#2196f3,color:#fff
-    style P2a fill:#2196f3,color:#fff
-    style P2b fill:#9c27b0,color:#fff
-```
-
-### Risk Assessment
-
-| Piece | Risk | Mitigation |
-|-------|------|-----------|
-| **1a** — Selective loading via run path | Low — activates already-existing `find_pipelines(pipelines_to_find=...)` | `TypeError` fallback for custom `register_pipelines` that doesn't accept kwargs |
-| **1b** — Lightweight name discovery | Low — purely additive new method | Falls back to full load for non-standard layouts |
-| **1c** — Wire CLI commands | Low — single line additions | No logic change, just earlier hint-setting |
-| **2a** — Defer signature inspection | Medium — changes when `TypeError` is raised (at run, not at pipeline construction) | Expose explicit `node.validate()` for test suites and dry-runs |
-| **2b** — String function references | High — API change, affects IDE tooling, kedro-viz | Gate behind feature flag; maintain full backwards compatibility |
-
-### What Stays Unchanged
-
-- `register_pipelines()` signature in user projects (kwargs are optional)
-- `find_pipelines()` public API
-- `node(func, ...)` with live callables (Piece 2a defers but doesn't remove validation)
-- All existing tests — the filtering is strictly additive
+**Key takeaway for non-run commands:** Gap 1 alone already means you only need the specific pipeline's dependencies installed — not all pipelines'. Gap 2a gives an additional bonus: since non-run commands never call `node.run()`, the deferred `inspect.signature()` simply never runs at all. Full dependency freedom (zero installs required) is only achieved for `kedro registry list` via `list_names()`, since it never loads any pipeline module.

--- a/docs/on_demand_dependency_loading.md
+++ b/docs/on_demand_dependency_loading.md
@@ -10,11 +10,9 @@
 
 This spike addresses two distinct scenarios with different root causes and solutions.
 
-### Scenario 1 — Selective Pipeline Loading (all dependencies installed)
+### Scenario 1 — Selective Pipeline Loading
 
 When a user runs `kedro run --pipeline data_science`, Kedro imports every pipeline module in the project — including unrelated pipelines. The selective loading capability already exists via `find_pipelines(pipelines_to_find=...)` from [PR #5401](https://github.com/kedro-org/kedro/pull/5401), but it is never wired to the CLI `--pipeline` flag automatically.
-
-**This scenario assumes all project dependencies are installed.** The goal is purely to avoid importing unrelated pipeline modules at startup.
 
 ### Scenario 2 — CLI Commands Without Project Dependencies
 
@@ -55,15 +53,13 @@ flowchart TD
     style E fill:#ffa500,color:#fff
 ```
 
-**Key problem:** `find_pipelines()` receives no filter, so it imports every pipeline directory and calls `inspect.signature()` on every node function — even though only `data_science` was requested. The unused pipelines (red) are fully loaded before the result is returned.
+**Key problem:** `find_pipelines()` receives no filter, so it imports every pipeline directory even though only `data_science` was requested. The unused pipelines (red) are fully loaded before the result is returned.
 
 ---
 
 ## 3. Root Cause Analysis
 
-There are **two distinct bottlenecks** at different layers of the stack:
-
-### Bottleneck 1: `_ProjectPipelines._load_data()` — Pipeline Level
+### `_ProjectPipelines._load_data()` — Pipeline Level
 
 ```python
 # kedro/framework/project/__init__.py
@@ -83,7 +79,7 @@ def _load_data(self) -> None:
 
 The selective loading capability **already exists** in `find_pipelines(pipelines_to_find=...)` from PR #5401, but `_load_data()` never passes a filter through.
 
-### Bottleneck 2: Missing project dependencies at module load time — Import Level
+### Missing project dependencies at module load time — Import Level
 
 Even when `_load_data()` correctly filters which pipelines to load, importing `pipeline_registry.py` triggers the full import chain for every pipeline referenced at the top level:
 
@@ -95,31 +91,6 @@ from my_project.pipelines.reporting import create_pipeline
 ```
 
 This happens before `register_pipelines()` is even called — before any filter can intervene.
-
-### The Gap Visualised
-
-```mermaid
-flowchart LR
-    subgraph "What Exists"
-        A["find_pipelines(pipelines_to_find=['data_science'])"]
-        B["KedroSession.run(pipeline_names=['data_science'])"]
-    end
-
-    subgraph "The Gap"
-        C["_load_data() calls register_pipelines()\nwith NO filter"]
-        D["pipeline_registry.py top-level imports\ntrigger full dep chain before any filter"]
-    end
-
-    subgraph "What We Need"
-        E["CLI calls pipelines.set_requested(names)\nfind_pipelines() reads _requested_pipelines\nwith CLI precedence over pipelines_to_find kwarg"]
-        F["safe_context() mocks missing deps\nin sys.modules before registry load"]
-    end
-
-    A -.->|"never wired to CLI"| C
-    B -.->|"never wired"| C
-    C -->|"Scenario 1 fix"| E
-    D -->|"Scenario 2 fix"| F
-```
 
 ---
 

--- a/docs/on_demand_dependency_loading.md
+++ b/docs/on_demand_dependency_loading.md
@@ -1,30 +1,24 @@
-# On-Demand Project Dependency Loading
+# On-Demand Project Dependency Loading — Overview
 
 **Spike:** [#5406](https://github.com/kedro-org/kedro/issues/5406)
 
-**Goal:** Eliminate unnecessary pipeline dependency imports across CLI commands, targeted runs, and inspection workflows.
+**Goal:** Reduce unnecessary dependency loading across CLI commands, targeted runs, and inspection workflows.
 
 ---
 
 ## 1. Problem Statement
 
-Kedro currently requires **all** pipeline dependencies to be installed before executing any project-specific CLI command — even when targeting a single pipeline or performing read-only inspection.
+This spike addresses two distinct scenarios with different root causes and solutions.
 
-```
-kedro run --pipeline data_science
-```
+### Scenario 1 — Selective Pipeline Loading (all dependencies installed)
 
-This command today imports and instantiates **every** pipeline in the project, including `data_engineering`, `feature_engineering`, `reporting` — none of which are relevant to the run.
+When a user runs `kedro run --pipeline data_science`, Kedro imports every pipeline module in the project — including unrelated pipelines. The selective loading capability already exists via `find_pipelines(pipelines_to_find=...)` from [PR #5401](https://github.com/kedro-org/kedro/pull/5401), but it is never wired to the CLI `--pipeline` flag automatically.
 
-### Real-World Impact
+**This scenario assumes all project dependencies are installed.** The goal is purely to avoid importing unrelated pipeline modules at startup.
 
-| Scenario | Current Behavior | Desired Behavior |
-|----------|-----------------|------------------|
-| `kedro run --pipeline data_science` | All pipeline modules imported | Only `data_science` imports loaded |
-| `kedro registry list` | All Pipeline objects constructed | Directory scan only — no imports |
-| `kedro catalog describe-datasets -p reporting` | All pipelines loaded | Only `reporting` pipeline loaded |
-| CI/CD lint/metadata check | Full dependency footprint required | Near-zero dependency footprint |
-| New developer onboarding | Must install all deps to run anything | Install only the pipeline they work on |
+### Scenario 2 — CLI Commands Without Project Dependencies
+
+Read-only CLI commands (`kedro registry list`, `kedro registry describe`, `kedro catalog describe-datasets`, inspection API) do not execute node functions. They should be able to return pipeline metadata even when heavy project dependencies (sklearn, torch, seaborn) are not installed. Today they require a full pipeline load, which transitively imports all dependencies.
 
 ---
 
@@ -72,7 +66,7 @@ There are **two distinct bottlenecks** at different layers of the stack:
 ### Bottleneck 1: `_ProjectPipelines._load_data()` — Pipeline Level
 
 ```python
-# kedro/framework/project/__init__.py:211-225
+# kedro/framework/project/__init__.py
 def _load_data(self) -> None:
     if self._pipelines_module is None or self._is_data_loaded:
         return
@@ -92,10 +86,9 @@ The selective loading capability **already exists** in `find_pipelines(pipelines
 ### Bottleneck 2: `Node.__init__._validate_inputs()` — Function Level
 
 ```python
-# kedro/pipeline/node.py:155
+# kedro/pipeline/node.py
 self._validate_inputs(func, inputs)  # called eagerly in __init__
 
-# kedro/pipeline/node.py:683-701
 def _validate_inputs(self, func, inputs):
     if not inspect.isbuiltin(func):
         # ❌ Requires func to be a live callable — the module must already be imported
@@ -119,275 +112,18 @@ flowchart LR
     end
 
     subgraph "What We Need"
-        E["_load_data() forwards the requested\npipeline names to register_pipelines()"]
+        E["CLI --pipeline flag wired to\nfind_pipelines(pipelines_to_find=...)"]
         F["Node defers signature validation\nto execution time"]
     end
 
-    A -.->|"never wired"| C
+    A -.->|"never wired to CLI"| C
     B -.->|"never wired"| C
-    C -->|"fix"| E
-    D -->|"fix"| F
+    C -->|"Scenario 1 fix"| E
+    D -->|"Scenario 2 fix"| F
 ```
 
 ---
 
-## 4. Solutions
-
-The gap diagram above identifies two independent problems. Each has its own fix, and both can be shipped and applied without the other.
-
----
-
-### Gap 1 — Wire the filter through `_load_data()`
-
-**Problem recap:** `_load_data()` calls `register_pipelines()` with no filter, so `find_pipelines()` imports every pipeline directory even when only one is needed. The `find_pipelines(pipelines_to_find=...)` parameter already exists but is never passed in.
-
-**Fix:** Add `set_requested()` to `_ProjectPipelines` so callers can declare which pipelines they need before the first dict access. `_load_data()` then forwards those names to `register_pipelines()` as the `pipelines_to_find` kwarg.
-
-#### a. Add `set_requested()` and update `_load_data()` — `kedro/framework/project/__init__.py`
-
-```python
-class _ProjectPipelines(MutableMapping):
-    def __init__(self) -> None:
-        self._pipelines_module: str | None = None
-        self._is_data_loaded = False
-        self._content: dict[str, Pipeline] = {}
-        self._requested_pipelines: list[str] | None = None  # NEW
-
-    def set_requested(self, pipeline_names: list[str] | None) -> None:
-        """Hint which pipelines will be needed before first data access.
-
-        Must be called before any dict-access on this object. If the filter
-        changes after data has been loaded, the cache is invalidated.
-        """
-        if self._requested_pipelines != pipeline_names:
-            self._is_data_loaded = False
-            self._content = {}
-        self._requested_pipelines = pipeline_names
-
-    def _load_data(self) -> None:
-        if self._pipelines_module is None or self._is_data_loaded:
-            return
-
-        register_pipelines = self._get_pipelines_registry_callable(
-            self._pipelines_module
-        )
-        try:
-            project_pipelines = register_pipelines(
-                pipelines_to_find=self._requested_pipelines  # NEW — pass the filter
-            )
-        except TypeError:
-            # Fallback: custom register_pipelines doesn't accept kwargs
-            project_pipelines = register_pipelines()
-
-        self._content = project_pipelines
-        self._is_data_loaded = True
-```
-
-#### b. Wire `KedroSession.run()` to call `set_requested()` before any dict access — `kedro/framework/session/session.py`
-
-```python
-def run(self, pipeline_names: list[str] | None = None, ...) -> dict[str, Any]:
-    ...
-    names = pipeline_names or ["__default__"]
-
-    pipelines.set_requested(names)  # NEW — must happen before pipelines[name]
-
-    combined_pipelines = Pipeline([])
-    for name in names:
-        combined_pipelines += pipelines[name]  # only loads requested ones
-```
-
-With these two changes, `kedro run --pipeline data_science` imports only `data_science/pipeline.py` — `data_engineering`, `feature_engineering`, and `reporting` are never touched.
-
-#### c. Wire CLI commands that take `--pipeline` to call `set_requested()`
-
-Every CLI command that accepts a `--pipeline` argument should call `set_requested()` before any pipeline access, so `_load_data()` has the filter ready. `kedro registry list` is special — it only needs names, so it gets a zero-import `list_names()` method instead.
-
-| Command | Change | Result |
-|---------|--------|--------|
-| `kedro run --pipeline X` | `set_requested()` called inside `KedroSession.run()` (section b above) | Only X loaded |
-| `kedro catalog describe-datasets -p X` | `set_requested(["X"])` before session creation | Only X loaded |
-| `kedro catalog resolve-patterns -p X` | `set_requested(["X"])` before session creation | Only X loaded |
-| `kedro registry describe X` | `set_requested(["X"])` before `pipelines.get(name)` | Only X loaded |
-| `kedro registry list` | Use new `list_names()` — directory scan, no imports | Zero imports |
-| `inspection: get_project_snapshot(pipeline_names=["X"])` | `set_requested(["X"])` before pipeline dict access | Only X loaded |
-| `kedro info`, `kedro package`, `kedro catalog list-patterns` | No change needed — never access `pipelines` | Unchanged |
-
-The pattern is identical for every command that takes `--pipeline`. Using `kedro catalog describe-datasets` as the representative example:
-
-```python
-# kedro/framework/cli/catalog.py — BEFORE
-def describe_datasets(metadata, pipeline, env):
-    session = _create_session(metadata.package_name, env=env)
-    datasets_dict = context.catalog.describe_datasets(pipeline or None)
-    secho(yaml.dump(datasets_dict))
-
-# kedro/framework/cli/catalog.py — AFTER
-def describe_datasets(metadata, pipeline, env):
-    if pipeline:
-        from kedro.framework.project import pipelines as _pipelines
-        _pipelines.set_requested(pipeline)  # one line before session creation
-    session = _create_session(metadata.package_name, env=env)
-    datasets_dict = context.catalog.describe_datasets(pipeline or None)
-    secho(yaml.dump(datasets_dict))
-```
-
-`kedro registry list` uses `list_names()` instead — a pure filesystem scan with zero imports
-
-```python
-# kedro/framework/project/__init__.py
-
-def list_names(self) -> list[str]:
-    """Return pipeline names by scanning the filesystem — no imports."""
-    spec = importlib.util.find_spec(PACKAGE_NAME)
-    if spec is None or spec.origin is None:
-        return list(self.keys())  # fallback to full load
-
-    pipelines_path = Path(spec.origin).parent / "pipelines"
-    if not pipelines_path.is_dir():
-        return list(self.keys())  # non-standard layout — fallback
-
-    names = [
-        d.name for d in pipelines_path.iterdir()
-        if d.is_dir() and not d.name.startswith(".") and d.name != "__pycache__"
-    ]
-    return sorted(["__default__", *names])
-```
-
-```python
-# kedro/framework/cli/registry.py — AFTER
-@registry.command("list")
-def list_registered_pipelines() -> None:
-    click.echo(yaml.dump(pipelines.list_names()))  # zero imports
-```
-
-> **Limitation — custom `register_pipelines` that constructs all pipelines unconditionally**
->
-> This fix only delivers selective loading for projects using the default `find_pipelines()` layout. Projects with a hand-written `register_pipelines` that eagerly constructs every pipeline at the top of the function receive no benefit:
->
-> ```python
-> def register_pipelines() -> Dict[str, Pipeline]:
->     ingestion_pipeline = di.create_pipeline()    # ← imports di + all its deps
->     feature_pipeline   = fe.create_pipeline()    # ← imports fe + all its deps
->     modelling_pipeline = mod.create_pipeline()   # ← imports sklearn etc.
->     reporting_pipeline = rep.create_pipeline()   # ← imports matplotlib etc.
->     return {"data_ingestion": ingestion_pipeline, ...}
-> ```
->
-> Two reasons it fails for this pattern:
-> 1. The function doesn't accept `pipelines_to_find`, so `_load_data()` hits `TypeError` and falls back to `register_pipelines()` with no filter — same behaviour as today.
-> 2. Even if the kwarg were accepted, all pipeline modules are already imported unconditionally before any filter could be applied.
->
-> **Options for affected projects:**
-> - Switch to the default `find_pipelines()` layout (recommended for new projects).
-> - Rely on the Gap 2 fix (lazy `inspect.signature` / string node references), which defers function-module imports regardless of how `register_pipelines` is structured.
-
----
-
-### Gap 2 — Defer `inspect.signature()` to execution time
-
-**Problem recap:** `Node.__init__()` calls `_validate_inputs()` immediately, which calls `inspect.signature(func)`. This forces the module containing `func` to be fully imported at pipeline construction time — even when running a completely different pipeline or just listing pipeline names.
-
-**Fix:** Move signature validation out of `__init__()` and into `run()`, where the function's module is guaranteed to already be loaded.
-
-#### a. Defer `_validate_inputs()` to `Node.run()` — `kedro/pipeline/node.py`
-
-```python
-# BEFORE — eager validation at construction
-def __init__(self, func, inputs, outputs, ...):
-    ...
-    self._validate_inputs(func, inputs)  # ← runs immediately, imports func's module
-    self._func = func
-
-# AFTER — deferred validation at first run
-def __init__(self, func, inputs, outputs, ...):
-    ...
-    self._func = func
-    self._inputs = inputs
-    self._inputs_validated = False  # NEW
-    # Structural checks that don't need imports still run eagerly:
-    self._validate_unique_outputs()
-    self._validate_inputs_dif_than_outputs()
-
-def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
-    if not self._inputs_validated:
-        self._validate_inputs(self._func, self._inputs)  # func's module loaded by now
-        self._inputs_validated = True
-    ...
-```
-
-For contexts that want eager validation (e.g. `kedro run --dry-run` or test suites), expose an explicit method:
-
-```python
-def validate(self) -> None:
-    """Validate node inputs against the function signature.
-
-    Called automatically on first run(). Can be called earlier for
-    eager validation, e.g. during a dry-run or test suite setup.
-    """
-    self._validate_inputs(self._func, self._inputs)
-    self._inputs_validated = True
-```
-
-#### b. String function references in `Node` (future)
-
-Accept a dotted string path as `func`, deferring both the import and signature inspection until execution:
-
-```python
-# kedro/pipeline/node.py — future
-
-class Node:
-    def __init__(self, func: Callable | str, inputs, outputs, ...):
-        if isinstance(func, str):
-            self._func_path = func
-            self._func: Callable | None = None
-            # No import, no inspect.signature — deferred entirely
-        else:
-            self._func_path = None
-            self._func = func
-            self._validate_inputs(func, inputs)  # still eager for live callables
-
-    @property
-    def func(self) -> Callable:
-        """Resolve the function, importing its module on first access."""
-        if self._func is None:
-            module_path, func_name = self._func_path.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            self._func = getattr(module, func_name)
-        return self._func
-
-    def run(self, inputs):
-        result = self.func(...)  # .func resolves + imports here
-```
-
-Usage:
-
-```python
-# BEFORE — eager import at module load
-from my_project.pipelines.data_science.nodes import train_model
-
-def create_pipeline(**kwargs):
-    return pipeline([node(train_model, inputs="X_train", outputs="model")])
-
-# AFTER — deferred via string reference
-def create_pipeline(**kwargs):
-    return pipeline([
-        node(
-            "my_project.pipelines.data_science.nodes.train_model",
-            inputs="X_train",
-            outputs="model",
-        )
-    ])
-```
-
-> This is a **potential breaking API change**. Key design questions: backwards compatibility with live callables (must be unchanged), error surfacing (import errors surface at `node.run()` not at `Pipeline()` construction — needs clear messages), `node.name` auto-derivation (today from `func.__name__`, needs a fallback), IDE/type-checking support (string paths lose navigation), and `kedro-viz`/inspection tool compatibility.
-
-**What each fix defers:**
-
-| Fix applied | `kedro run --pipeline X` | Non-run commands (e.g. `registry describe X`) |
-|-------------|--------------------------|-----------------------------------------------|
-| Gap 1 only | Only X's `pipeline.py` loaded; X's deps (e.g. `sklearn`) still import at construction | Same — only X's deps needed; other pipelines' deps not required |
-| Gap 1 + Gap 2a | Only X's `pipeline.py` loaded; X's deps still import at construction; `inspect.signature()` deferred to `node.run()` | Only X's deps needed; `inspect.signature()` **never runs at all** (nodes are never executed) |
-| Gap 1 + Gap 2a + Gap 2b | Nothing loads until `node.run()` — X's deps deferred to execution | X's deps never load for commands that don't execute nodes |
-
-**Key takeaway for non-run commands:** Gap 1 alone already means you only need the specific pipeline's dependencies installed — not all pipelines'. Gap 2a gives an additional bonus: since non-run commands never call `node.run()`, the deferred `inspect.signature()` simply never runs at all. Full dependency freedom (zero installs required) is only achieved for `kedro registry list` via `list_names()`, since it never loads any pipeline module.
+**Solution details:**
+- [Scenario 1 — Selective Pipeline Loading](scenario_1_selective_loading.md)
+- [Scenario 2 — CLI Commands Without Project Dependencies](scenario_2_dep_free_commands.md)

--- a/docs/on_demand_dependency_loading.md
+++ b/docs/on_demand_dependency_loading.md
@@ -83,19 +83,18 @@ def _load_data(self) -> None:
 
 The selective loading capability **already exists** in `find_pipelines(pipelines_to_find=...)` from PR #5401, but `_load_data()` never passes a filter through.
 
-### Bottleneck 2: `Node.__init__._validate_inputs()` — Function Level
+### Bottleneck 2: Missing project dependencies at module load time — Import Level
+
+Even when `_load_data()` correctly filters which pipelines to load, importing `pipeline_registry.py` triggers the full import chain for every pipeline referenced at the top level:
 
 ```python
-# kedro/pipeline/node.py
-self._validate_inputs(func, inputs)  # called eagerly in __init__
-
-def _validate_inputs(self, func, inputs):
-    if not inspect.isbuiltin(func):
-        # ❌ Requires func to be a live callable — the module must already be imported
-        inspect.signature(func, follow_wrapped=False).bind(*args, **kwargs)
+# pipeline_registry.py — top-level import fires immediately
+from my_project.pipelines.reporting import create_pipeline
+#   → reporting/pipeline.py → from .nodes import train_model
+#   → reporting/nodes.py   → import seaborn  ← ModuleNotFoundError
 ```
 
-Every `node(my_function, ...)` call in every `create_pipeline()` body triggers `inspect.signature()`, which forces the module containing `my_function` to be fully imported.
+This happens before `register_pipelines()` is even called — before any filter can intervene.
 
 ### The Gap Visualised
 
@@ -108,12 +107,12 @@ flowchart LR
 
     subgraph "The Gap"
         C["_load_data() calls register_pipelines()\nwith NO filter"]
-        D["Node.__init__ calls inspect.signature()\nat construction time"]
+        D["pipeline_registry.py top-level imports\ntrigger full dep chain before any filter"]
     end
 
     subgraph "What We Need"
-        E["CLI --pipeline flag wired to\nfind_pipelines(pipelines_to_find=...)"]
-        F["Node defers signature validation\nto execution time"]
+        E["CLI calls pipelines.set_requested(names)\nfind_pipelines() reads _requested_pipelines\nwith CLI precedence over pipelines_to_find kwarg"]
+        F["safe_context() mocks missing deps\nin sys.modules before registry load"]
     end
 
     A -.->|"never wired to CLI"| C

--- a/docs/pipeline_loading_architecture.md
+++ b/docs/pipeline_loading_architecture.md
@@ -1,0 +1,150 @@
+# Pipeline Loading Architecture
+
+**Branch:** `spike/dep_free` · **Related:** [Registry Architecture](pipeline_registry_architecture.md)
+
+---
+
+## Three Layers of Laziness
+
+```
+Layer 1 — Pipeline names     zero imports, directory scan or pyproject.toml read only
+Layer 2 — Pipeline modules   import only the requested pipeline's __init__.py
+Layer 3 — Node functions     import heavy dependencies only when the node runs  [TBD]
+```
+
+Today Kedro partially addresses Layer 1 and Layer 2 via the `_requested_pipelines` side-channel. Layer 3 is unaddressed. The entire mechanism lives in a god module (`framework/project/__init__.py`).
+
+---
+
+## What `__init__.py` Looks Like After
+
+The `pyproject.toml` + `AutoDiscoveryRegistry` approach removes **all pipeline-related code** from `__init__.py`:
+
+| Removed | Why gone |
+|---|---|
+| `_ProjectPipelines` class | `AutoDiscoveryRegistry` in `kedro/pipeline/registry.py` replaces it |
+| `_load_data_wrapper` decorator | No more lazy dict proxy needed |
+| `_get_pipelines_registry_callable` | No `register_pipelines` function to call |
+| `_load_data()` | Discovery logic lives in the registry class |
+| `find_pipelines()` | Moves to `AutoDiscoveryRegistry.list()` / `.load()` |
+| `_load_modular_pipelines()` | Same |
+| `_load_default_pipeline()` | Same |
+| `set_requested()` / `_requested_pipelines` | Commands call `registry.load(name)` directly — no global state |
+| `pipelines` global singleton | Gone |
+
+`__init__.py` becomes settings + logging + bootstrap only. The pipeline concern moves entirely to `kedro/pipeline/registry.py`.
+
+### New file topology
+
+```
+kedro/
+  pipeline/
+    registry.py        # PipelineRegistry Protocol + AutoDiscoveryRegistry
+  framework/
+    project/
+      __init__.py      # settings, LOGGING, PACKAGE_NAME, configure_project() only
+      _settings.py     # _ProjectSettings (Dynaconf wrapper)
+      _logging.py      # _ProjectLogging
+    session/
+      session.py       # no set_requested(), no pipelines global
+    cli/
+      project.py       # explicit load sequence per command
+```
+
+---
+
+## CLI-Demand-Driven Loading
+
+Each command has a well-defined demand profile. Today this is implicit and scattered across `session.py`, `cli/catalog.py`, `cli/registry.py` with manual `set_requested()` calls. Making it explicit:
+
+| Command | Layer 1 (names) | Layer 2 (modules) | Config | Catalog |
+|---|---|---|---|---|
+| `kedro -h` | — | — | — | — |
+| `kedro info` | — | — | — | — |
+| `kedro registry list` | yes | — | — | — |
+| `kedro registry describe X` | — | X only | — | — |
+| `kedro catalog list` | — | — | yes | yes |
+| `kedro catalog list -p X` | X only | — | yes | yes |
+| `kedro run --pipeline X` | — | X only | yes | yes |
+| `kedro run` | default set | default set | yes | yes |
+
+### What the run command looks like
+
+```python
+# kedro/framework/cli/project.py
+
+@click.command()
+@click.option("--pipeline", multiple=True)
+def run(pipeline, ...):
+    registry = _get_registry()                        # reads pyproject.toml — zero imports
+    names = pipeline or registry.default_names        # Layer 1
+
+    with KedroSession.create(...) as session:
+        catalog = session.load_catalog()              # config + catalog only
+        for name in names:
+            pl = registry.load(name)                  # Layer 2, one at a time
+            runner.run(pl, catalog, ...)
+```
+
+No global `pipelines` object. No `set_requested()`. No temporal ordering to manage. Each command owns its loading sequence explicitly.
+
+### `AutoDiscoveryRegistry` — the full picture
+
+```python
+# kedro/pipeline/registry.py
+
+class AutoDiscoveryRegistry:
+    def __init__(self, package_name: str, config: PipelineConfig):
+        self._package = package_name
+        self._exclude = set(config.exclude or [])
+        self._default_names = config.default          # None means "all discovered"
+        self._cache: dict[str, Pipeline] = {}
+
+    def list(self) -> list[str]:
+        """Layer 1 — directory scan only, zero pipeline imports."""
+        pkg = importlib.resources.files(f"{self._package}.pipelines")
+        return [
+            d.name for d in pkg.iterdir()
+            if d.is_dir()
+            and not d.name.startswith("_")
+            and d.name not in self._exclude
+        ]
+
+    def load(self, name: str) -> Pipeline:
+        """Layer 2 — import one pipeline module on demand."""
+        if name not in self._cache:
+            mod = importlib.import_module(f"{self._package}.pipelines.{name}")
+            self._cache[name] = mod.create_pipeline()
+        return self._cache[name]
+
+    @property
+    def default_names(self) -> list[str]:
+        return self._default_names or self.list()
+
+    @property
+    def default(self) -> Pipeline:
+        return sum(self.load(n) for n in self.default_names) or Pipeline([])
+```
+
+### `pyproject.toml` configuration
+
+```toml
+[tool.kedro.pipelines]
+exclude  = ["experimental", "legacy"]        # never surfaced, never run
+default  = ["data_processing", "data_science"]  # what kedro run runs with no --pipeline flag
+```
+
+- `exclude` — directories exist but Kedro ignores them. Absent from `kedro registry list` and from the default run.
+- `default` — explicit composition for the no-flag case. If absent, all non-excluded pipelines are combined.
+- `PIPELINE_REGISTRY_CLASS` in `settings.py` provides the programmatic escape hatch for namespaced pipelines, dynamic pipeline generation, or any case `pyproject.toml` cannot express.
+
+---
+
+## Migration Path
+
+| Phase | Change | Breaking |
+|---|---|---|
+| 1 | Introduce `PIPELINE_REGISTRY_CLASS` in `settings.py`, default `AutoDiscoveryRegistry` | No |
+| 2 | If `pipeline_registry.py` exists: use it with a deprecation warning | No |
+| 3 | If `pipeline_registry.py` absent: auto-discover from `pyproject.toml` + directory scan | No |
+| 4 | Remove `pipeline_registry.py` support, `find_pipelines()`, `_ProjectPipelines` | Yes (major) |

--- a/docs/scenario_1_selective_loading.md
+++ b/docs/scenario_1_selective_loading.md
@@ -2,8 +2,6 @@
 
 **Part of spike [#5406](https://github.com/kedro-org/kedro/issues/5406) · [← Overview](on_demand_dependency_loading.md) · [Scenario 2 →](scenario_2_dep_free_commands.md)**
 
-**Assumption:** All project dependencies are installed. The goal is to avoid importing unrelated pipeline modules when a specific pipeline is requested via `--pipeline`.
-
 ---
 
 ## Background

--- a/docs/scenario_1_selective_loading.md
+++ b/docs/scenario_1_selective_loading.md
@@ -1,0 +1,127 @@
+# Scenario 1 — Selective Pipeline Loading
+
+**Part of spike [#5406](https://github.com/kedro-org/kedro/issues/5406) · [← Overview](on_demand_dependency_loading.md) · [Scenario 2 →](scenario_2_dep_free_commands.md)**
+
+**Assumption:** All project dependencies are installed. The goal is to avoid importing unrelated pipeline modules when a specific pipeline is requested via `--pipeline`.
+
+---
+
+## Background
+
+`find_pipelines(pipelines_to_find=...)` from [PR #5401](https://github.com/kedro-org/kedro/pull/5401) already supports selective loading. If called with `["data_science"]`, it only imports `my_project/pipelines/data_science/`. The capability exists; it just needs to be wired to the CLI `--pipeline` flag.
+
+For projects using the default registry pattern:
+
+```python
+# my_project/pipeline_registry.py
+from kedro.framework.project import find_pipelines
+
+def register_pipelines():
+    return find_pipelines()  # pipelines_to_find=None → loads everything today
+```
+
+If `_requested_pipelines` is set before `find_pipelines()` runs, only the requested pipeline directory is imported.
+
+---
+
+## Solution
+
+### Step 1 — `set_requested()` on `_ProjectPipelines`
+
+`_ProjectPipelines` stores which pipelines are needed before the first dict access. Invalidates the cache if the filter changes so a subsequent full run still loads everything.
+
+```python
+# kedro/framework/project/__init__.py
+
+class _ProjectPipelines(MutableMapping):
+    def __init__(self) -> None:
+        self._pipelines_module: str | None = None
+        self._is_data_loaded = False
+        self._content: dict[str, Pipeline] = {}
+        self._requested_pipelines: list[str] | None = None  # NEW
+
+    def set_requested(self, pipeline_names: list[str] | None) -> None:
+        """Store which pipelines are needed before first dict access.
+        Invalidates the cache if the filter changes.
+        """
+        if self._requested_pipelines != pipeline_names:
+            self._is_data_loaded = False
+            self._content = {}
+        self._requested_pipelines = pipeline_names
+```
+
+### Step 2 — `find_pipelines()` reads `_requested_pipelines` with CLI precedence
+
+The CLI-set filter (via `set_requested()`) takes precedence over the explicit `pipelines_to_find` kwarg. When no CLI filter is active (`_requested_pipelines` is `None`), the explicit kwarg is used as before.
+
+Since `find_pipelines()` and the `pipelines` global are in the **same file**, there is no circular import risk. **No changes to `_load_data()` are needed for Scenario 1.**
+
+```python
+# kedro/framework/project/__init__.py
+
+def find_pipelines(raise_errors: bool = False, pipelines_to_find: list[str] | None = None):
+    # CLI-set filter takes precedence; falls back to the explicit kwarg.
+    requested_pipelines = (
+        pipelines._requested_pipelines
+        if pipelines._requested_pipelines is not None
+        else pipelines_to_find
+    )
+    load_all = requested_pipelines is None or "__default__" in requested_pipelines
+    pipeline_filter: set[str] | None = None if load_all else set(requested_pipelines)
+    # ... rest of function unchanged
+```
+
+### Step 3 — CLI commands call `set_requested()` before pipeline access
+
+`set_requested()` must be called **before** any dict access on `pipelines`. For session-based commands, this means before `_create_session()` — the first catalog or pipeline access inside the session triggers `_load_data()`.
+
+#### Current status
+
+| Command | File | Call | Status |
+|---------|------|------|--------|
+| `kedro run --pipeline X` | `session.py:348` | `pipelines.set_requested(names)` | **Done** |
+| `kedro registry describe X` | `registry.py:38` | `pipelines.set_requested([name])` | **Done** |
+| `kedro catalog describe-datasets -p X` | `catalog.py:56` | `pipelines.set_requested([pipeline])` | **Done** |
+| `kedro catalog resolve-patterns -p X` | `catalog.py:104` | `pipelines.set_requested([pipeline])` | **Done** |
+| `inspection: get_project_snapshot(pipelines=["X"])` | `snapshot.py:136` | requires new `pipeline_names` parameter first | **Future** |
+
+> **Bug to fix in `catalog.py`:** The `--pipeline` option uses `callback=split_string` which already returns `list[str]`, so `pipeline` is e.g. `["data_science"]`. Wrapping it as `[pipeline]` produces `[["data_science"]]`. The correct call is `pipelines.set_requested(pipeline)` (without the extra list).
+
+---
+
+## Limitation — Custom `register_pipelines` Without `find_pipelines()`
+
+This fix only works for projects using `find_pipelines()`. Projects with a hand-written `register_pipelines` receive no benefit — `find_pipelines()` is never called so `_requested_pipelines` is never read. This includes top-level imports in `pipeline_registry.py`:
+
+```python
+# pipeline_registry.py — these fire BEFORE register_pipelines() is called
+from my_project.pipelines.reporting import create_pipeline as reporting_pipeline
+from my_project.pipelines.data_science import create_pipeline as ds_pipeline
+
+def register_pipelines():
+    return {"reporting": reporting_pipeline(), "data_science": ds_pipeline()}
+```
+
+**Options for affected projects:**
+
+1. **Switch to `find_pipelines()`** — the default layout since Kedro 0.18.3.
+
+2. **Read `_requested_pipelines` manually** — gate local imports behind the stored filter:
+   ```python
+   from kedro.framework.project import pipelines as _pipelines
+
+   def register_pipelines():
+       requested = _pipelines._requested_pipelines  # None means load all
+       result = {}
+       if requested is None or "data_ingestion" in requested:
+           from my_project.pipelines import data_ingestion
+           result["data_ingestion"] = data_ingestion.create_pipeline()
+       if requested is None or "reporting" in requested:
+           from my_project.pipelines import reporting
+           result["reporting"] = reporting.create_pipeline()
+       return result
+   ```
+
+3. **Use Scenario 2, Approach C** — the only zero-user-code-change path. `sys.meta_path` stubs intercept all non-requested pipeline module imports before `pipeline_registry.py` runs, regardless of how `register_pipelines` is written. See [scenario_2_dep_free_commands.md](scenario_2_dep_free_commands.md).
+
+---

--- a/docs/scenario_1_selective_loading.md
+++ b/docs/scenario_1_selective_loading.md
@@ -85,8 +85,6 @@ def find_pipelines(raise_errors: bool = False, pipelines_to_find: list[str] | No
 | `kedro catalog resolve-patterns -p X` | `catalog.py:104` | `pipelines.set_requested([pipeline])` | **Done** |
 | `inspection: get_project_snapshot(pipelines=["X"])` | `snapshot.py:136` | requires new `pipeline_names` parameter first | **Future** |
 
-> **Bug to fix in `catalog.py`:** The `--pipeline` option uses `callback=split_string` which already returns `list[str]`, so `pipeline` is e.g. `["data_science"]`. Wrapping it as `[pipeline]` produces `[["data_science"]]`. The correct call is `pipelines.set_requested(pipeline)` (without the extra list).
-
 ---
 
 ## Limitation — Custom `register_pipelines` Without `find_pipelines()`

--- a/docs/scenario_1_selective_loading.md
+++ b/docs/scenario_1_selective_loading.md
@@ -119,7 +119,3 @@ def register_pipelines():
            result["reporting"] = reporting.create_pipeline()
        return result
    ```
-
-3. **Use Scenario 2, Approach C** — the only zero-user-code-change path. `sys.meta_path` stubs intercept all non-requested pipeline module imports before `pipeline_registry.py` runs, regardless of how `register_pipelines` is written. See [scenario_2_dep_free_commands.md](scenario_2_dep_free_commands.md).
-
----

--- a/docs/scenario_2_dep_free_commands.md
+++ b/docs/scenario_2_dep_free_commands.md
@@ -4,52 +4,11 @@
 
 **Goal:** Read-only CLI commands (`kedro registry list`, `kedro registry describe`, `kedro catalog describe-datasets`, inspection API) should function even when heavy project dependencies (sklearn, torch, seaborn) are not installed.
 
-Four approaches address different layers of the stack — they are complementary, not mutually exclusive.
+Three approaches address different layers of the stack — they are complementary, not mutually exclusive.
 
 ---
 
-## Approach A — Filesystem-based Name Discovery
-
-**Command:** `kedro registry list`
-
-`kedro registry list` only needs pipeline names — no `Pipeline` or `Node` objects. Today iterating `pipelines` triggers `_load_data()`, constructing every `Node` and calling `inspect.signature()` on every function just to print names.
-
-`list_names()` bypasses `_load_data()` entirely by scanning the filesystem directly.
-
-> **Why not `importlib.resources.files()`?** It calls `importlib.import_module()` internally, which would import `my_project.pipelines`. `importlib.util.find_spec()` locates the package on disk without importing it.
-
-```python
-# kedro/framework/project/__init__.py — new method on _ProjectPipelines
-
-def list_names(self) -> list[str]:
-    """Return pipeline names by scanning the filesystem — no imports."""
-    spec = importlib.util.find_spec(PACKAGE_NAME)
-    if spec is None or spec.origin is None:
-        return list(self.keys())  # fallback to full load
-
-    pipelines_path = Path(spec.origin).parent / "pipelines"
-    if not pipelines_path.is_dir():
-        return list(self.keys())  # non-standard layout — fallback
-
-    names = [
-        d.name for d in pipelines_path.iterdir()
-        if d.is_dir() and not d.name.startswith(".") and d.name != "__pycache__"
-    ]
-    return sorted(["__default__", *names])
-```
-
-`list_names()` is **not** wrapped by `_load_data_wrapper`, so calling it never triggers `_load_data()`.
-
-```python
-# kedro/framework/cli/registry.py — AFTER
-@registry.command("list")
-def list_registered_pipelines() -> None:
-    click.echo(yaml.dump(pipelines.list_names()))  # zero imports
-```
-
----
-
-## Approach B — Defer `inspect.signature()` to `Node.run()`
+## Approach A — Defer `inspect.signature()` to `Node.run()`
 
 **Commands:** `kedro registry describe X`, `kedro catalog describe-datasets -p X`, inspection API
 
@@ -90,19 +49,11 @@ def validate(self) -> None:
     self._inputs_validated = True
 ```
 
-**What each combination defers:**
-
-| Approaches applied | What still loads at pipeline construction | What is deferred |
-|-------------------|-------------------------------------------|-----------------|
-| Scenario 1 only | Only X's `pipeline.py` → `nodes.py` → `sklearn` | All other pipelines' modules |
-| Scenario 1 + Approach B | Only X's `pipeline.py` → `nodes.py` → `sklearn` | `inspect.signature()` — never runs for non-execution commands |
-| Scenario 1 + Approach B + Approach D | Nothing at construction | Both `nodes.py` import and `inspect.signature()` |
-
-> **Key insight:** With Approach B, `inspect.signature()` is never called for commands like `registry describe` since `node.run()` is never invoked. However, `from nodes import train_model` at the top of `pipeline.py` still fires when `pipeline.py` is loaded. Only the signature validation overhead is eliminated — not the module import itself.
+> **Key insight:** With Approach A, `inspect.signature()` is never called for commands like `registry describe` since `node.run()` is never invoked. However, `from nodes import train_model` at the top of `pipeline.py` still fires when `pipeline.py` is loaded. Only the signature validation overhead is eliminated — not the module import itself.
 
 ---
 
-## Approach C — `sys.meta_path` Stubs for Missing Dependencies
+## Approach B — `sys.meta_path` Stubs for Missing Dependencies
 
 **When to use:** Project dependencies are genuinely not installed (e.g., `kedro run -p data_ingestion` when `seaborn` — required only by `reporting` — is absent).
 
@@ -195,7 +146,7 @@ def _load_data(self) -> None:
 
 ---
 
-## Approach D — String Function References in `Node` (future)
+## Approach C — String Function References in `Node` (future)
 
 Accept a dotted string path as `func`, deferring both the module import and signature inspection until `node.run()`. This is the deepest level of lazy loading — even `nodes.py` is not imported until execution.
 
@@ -247,49 +198,3 @@ def create_pipeline(**kwargs):
 ```
 
 > **Potential breaking API change.** Key design questions before shipping: backwards compatibility with live callables (must be unchanged), error surfacing (import errors surface at `node.run()` not `Pipeline()` construction — needs clear messages), `node.name` auto-derivation (today from `func.__name__`, needs a fallback for strings), IDE/type-checking support (string paths lose navigation), and `kedro-viz`/inspection tool compatibility.
-
----
-
-## Implementation Roadmap
-
-```mermaid
-gantt
-    title Scenario 2 — Implementation Phases
-    dateFormat  YYYY-MM-DD
-    section Low Risk
-    Approach A: list_names() for registry list   :s2a, 2026-04-20, 2d
-    section Medium Risk
-    Approach B: Defer inspect.signature()        :s2b, 2026-04-23, 5d
-    Approach C: sys.meta_path stubs              :s2c, after s2b, 5d
-    section High Risk
-    Approach D: String function references       :s2d, after s2c, 10d
-```
-
-### Dependency Graph
-
-```mermaid
-flowchart LR
-    S2A["Approach A\nlist_names()"]
-    S2B["Approach B\nDefer inspect.signature()"]
-    S2C["Approach C\nsys.meta_path stubs"]
-    S2D["Approach D\nString function references"]
-
-    S2B --> S2C
-    S2B --> S2D
-
-    style S2A fill:#4caf50,color:#fff
-    style S2B fill:#2196f3,color:#fff
-    style S2C fill:#2196f3,color:#fff
-    style S2D fill:#9c27b0,color:#fff
-```
-
-Approach A is fully independent. B must land before C or D (C/D both rely on the lazy-validation infrastructure B introduces).
-
-### Risk Assessment
-
-| Approach | Risk | Mitigation |
-|----------|------|-----------|
-| A: `list_names()` | Low — purely additive; never triggers `_load_data()` | Falls back to full load for non-standard layouts |
-| B: Defer `inspect.signature()` | Medium — `TypeError` surfaces at `node.run()` not construction | Expose explicit `node.validate()` for dry-runs and test suites |
-| C: `sys.meta_path` stubs | Medium — mutations to `sys.meta_path` can have subtle side effects | Scoped tightly to `_load_data()` with cleanup in `finally`; stub modules removed post-load |
-| D: String function references | High — API change, affects IDE tooling, kedro-viz | Gate behind feature flag; maintain backward compatibility with live callables |

--- a/docs/scenario_2_dep_free_commands.md
+++ b/docs/scenario_2_dep_free_commands.md
@@ -23,7 +23,7 @@ There is no hook between "load the pipeline registry" and "import seaborn" that 
 
 ---
 
-## Solution — `lite_shim`: AST Scan + `sys.modules` Mock
+## Solution 1 — `lite_shim`: AST Scan + `sys.modules` Mock
 
 Stub the **missing dependency itself** before any pipeline code is loaded. When `nodes.py` runs `import seaborn`, Python checks `sys.modules["seaborn"]` first — if a mock is already there, the import is a no-op. The pipeline loads, `create_pipeline()` runs, the `Pipeline` structure is fully populated, and seaborn is never executed.
 
@@ -135,3 +135,216 @@ def _load_data(self) -> None:
 ```
 
 CLI commands that are inspection-only (`registry list`, `registry describe`, `catalog describe-datasets`) set `inspection_mode=True` before triggering `_load_data()`. Run commands never set it.
+
+---
+
+## Solution 2 — `sys.meta_path` Catch-All Stub Finder
+
+The `lite_shim` approach above is *proactive*: it scans first, then mocks what it predicts will be missing. A well-known alternative used by Sphinx is *reactive*: install a fallback finder that only fires for modules no other finder can locate.
+
+### How it works
+
+Python resolves every `import` statement by walking `sys.meta_path` in order. Each finder's `find_spec` is called; if it returns `None` the next finder is tried. Only when every finder returns `None` is `ModuleNotFoundError` raised.
+
+Appending a stub finder to the **end** of `sys.meta_path` makes it a last-resort fallback — stdlib and installed packages are found by the normal finders and load without interference. Only truly absent packages fall through to the stub:
+
+```python
+import sys
+import contextlib
+import importlib.abc
+import importlib.machinery
+from types import ModuleType
+
+
+class _MockObject:
+    """Absorbs any attribute access or call on a mocked dependency."""
+    def __getattr__(self, key):
+        return _MockObject()
+    def __call__(self, *args, **kwargs):
+        return _MockObject()
+    def __class_getitem__(cls, item):  # handles generics: List[MockObject]
+        return cls
+
+
+class _MockModule(ModuleType):
+    def __getattr__(self, key):
+        return _MockObject()
+
+
+class _CatchAllFinder(importlib.abc.MetaPathFinder, importlib.abc.Loader):
+    """Stub finder appended to sys.meta_path as a catch-all fallback.
+
+    Returns a _MockModule for any name that all preceding finders rejected.
+    Because it is appended (not inserted at 0), real modules are unaffected.
+    """
+
+    def find_spec(self, fullname, path, target=None):
+        return importlib.machinery.ModuleSpec(fullname, self, is_package=True)
+
+    def create_module(self, spec):
+        return _MockModule(spec.name)
+
+    def exec_module(self, module):
+        pass  # skip all module-level code — the mock handles attribute access
+
+
+@contextlib.contextmanager
+def safe_context_v2():
+    finder = _CatchAllFinder()
+    sys.meta_path.append(finder)   # append = fallback only, does not shadow real modules
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+```
+
+Usage is identical to `safe_context` from the AST-scan approach:
+
+```python
+with safe_context_v2():
+    register_pipelines = _get_pipelines_registry_callable(pipelines_module)
+    project_pipelines = register_pipelines()
+```
+
+### Prior Usage
+
+This is the same mechanism that several major Python tools ship in production:
+
+- **Sphinx `autodoc_mock_imports`** ([source](https://github.com/sphinx-doc/sphinx/blob/master/sphinx/ext/autodoc/mock.py), [docs](https://www.sphinx-doc.org/en/master/usage/extensions/autodoc.html#confval-autodoc_mock_imports)) — `MockFinder` / `MockLoader` are inserted into `sys.meta_path` around each autodoc import. Sphinx ships this specifically to generate API documentation for libraries whose optional heavy dependencies (e.g. `torch`, `tensorflow`) are not installed in the docs-build environment. The implementation is ~100 lines and has been stable since Sphinx 1.6 (2017).
+
+- **pytest import modes** ([docs](https://docs.pytest.org/en/stable/explanation/pythonpath.html)) — pytest installs its own `MetaPathFinder` (`sys.meta_path.insert(0, ...)`) to control how test modules are located and loaded. While pytest's finder is not a stub finder, the pattern of scoping a `MetaPathFinder` around a targeted import via a context manager is idiomatic pytest internal practice.
+
+- **mypy `--ignore-missing-imports`** — mypy avoids the problem entirely by never executing imports at runtime; it reads `.pyi` stubs and source AST only. Its `stubgen` tool ([source](https://github.com/python/mypy/blob/master/mypy/stubgen.py)) generates stubs without importing, which is why mypy recommends shipping `.pyi` files rather than runtime stubs. The mypy recommendation for library authors is explicit: stub out optional heavy dependencies in `.pyi` files so type checkers never need to import them ([mypy docs: missing stubs](https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports)).
+
+### Disadvantages
+
+- **Stubs all unknown modules unconditionally.** If a pipeline module tries to import a package that is simply misspelled or not yet installed intentionally, the stub silently succeeds rather than raising `ImportError`. The AST-scan approach only mocks modules it actively found in source files, which limits the blast radius.
+
+- **Module-level computed values become `_MockObject`.** Any expression that evaluates a mocked attribute at import time — e.g., `CLASSES = sklearn.utils.all_estimators()` — will store a `_MockObject` instead of the real list. If `register_pipelines` or `create_pipeline` reads that value to build pipeline structure, the result may be wrong. The AST-scan approach has the same weakness, but it is explicit about which packages are affected.
+
+- **Harder to audit.** With AST scanning, the set of mocked modules is computed and logged before the import runs (`log.debug("Mocking %d missing …")`). With the catch-all finder it is only known after the import completes, which makes debugging missing-dep issues less transparent.
+
+- **Thread safety.** Mutating `sys.meta_path` is not thread-safe. In a multi-threaded server (e.g. FastAPI startup), concurrent imports during the `with safe_context_v2()` block could interact with the catch-all finder unexpectedly. The AST-scan approach mutates `sys.modules` via `patch.dict`, which has the same caveat.
+
+
+---
+
+## Solution 3 — Generated Pipeline Manifest
+
+Both `lite_shim` approaches above still execute Python imports (with mocked deps). A fundamentally different approach sidesteps the import chain entirely: **compute the pipeline structure once, serialize it, and serve read-only commands from the serialized form**.
+
+This is the pattern used by build tools and package managers that separate a "build phase" (expensive, executes code) from a "query phase" (cheap, reads metadata):
+
+| Tool | Build phase | Query phase |
+|---|---|---|
+| `cargo` | `cargo build` | `cargo metadata` reads `Cargo.lock` |
+| `npm` | `npm install` | `npm list` reads `package-lock.json` |
+| CMake | `cmake ..` | reads `CMakeCache.txt` |
+| **Kedro (proposed)** | `kedro inspect` | `registry list/describe` reads `.kedro/pipeline_manifest.json` |
+
+### How it works
+
+#### Step 1 — Generate the manifest via `kedro inspect`
+
+The manifest already has a natural generation point: **`kedro inspect`** (`kedro.inspection.get_project_snapshot`). This existing API initialises the project, loads all pipelines and configuration, and returns a [`ProjectSnapshot`](../inspect/inspect-project.md) — a dataclass that contains exactly the structure `registry list` and `registry describe` need: pipeline names, nodes, inputs, outputs, tags, datasets, and parameter keys.
+
+Serializing it to disk is straightforward because `ProjectSnapshot` and its nested types are plain dataclasses:
+
+```python
+# kedro/framework/project/_manifest.py
+import dataclasses
+import json
+from pathlib import Path
+
+from kedro.inspection import get_project_snapshot
+
+_MANIFEST_PATH = Path(".kedro") / "pipeline_manifest.json"
+
+
+def write_manifest(project_path: Path) -> None:
+    snapshot = get_project_snapshot(project_path)
+    payload = {
+        "schema_version": 1,
+        **dataclasses.asdict(snapshot),
+    }
+    _MANIFEST_PATH.parent.mkdir(exist_ok=True)
+    _MANIFEST_PATH.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+```
+
+`kedro inspect` is the single authoritative source: it already handles environment resolution, catalog loading, and pipeline registration. No parallel serialization logic is needed — the manifest is just a persisted `ProjectSnapshot`.
+
+The `kedro inspect` command can be run explicitly before inspection-only CI steps, or automatically as a post-hook after `kedro run` succeeds.
+
+#### Step 2 — Read-only commands consume the manifest
+
+`kedro registry list` and `kedro registry describe` check for the manifest first. If present and fresh, they read it directly — zero imports, zero mocking:
+
+```python
+def load_manifest() -> dict | None:
+    if not _MANIFEST_PATH.exists():
+        return None
+    return json.loads(_MANIFEST_PATH.read_text(encoding="utf-8"))
+```
+
+#### Step 3 — Freshness check (optional but recommended)
+
+Hash the pipeline source files at write time and re-check at read time. If the hash has changed, warn the user that the manifest is stale:
+
+```python
+import hashlib
+
+def _source_hash(package_name: str) -> str:
+    spec = importlib.util.find_spec(package_name)
+    package_dir = Path(spec.submodule_search_locations[0])
+    h = hashlib.sha256()
+    for path in sorted(package_dir.rglob("*.py")):
+        h.update(path.read_bytes())
+    return h.hexdigest()
+
+# Stored in the manifest JSON:
+# { "source_hash": "a3f2...", "pipelines": { ... } }
+```
+
+If `source_hash` differs, the CLI can either fall back to the live import path or print a clear warning:
+
+```
+Warning: pipeline_manifest.json is stale (source files changed).
+Run 'kedro inspect' to refresh, or install all project dependencies to load live.
+```
+
+### What the manifest covers
+
+`ProjectSnapshot` already contains everything `registry list`, `registry describe`, and `catalog describe-datasets` need — it was designed for exactly this kind of read-only introspection. See [`inspect-project.md`](../inspect/inspect-project.md) for the full schema.
+
+| CLI command | Served from manifest? | `ProjectSnapshot` field |
+|---|---|---|
+| `kedro registry list` | **Yes** | `snapshot.pipelines[*].name` |
+| `kedro registry describe --pipeline data_science` | **Yes** | `snapshot.pipelines[*].nodes` (name, inputs, outputs, tags) |
+| `kedro catalog describe-datasets` | **Yes** | `snapshot.datasets` (type, filepath) |
+| `kedro run` | **No** — always loads live; manifest is never used for execution | — |
+
+### Prior Usage
+
+- **`cargo metadata`** ([docs](https://doc.rust-lang.org/cargo/commands/cargo-metadata.html)) — outputs JSON describing the full workspace graph without building. Cargo computes this from `Cargo.toml` and `Cargo.lock`, never by executing Rust code.
+- **`npm pack --dry-run` / `npm list`** ([docs](https://docs.npmjs.com/cli/v10/commands/npm-list)) — queries the installed package graph from `node_modules/.package-lock.json` without executing any JavaScript.
+- **`pip inspect`** ([PEP 566](https://peps.python.org/pep-0566/), added in pip 22.2) — returns installed package metadata as JSON by reading wheel `.dist-info` directories, never importing the packages.
+- **pytest `--collect-only`** ([docs](https://docs.pytest.org/en/stable/how-to/usage.html#calling-pytest-through-python-m-pytest)) — collects test structure by importing test modules, but the conceptual separation (collection vs execution) is the same principle. Many CI pipelines cache the collection output separately from the run output.
+
+### Disadvantages
+
+- **Staleness.** The manifest reflects the last time pipelines were successfully loaded. If a user edits pipeline code and immediately runs `kedro registry list`, they see the old structure unless they re-run `kedro manifest build` or have the freshness check in place.
+- **Requires a successful prior import.** The first time a project is set up, or after installing a new heavy dependency, the manifest does not yet exist. The CLI must fall back to the import path (with mocking) for the first run, or instruct the user to run `kedro manifest build` first.
+- **Catalog serialization is harder.** `DataCatalog` entries can be parameterized via `globals.yml`, Jinja2 templates, and runtime credentials. Serializing a fully-resolved catalog to JSON is non-trivial and may expose secrets.
+- **New surface area.** Introduces a new command, a new file format, a schema version, and a migration story when the schema changes.
+
+### Summary
+
+The manifest approach is the only alternative that is **both truly import-free and covers `registry describe`**. It is the right long-term architecture if Kedro wants to fully decouple read-only CLI tooling from the project's Python environment. The main cost is the staleness problem and the cold-start requirement.
+
+For the import-with-mocking tier (`lite_shim` or `sys.meta_path`), which remains the fallback when no fresh manifest exists: the `sys.meta_path` catch-all is strictly more robust than AST scanning for catching transitive and dynamic imports, at the cost of silently succeeding on misspelled package names. The AST-scan approach was chosen for the initial implementation because it produces an explicit, auditable list of what was mocked. Either can replace the other; the integration point in `_load_data()` is identical.
+
+A practical incremental path that combines all three tiers:
+
+1. Serialize the `ProjectSnapshot` to `.kedro/pipeline_manifest.json` automatically after every successful `kedro run` (post-hook) and after every explicit `kedro inspect` call.
+2. `registry list` and `registry describe` consume the manifest when present and fresh — zero imports, zero mocking.
+3. When the manifest is absent or stale, fall back to `lite_shim` (or `sys.meta_path`) to load live with mocked deps.

--- a/docs/scenario_2_dep_free_commands.md
+++ b/docs/scenario_2_dep_free_commands.md
@@ -4,197 +4,134 @@
 
 **Goal:** Read-only CLI commands (`kedro registry list`, `kedro registry describe`, `kedro catalog describe-datasets`, inspection API) should function even when heavy project dependencies (sklearn, torch, seaborn) are not installed.
 
-Three approaches address different layers of the stack — they are complementary, not mutually exclusive.
+---
+
+## Why This Is Hard
+
+The import chain fires before any framework filter can intervene:
+
+```
+pipeline_registry.py
+  → from my_project.pipelines.reporting import create_pipeline
+  → reporting/pipeline.py
+  → from .nodes import train_model
+  → reporting/nodes.py
+  → import seaborn          ← ModuleNotFoundError here
+```
+
+There is no hook between "load the pipeline registry" and "import seaborn" that the framework can exploit without changing user code.
 
 ---
 
-## Approach A — Defer `inspect.signature()` to `Node.run()`
+## Solution — `lite_shim`: AST Scan + `sys.modules` Mock
 
-**Commands:** `kedro registry describe X`, `kedro catalog describe-datasets -p X`, inspection API
+Stub the **missing dependency itself** before any pipeline code is loaded. When `nodes.py` runs `import seaborn`, Python checks `sys.modules["seaborn"]` first — if a mock is already there, the import is a no-op. The pipeline loads, `create_pipeline()` runs, the `Pipeline` structure is fully populated, and seaborn is never executed.
 
-For commands that construct `Pipeline` and `Node` objects but never execute them, the `inspect.signature()` call in `Node.__init__()` serves no purpose — it validates inputs against the function signature, which is only meaningful at execution time. Moving it to `Node.run()` means non-execution commands never trigger it.
+### Step 1 — AST-scan pipeline source files
 
-```python
-# kedro/pipeline/node.py — BEFORE
-def __init__(self, func, inputs, outputs, ...):
-    ...
-    self._validate_inputs(func, inputs)  # ← runs immediately, forces function module import
-    self._func = func
-
-# kedro/pipeline/node.py — AFTER
-def __init__(self, func, inputs, outputs, ...):
-    ...
-    self._func = func
-    self._inputs = inputs
-    self._inputs_validated = False  # NEW
-    # Structural checks that don't require imports still run eagerly:
-    self._validate_unique_outputs()
-    self._validate_inputs_dif_than_outputs()
-
-def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
-    if not self._inputs_validated:
-        self._validate_inputs(self._func, self._inputs)  # func's module is loaded by now
-        self._inputs_validated = True
-    ...
-```
-
-Expose an explicit `validate()` for test suites and dry-runs that want eager validation:
+Parse every `pipelines/**/*.py` file and collect all **absolute** import names. Relative imports (`from .nodes import train_model`, `level > 0`) are explicitly excluded — they are project-internal and must never be mocked.
 
 ```python
-def validate(self) -> None:
-    """Validate inputs against the function signature.
-    Called automatically on first run(). Can be called earlier for dry-runs or tests.
-    """
-    self._validate_inputs(self._func, self._inputs)
-    self._inputs_validated = True
+def _collect_imports_from_file(file_path: Path) -> set[str]:
+    source = file_path.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    modules: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if not alias.name.startswith("_"):
+                    modules.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            # level==0 means absolute import; skip relative imports (level > 0)
+            if node.module and not node.module.startswith("_") and node.level == 0:
+                modules.add(node.module)
+    return modules
 ```
 
-> **Key insight:** With Approach A, `inspect.signature()` is never called for commands like `registry describe` since `node.run()` is never invoked. However, `from nodes import train_model` at the top of `pipeline.py` still fires when `pipeline.py` is loaded. Only the signature validation overhead is eliminated — not the module import itself.
+### Step 2 — Filter to genuinely missing modules
+
+Check each candidate against `sys.modules`. Standard library modules (`os`, `re`, `datetime`, `functools`, …) are always loaded at Python startup and are always in `sys.modules` — they are filtered out implicitly. Only truly absent third-party packages remain.
+
+```python
+def _get_missing_modules(candidate_imports: set[str]) -> set[str]:
+    missing: set[str] = set()
+    for full_name in candidate_imports:
+        for part in _iter_parts(full_name):   # e.g. "sklearn.base" → ["sklearn", "sklearn.base"]
+            if part not in sys.modules:
+                missing.add(part)
+    return missing
+```
+
+Kedro's own packages (`kedro`, the project package itself) and known required deps (`yaml`) are excluded by a skip-list before this check, so they are never candidates for mocking.
+
+### Step 3 — Pre-populate `sys.modules` with `MagicMock`
+
+`MagicMock` is used rather than a plain `types.ModuleType` because it handles transitive attribute access automatically — `seaborn.lineplot(...)`, `torch.nn.Linear(10, 10)`, `sklearn.preprocessing.StandardScaler()` all return further `MagicMock` instances without raising `AttributeError`. Parent packages are given `__path__=[]` so the import system treats them as packages and submodule imports like `from sklearn.base import BaseEstimator` succeed.
+
+```python
+def _create_mock_modules(module_names: set[str]) -> dict[str, MagicMock]:
+    result: dict[str, MagicMock] = {}
+    for name in sorted(module_names):
+        for part in _iter_parts(name):
+            if part in result:
+                continue
+            is_package = "." not in part or any(
+                p != part and p.startswith(part + ".") for p in module_names
+            )
+            mock = MagicMock(__path__=[]) if is_package else MagicMock()
+            mock.__spec__ = importlib.machinery.ModuleSpec(part, None, is_package=is_package)
+            result[part] = mock
+    return result
+```
+
+### Step 4 — Scope with `patch.dict`
+
+`unittest.mock.patch.dict` installs the mocks and restores `sys.modules` exactly to its prior state on exit. No manual cleanup loop required.
+
+```python
+@contextmanager
+def safe_context(
+    project_path: Path | str, package_name: str
+) -> Generator[set[str], None, None]:
+    candidate_imports = _collect_pipeline_imports(project_path, package_name)
+    skip_prefixes = ("kedro", "importlib", "pathlib", "typing",
+                     "collections", "json", "yaml", package_name)
+    candidates = {
+        n for n in candidate_imports
+        if not any(n == p or n.startswith(p + ".") for p in skip_prefixes)
+    }
+    missing_modules = _get_missing_modules(candidates)
+    mock_modules = _create_mock_modules(missing_modules) if missing_modules else {}
+    with patch.dict("sys.modules", {**sys.modules, **mock_modules}, clear=False):
+        yield missing_modules
+```
 
 ---
 
-## Approach B — `sys.meta_path` Stubs for Missing Dependencies
+## Integration Points
 
-**When to use:** Project dependencies are genuinely not installed (e.g., `kedro run -p data_ingestion` when `seaborn` — required only by `reporting` — is absent).
-
-**Why Scenario 1 alone doesn't cover this:** The error occurs at `importlib.import_module(pipeline_registry_module)` inside `_get_pipelines_registry_callable` — importing `pipeline_registry.py` itself — before `find_pipelines()` or any filter can intervene:
-
-```python
-# pipeline_registry.py
-from my_project.pipelines.reporting import create_pipeline  # ← seaborn imported here
-# ↑ fires when pipeline_registry.py is imported, before register_pipelines() is called
-```
-
-**Fix:** Install a scoped `sys.meta_path` hook inside `_load_data()` that intercepts imports of non-requested pipeline sub-packages and returns stubs, preventing their dependencies from ever being needed.
+`safe_context` should wrap the `register_pipelines()` call inside `_load_data()` when the command is inspection-only (no runner active):
 
 ```python
 # kedro/framework/project/__init__.py
-
-@contextlib.contextmanager
-def _stub_non_requested_pipelines(package_name: str, requested: set[str] | None):
-    """Intercept imports of non-requested pipeline sub-packages during _load_data()
-    and return stubs so their dependencies are never needed."""
-    if requested is None or package_name is None:
-        yield
-        return
-
-    prefix = f"{package_name}.pipelines."
-
-    class _StubFinder(importlib.abc.MetaPathFinder):
-        def find_spec(self, fullname, path, target=None):
-            if not fullname.startswith(prefix):
-                return None
-            pipeline_name = fullname[len(prefix):].split(".")[0]
-            if pipeline_name not in requested:
-                return importlib.machinery.ModuleSpec(fullname, _StubLoader())
-            return None
-
-    class _StubLoader(importlib.abc.Loader):
-        def create_module(self, spec):
-            return types.ModuleType(spec.name)
-        def exec_module(self, module):
-            module.create_pipeline = lambda **kwargs: pipeline([])
-
-    finder = _StubFinder()
-    sys.meta_path.insert(0, finder)
-    try:
-        yield
-    finally:
-        sys.meta_path.remove(finder)
-        # Clean up so a subsequent full load works correctly
-        for key in list(sys.modules):
-            if key.startswith(prefix):
-                if key[len(prefix):].split(".")[0] not in (requested or set()):
-                    del sys.modules[key]
-```
-
-`_load_data()` activates the stub before importing `pipeline_registry.py`:
-
-```python
 def _load_data(self) -> None:
     if self._pipelines_module is None or self._is_data_loaded:
         return
 
-    requested = set(self._requested_pipelines) if self._requested_pipelines else None
+    if self._inspection_mode:
+        ctx = safe_context(PROJECT_PATH, PACKAGE_NAME)
+    else:
+        ctx = contextlib.nullcontext(set())
 
-    with _stub_non_requested_pipelines(PACKAGE_NAME, requested):
+    with ctx as mocked_deps:
         register_pipelines = self._get_pipelines_registry_callable(
-            self._pipelines_module          # ← pipeline_registry.py imported here
-        )                                   #   top-level imports hit stubs, not real modules
+            self._pipelines_module
+        )
         project_pipelines = register_pipelines()
 
     self._content = project_pipelines
+    self._mocked_dependencies = mocked_deps
     self._is_data_loaded = True
 ```
 
-**Trace through the failing scenario (`seaborn` not installed):**
-
-1. CLI: `kedro run -p data_ingestion` → `pipelines.set_requested(["data_ingestion"])`
-2. `pipelines["data_ingestion"]` triggers `_load_data()`
-3. Stub hook installed — intercepts `my_project.pipelines.reporting.*`, etc.
-4. `importlib.import_module("my_project.pipeline_registry")` runs
-5. `from my_project.pipelines.reporting import create_pipeline` → stub returns `lambda **kwargs: Pipeline([])` — **no seaborn import**
-6. `from my_project.pipelines.data_ingestion import create_pipeline` → not stubbed, real module loads normally
-7. `register_pipelines()` runs — stubs return empty pipelines for non-requested entries
-8. Stub hook removed, stubbed modules cleaned from `sys.modules`
-
-**Trade-offs:**
-- Works for **any** `register_pipelines` pattern — no user code changes needed
-- Scoped tightly to `_load_data()` — installed and removed in the same call
-- Stub cleanup ensures a subsequent full `kedro run` (no `--pipeline`) still loads everything correctly
-- Non-requested entries in the returned dict are empty `Pipeline([])` — acceptable since they are never accessed in a targeted run
-
----
-
-## Approach C — String Function References in `Node` (future)
-
-Accept a dotted string path as `func`, deferring both the module import and signature inspection until `node.run()`. This is the deepest level of lazy loading — even `nodes.py` is not imported until execution.
-
-```python
-# kedro/pipeline/node.py — future
-
-class Node:
-    def __init__(self, func: Callable | str, inputs, outputs, ...):
-        if isinstance(func, str):
-            self._func_path = func
-            self._func: Callable | None = None
-            # No import, no inspect.signature — deferred entirely
-        else:
-            self._func_path = None
-            self._func = func
-            self._validate_inputs(func, inputs)  # still eager for live callables
-
-    @property
-    def func(self) -> Callable:
-        """Resolve the function, importing its module on first access."""
-        if self._func is None:
-            module_path, func_name = self._func_path.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            self._func = getattr(module, func_name)
-        return self._func
-
-    def run(self, inputs):
-        result = self.func(...)  # .func resolves + imports here
-```
-
-Usage:
-
-```python
-# BEFORE — eager import at module load
-from my_project.pipelines.data_science.nodes import train_model
-
-def create_pipeline(**kwargs):
-    return pipeline([node(train_model, inputs="X_train", outputs="model")])
-
-# AFTER — deferred via string reference
-def create_pipeline(**kwargs):
-    return pipeline([
-        node(
-            "my_project.pipelines.data_science.nodes.train_model",
-            inputs="X_train",
-            outputs="model",
-        )
-    ])
-```
-
-> **Potential breaking API change.** Key design questions before shipping: backwards compatibility with live callables (must be unchanged), error surfacing (import errors surface at `node.run()` not `Pipeline()` construction — needs clear messages), `node.name` auto-derivation (today from `func.__name__`, needs a fallback for strings), IDE/type-checking support (string paths lose navigation), and `kedro-viz`/inspection tool compatibility.
+CLI commands that are inspection-only (`registry list`, `registry describe`, `catalog describe-datasets`) set `inspection_mode=True` before triggering `_load_data()`. Run commands never set it.

--- a/docs/scenario_2_dep_free_commands.md
+++ b/docs/scenario_2_dep_free_commands.md
@@ -1,0 +1,295 @@
+# Scenario 2 — CLI Commands Without Project Dependencies
+
+**Part of spike [#5406](https://github.com/kedro-org/kedro/issues/5406) · [← Scenario 1](scenario_1_selective_loading.md) · [← Overview](on_demand_dependency_loading.md)**
+
+**Goal:** Read-only CLI commands (`kedro registry list`, `kedro registry describe`, `kedro catalog describe-datasets`, inspection API) should function even when heavy project dependencies (sklearn, torch, seaborn) are not installed.
+
+Four approaches address different layers of the stack — they are complementary, not mutually exclusive.
+
+---
+
+## Approach A — Filesystem-based Name Discovery
+
+**Command:** `kedro registry list`
+
+`kedro registry list` only needs pipeline names — no `Pipeline` or `Node` objects. Today iterating `pipelines` triggers `_load_data()`, constructing every `Node` and calling `inspect.signature()` on every function just to print names.
+
+`list_names()` bypasses `_load_data()` entirely by scanning the filesystem directly.
+
+> **Why not `importlib.resources.files()`?** It calls `importlib.import_module()` internally, which would import `my_project.pipelines`. `importlib.util.find_spec()` locates the package on disk without importing it.
+
+```python
+# kedro/framework/project/__init__.py — new method on _ProjectPipelines
+
+def list_names(self) -> list[str]:
+    """Return pipeline names by scanning the filesystem — no imports."""
+    spec = importlib.util.find_spec(PACKAGE_NAME)
+    if spec is None or spec.origin is None:
+        return list(self.keys())  # fallback to full load
+
+    pipelines_path = Path(spec.origin).parent / "pipelines"
+    if not pipelines_path.is_dir():
+        return list(self.keys())  # non-standard layout — fallback
+
+    names = [
+        d.name for d in pipelines_path.iterdir()
+        if d.is_dir() and not d.name.startswith(".") and d.name != "__pycache__"
+    ]
+    return sorted(["__default__", *names])
+```
+
+`list_names()` is **not** wrapped by `_load_data_wrapper`, so calling it never triggers `_load_data()`.
+
+```python
+# kedro/framework/cli/registry.py — AFTER
+@registry.command("list")
+def list_registered_pipelines() -> None:
+    click.echo(yaml.dump(pipelines.list_names()))  # zero imports
+```
+
+---
+
+## Approach B — Defer `inspect.signature()` to `Node.run()`
+
+**Commands:** `kedro registry describe X`, `kedro catalog describe-datasets -p X`, inspection API
+
+For commands that construct `Pipeline` and `Node` objects but never execute them, the `inspect.signature()` call in `Node.__init__()` serves no purpose — it validates inputs against the function signature, which is only meaningful at execution time. Moving it to `Node.run()` means non-execution commands never trigger it.
+
+```python
+# kedro/pipeline/node.py — BEFORE
+def __init__(self, func, inputs, outputs, ...):
+    ...
+    self._validate_inputs(func, inputs)  # ← runs immediately, forces function module import
+    self._func = func
+
+# kedro/pipeline/node.py — AFTER
+def __init__(self, func, inputs, outputs, ...):
+    ...
+    self._func = func
+    self._inputs = inputs
+    self._inputs_validated = False  # NEW
+    # Structural checks that don't require imports still run eagerly:
+    self._validate_unique_outputs()
+    self._validate_inputs_dif_than_outputs()
+
+def run(self, inputs: dict[str, Any]) -> dict[str, Any]:
+    if not self._inputs_validated:
+        self._validate_inputs(self._func, self._inputs)  # func's module is loaded by now
+        self._inputs_validated = True
+    ...
+```
+
+Expose an explicit `validate()` for test suites and dry-runs that want eager validation:
+
+```python
+def validate(self) -> None:
+    """Validate inputs against the function signature.
+    Called automatically on first run(). Can be called earlier for dry-runs or tests.
+    """
+    self._validate_inputs(self._func, self._inputs)
+    self._inputs_validated = True
+```
+
+**What each combination defers:**
+
+| Approaches applied | What still loads at pipeline construction | What is deferred |
+|-------------------|-------------------------------------------|-----------------|
+| Scenario 1 only | Only X's `pipeline.py` → `nodes.py` → `sklearn` | All other pipelines' modules |
+| Scenario 1 + Approach B | Only X's `pipeline.py` → `nodes.py` → `sklearn` | `inspect.signature()` — never runs for non-execution commands |
+| Scenario 1 + Approach B + Approach D | Nothing at construction | Both `nodes.py` import and `inspect.signature()` |
+
+> **Key insight:** With Approach B, `inspect.signature()` is never called for commands like `registry describe` since `node.run()` is never invoked. However, `from nodes import train_model` at the top of `pipeline.py` still fires when `pipeline.py` is loaded. Only the signature validation overhead is eliminated — not the module import itself.
+
+---
+
+## Approach C — `sys.meta_path` Stubs for Missing Dependencies
+
+**When to use:** Project dependencies are genuinely not installed (e.g., `kedro run -p data_ingestion` when `seaborn` — required only by `reporting` — is absent).
+
+**Why Scenario 1 alone doesn't cover this:** The error occurs at `importlib.import_module(pipeline_registry_module)` inside `_get_pipelines_registry_callable` — importing `pipeline_registry.py` itself — before `find_pipelines()` or any filter can intervene:
+
+```python
+# pipeline_registry.py
+from my_project.pipelines.reporting import create_pipeline  # ← seaborn imported here
+# ↑ fires when pipeline_registry.py is imported, before register_pipelines() is called
+```
+
+**Fix:** Install a scoped `sys.meta_path` hook inside `_load_data()` that intercepts imports of non-requested pipeline sub-packages and returns stubs, preventing their dependencies from ever being needed.
+
+```python
+# kedro/framework/project/__init__.py
+
+@contextlib.contextmanager
+def _stub_non_requested_pipelines(package_name: str, requested: set[str] | None):
+    """Intercept imports of non-requested pipeline sub-packages during _load_data()
+    and return stubs so their dependencies are never needed."""
+    if requested is None or package_name is None:
+        yield
+        return
+
+    prefix = f"{package_name}.pipelines."
+
+    class _StubFinder(importlib.abc.MetaPathFinder):
+        def find_spec(self, fullname, path, target=None):
+            if not fullname.startswith(prefix):
+                return None
+            pipeline_name = fullname[len(prefix):].split(".")[0]
+            if pipeline_name not in requested:
+                return importlib.machinery.ModuleSpec(fullname, _StubLoader())
+            return None
+
+    class _StubLoader(importlib.abc.Loader):
+        def create_module(self, spec):
+            return types.ModuleType(spec.name)
+        def exec_module(self, module):
+            module.create_pipeline = lambda **kwargs: pipeline([])
+
+    finder = _StubFinder()
+    sys.meta_path.insert(0, finder)
+    try:
+        yield
+    finally:
+        sys.meta_path.remove(finder)
+        # Clean up so a subsequent full load works correctly
+        for key in list(sys.modules):
+            if key.startswith(prefix):
+                if key[len(prefix):].split(".")[0] not in (requested or set()):
+                    del sys.modules[key]
+```
+
+`_load_data()` activates the stub before importing `pipeline_registry.py`:
+
+```python
+def _load_data(self) -> None:
+    if self._pipelines_module is None or self._is_data_loaded:
+        return
+
+    requested = set(self._requested_pipelines) if self._requested_pipelines else None
+
+    with _stub_non_requested_pipelines(PACKAGE_NAME, requested):
+        register_pipelines = self._get_pipelines_registry_callable(
+            self._pipelines_module          # ← pipeline_registry.py imported here
+        )                                   #   top-level imports hit stubs, not real modules
+        project_pipelines = register_pipelines()
+
+    self._content = project_pipelines
+    self._is_data_loaded = True
+```
+
+**Trace through the failing scenario (`seaborn` not installed):**
+
+1. CLI: `kedro run -p data_ingestion` → `pipelines.set_requested(["data_ingestion"])`
+2. `pipelines["data_ingestion"]` triggers `_load_data()`
+3. Stub hook installed — intercepts `my_project.pipelines.reporting.*`, etc.
+4. `importlib.import_module("my_project.pipeline_registry")` runs
+5. `from my_project.pipelines.reporting import create_pipeline` → stub returns `lambda **kwargs: Pipeline([])` — **no seaborn import**
+6. `from my_project.pipelines.data_ingestion import create_pipeline` → not stubbed, real module loads normally
+7. `register_pipelines()` runs — stubs return empty pipelines for non-requested entries
+8. Stub hook removed, stubbed modules cleaned from `sys.modules`
+
+**Trade-offs:**
+- Works for **any** `register_pipelines` pattern — no user code changes needed
+- Scoped tightly to `_load_data()` — installed and removed in the same call
+- Stub cleanup ensures a subsequent full `kedro run` (no `--pipeline`) still loads everything correctly
+- Non-requested entries in the returned dict are empty `Pipeline([])` — acceptable since they are never accessed in a targeted run
+
+---
+
+## Approach D — String Function References in `Node` (future)
+
+Accept a dotted string path as `func`, deferring both the module import and signature inspection until `node.run()`. This is the deepest level of lazy loading — even `nodes.py` is not imported until execution.
+
+```python
+# kedro/pipeline/node.py — future
+
+class Node:
+    def __init__(self, func: Callable | str, inputs, outputs, ...):
+        if isinstance(func, str):
+            self._func_path = func
+            self._func: Callable | None = None
+            # No import, no inspect.signature — deferred entirely
+        else:
+            self._func_path = None
+            self._func = func
+            self._validate_inputs(func, inputs)  # still eager for live callables
+
+    @property
+    def func(self) -> Callable:
+        """Resolve the function, importing its module on first access."""
+        if self._func is None:
+            module_path, func_name = self._func_path.rsplit(".", 1)
+            module = importlib.import_module(module_path)
+            self._func = getattr(module, func_name)
+        return self._func
+
+    def run(self, inputs):
+        result = self.func(...)  # .func resolves + imports here
+```
+
+Usage:
+
+```python
+# BEFORE — eager import at module load
+from my_project.pipelines.data_science.nodes import train_model
+
+def create_pipeline(**kwargs):
+    return pipeline([node(train_model, inputs="X_train", outputs="model")])
+
+# AFTER — deferred via string reference
+def create_pipeline(**kwargs):
+    return pipeline([
+        node(
+            "my_project.pipelines.data_science.nodes.train_model",
+            inputs="X_train",
+            outputs="model",
+        )
+    ])
+```
+
+> **Potential breaking API change.** Key design questions before shipping: backwards compatibility with live callables (must be unchanged), error surfacing (import errors surface at `node.run()` not `Pipeline()` construction — needs clear messages), `node.name` auto-derivation (today from `func.__name__`, needs a fallback for strings), IDE/type-checking support (string paths lose navigation), and `kedro-viz`/inspection tool compatibility.
+
+---
+
+## Implementation Roadmap
+
+```mermaid
+gantt
+    title Scenario 2 — Implementation Phases
+    dateFormat  YYYY-MM-DD
+    section Low Risk
+    Approach A: list_names() for registry list   :s2a, 2026-04-20, 2d
+    section Medium Risk
+    Approach B: Defer inspect.signature()        :s2b, 2026-04-23, 5d
+    Approach C: sys.meta_path stubs              :s2c, after s2b, 5d
+    section High Risk
+    Approach D: String function references       :s2d, after s2c, 10d
+```
+
+### Dependency Graph
+
+```mermaid
+flowchart LR
+    S2A["Approach A\nlist_names()"]
+    S2B["Approach B\nDefer inspect.signature()"]
+    S2C["Approach C\nsys.meta_path stubs"]
+    S2D["Approach D\nString function references"]
+
+    S2B --> S2C
+    S2B --> S2D
+
+    style S2A fill:#4caf50,color:#fff
+    style S2B fill:#2196f3,color:#fff
+    style S2C fill:#2196f3,color:#fff
+    style S2D fill:#9c27b0,color:#fff
+```
+
+Approach A is fully independent. B must land before C or D (C/D both rely on the lazy-validation infrastructure B introduces).
+
+### Risk Assessment
+
+| Approach | Risk | Mitigation |
+|----------|------|-----------|
+| A: `list_names()` | Low — purely additive; never triggers `_load_data()` | Falls back to full load for non-standard layouts |
+| B: Defer `inspect.signature()` | Medium — `TypeError` surfaces at `node.run()` not construction | Expose explicit `node.validate()` for dry-runs and test suites |
+| C: `sys.meta_path` stubs | Medium — mutations to `sys.meta_path` can have subtle side effects | Scoped tightly to `_load_data()` with cleanup in `finally`; stub modules removed post-load |
+| D: String function references | High — API change, affects IDE tooling, kedro-viz | Gate behind feature flag; maintain backward compatibility with live callables |

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -9,7 +9,7 @@ import yaml
 from click import secho
 
 from kedro.framework.cli.utils import env_option, split_string
-from kedro.framework.project import settings
+from kedro.framework.project import pipelines, settings
 
 if TYPE_CHECKING:
     from kedro.framework.startup import ProjectMetadata
@@ -52,6 +52,9 @@ def describe_datasets(metadata: ProjectMetadata, pipeline: str, env: str) -> Non
     - `factories`: Datasets resolved from dataset factory patterns.\n
     - `defaults`: Datasets that do not match any pattern or explicit definition.\n
     """
+    if pipeline:
+        pipelines.set_requested(pipeline)
+
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 
@@ -97,6 +100,9 @@ def resolve_patterns(metadata: ProjectMetadata, pipeline: str, env: str) -> None
     It includes datasets explicitly defined in the catalog as well as those resolved
     from dataset factory patterns.
     """
+    if pipeline:
+        pipelines.set_requested(pipeline)
+
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 

--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -35,6 +35,7 @@ def describe_registered_pipeline(
     """Describe a registered pipeline by providing a pipeline name.
     Defaults to the `__default__` pipeline.
     """
+    pipelines.set_requested([name])
     pipeline_obj = pipelines.get(name)
     if not pipeline_obj:
         all_pipeline_names = pipelines.keys()

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -201,6 +201,16 @@ class _ProjectPipelines(MutableMapping):
         self._pipelines_module: str | None = None
         self._is_data_loaded = False
         self._content: dict[str, Pipeline] = {}
+        self._requested_pipelines: list[str] | None = None
+
+    def set_requested(self, pipeline_names: list[str] | None) -> None:
+        """Set which pipelines are needed before first dict access.
+        Invalidates the cache if the filter changes.
+        """
+        if self._requested_pipelines != pipeline_names:
+            self._is_data_loaded = False
+            self._content = {}
+        self._requested_pipelines = pipeline_names
 
     @staticmethod
     def _get_pipelines_registry_callable(pipelines_module: str) -> Any:
@@ -457,7 +467,87 @@ def _create_pipeline(pipeline_module: types.ModuleType) -> Pipeline | None:
     return obj
 
 
-def find_pipelines(  # noqa: PLR0912, PLR0915
+def _load_default_pipeline(raise_errors: bool) -> Pipeline:
+    """Load the pipeline from the simplified single-file project structure."""
+    pipeline_module_name = f"{PACKAGE_NAME}.pipeline"
+    try:
+        pipeline_module = importlib.import_module(pipeline_module_name)
+    except Exception as exc:
+        if str(exc) != f"No module named '{pipeline_module_name}'":
+            if raise_errors:
+                raise ImportError(
+                    f"An error occurred while importing the '{pipeline_module_name}' module."
+                ) from exc
+            warnings.warn(
+                IMPORT_ERROR_MESSAGE.format(
+                    module=pipeline_module_name, tb_exc=traceback.format_exc()
+                )
+            )
+        return pipeline([])
+    return _create_pipeline(pipeline_module) or pipeline([])
+
+
+def _load_modular_pipelines(
+    pipelines_package: importlib.resources.abc.Traversable,
+    pipeline_filter: set[str] | None,
+    pipelines_dict: dict[str, Pipeline],
+    raise_errors: bool,
+) -> set[str]:
+    """Import each pipeline subdirectory, populating *pipelines_dict* in place.
+
+    Returns the set of pipeline names that were actually discovered on disk.
+    """
+    seen: set[str] = set()
+    for pipeline_dir in pipelines_package.iterdir():
+        if not pipeline_dir.is_dir():
+            continue
+        pipeline_name = pipeline_dir.name
+        if pipeline_name == "__pycache__" or pipeline_name.startswith("."):
+            continue
+        if pipeline_filter is not None and pipeline_name not in pipeline_filter:
+            continue
+
+        seen.add(pipeline_name)
+        pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
+        try:
+            pipeline_module = importlib.import_module(pipeline_module_name)
+        except Exception as exc:
+            if raise_errors:
+                raise ImportError(
+                    f"An error occurred while importing the '{pipeline_module_name}' module."
+                ) from exc
+            warnings.warn(
+                IMPORT_ERROR_MESSAGE.format(
+                    module=pipeline_module_name, tb_exc=traceback.format_exc()
+                )
+            )
+            continue
+
+        pipeline_obj = _create_pipeline(pipeline_module)
+        if pipeline_obj is not None:
+            pipelines_dict[pipeline_name] = pipeline_obj
+        elif raise_errors:
+            raise KeyError(f"Pipeline '{pipeline_name}' not found")
+
+    return seen
+
+
+def _report_missing_pipelines(
+    pipeline_filter: set[str], seen: set[str], raise_errors: bool
+) -> None:
+    """Warn or raise for each pipeline that was requested but not found on disk."""
+    for pipeline_name in sorted(pipeline_filter - seen):
+        pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
+        error_msg = (
+            f"An error occurred while importing the '{pipeline_module_name}' module. "
+            f"Nothing defined therein will be returned by 'find_pipelines'."
+        )
+        if raise_errors:
+            raise ImportError(error_msg)
+        warnings.warn(error_msg)
+
+
+def find_pipelines(
     raise_errors: bool = False, pipelines_to_find: list[str] | None = None
 ) -> dict[str, Pipeline]:
     """Automatically find modular pipelines having a ``create_pipeline``
@@ -499,43 +589,27 @@ def find_pipelines(  # noqa: PLR0912, PLR0915
             "Call 'configure_project' first."
         )
 
-    # Determine if specific pipelines were requested
-    load_all = pipelines_to_find is None or "__default__" in pipelines_to_find
-    requested_pipelines: set[str] | None = None if load_all else set(pipelines_to_find)  # type: ignore[arg-type]
+    # Explicit CLI flag takes precedence; fallback to the kwarg.
+    requested_pipelines = (
+        pipelines._requested_pipelines
+        if pipelines._requested_pipelines is not None
+        else pipelines_to_find
+    )
+    load_all = requested_pipelines is None or "__default__" in requested_pipelines
+    pipeline_filter: set[str] | None = None if load_all else set(requested_pipelines)  # type: ignore[arg-type]
 
     pipelines_dict: dict[str, Pipeline] = {}
 
     if load_all:
-        # Handle the simplified project structure found in several starters.
-        pipeline_obj = None
-        pipeline_module_name = f"{PACKAGE_NAME}.pipeline"
-        try:
-            pipeline_module = importlib.import_module(pipeline_module_name)
-        except Exception as exc:
-            if str(exc) != f"No module named '{pipeline_module_name}'":
-                if raise_errors:
-                    raise ImportError(
-                        f"An error occurred while importing the "
-                        f"'{pipeline_module_name}' module."
-                    ) from exc
+        pipelines_dict["__default__"] = _load_default_pipeline(raise_errors)
 
-                warnings.warn(
-                    IMPORT_ERROR_MESSAGE.format(
-                        module=pipeline_module_name, tb_exc=traceback.format_exc()
-                    )
-                )
-        else:
-            pipeline_obj = _create_pipeline(pipeline_module)
-
-        pipelines_dict["__default__"] = pipeline_obj or pipeline([])
-
-    # Handle the case that a project doesn't have a pipelines directory.
+    # Handle projects that have no pipelines/ directory.
     try:
         pipelines_package = importlib.resources.files(f"{PACKAGE_NAME}.pipelines")
     except ModuleNotFoundError as exc:
         if str(exc) == f"No module named '{PACKAGE_NAME}.pipelines'":
-            if requested_pipelines is not None:
-                missing_str = ", ".join(sorted(requested_pipelines))
+            if pipeline_filter is not None:
+                missing_str = ", ".join(sorted(pipeline_filter))
                 error_msg = f"Pipeline(s) not found: {missing_str}"
                 if raise_errors:
                     raise KeyError(error_msg) from exc
@@ -543,53 +617,11 @@ def find_pipelines(  # noqa: PLR0912, PLR0915
                 return {}
             return pipelines_dict
 
-    seen: set[str] = set()
-    for pipeline_dir in pipelines_package.iterdir():
-        if not pipeline_dir.is_dir():
-            continue
+    seen = _load_modular_pipelines(
+        pipelines_package, pipeline_filter, pipelines_dict, raise_errors
+    )
 
-        pipeline_name = pipeline_dir.name
-        if pipeline_name == "__pycache__":
-            continue
-        # Prevent imports of hidden directories/files
-        if pipeline_name.startswith("."):
-            continue
-
-        if requested_pipelines is not None and pipeline_name not in requested_pipelines:
-            continue
-
-        seen.add(pipeline_name)
-        pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
-        try:
-            pipeline_module = importlib.import_module(pipeline_module_name)
-        except Exception as exc:
-            if raise_errors:
-                raise ImportError(
-                    f"An error occurred while importing the "
-                    f"'{pipeline_module_name}' module."
-                ) from exc
-
-            warnings.warn(
-                IMPORT_ERROR_MESSAGE.format(
-                    module=pipeline_module_name, tb_exc=traceback.format_exc()
-                )
-            )
-            continue
-
-        pipeline_obj = _create_pipeline(pipeline_module)
-        if pipeline_obj is not None:
-            pipelines_dict[pipeline_name] = pipeline_obj
-        elif raise_errors:
-            raise KeyError(f"Pipeline '{pipeline_name}' not found")
-
-    if requested_pipelines is not None:
-        for pipeline_name in requested_pipelines - seen:
-            pipeline_module_name = f"{PACKAGE_NAME}.pipelines.{pipeline_name}"
-            error_msg = f"An error occurred while importing the '{pipeline_module_name}' module."
-            if raise_errors:
-                raise ImportError(error_msg)
-            warnings.warn(
-                f"{error_msg} Nothing defined therein will be returned by 'find_pipelines'."
-            )
+    if pipeline_filter is not None:
+        _report_missing_pipelines(pipeline_filter, seen, raise_errors)
 
     return pipelines_dict

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -345,6 +345,7 @@ class KedroSession(AbstractSession):
         context = self.load_context()
 
         names = pipeline_names or ["__default__"]
+        pipelines.set_requested(names)
         combined_pipelines = Pipeline([])
         for name in names:
             try:


### PR DESCRIPTION
## Description

### Scenario 1 — Selective Pipeline Loading (all dependencies installed)

When a user runs `kedro run --pipeline data_science`, Kedro imports every pipeline module in the project — including unrelated pipelines. The selective loading capability already exists via `find_pipelines(pipelines_to_find=...)` from [PR #5401](https://github.com/kedro-org/kedro/pull/5401), but it is never wired to the CLI `--pipeline` flag automatically.

**This scenario assumes all project dependencies are installed.** The goal is purely to avoid importing unrelated pipeline modules at startup.


## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
