### PR TITLE
Fix/param validation none min

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,8 +6,11 @@ NOTE: This session implementation is under active development and may occasional
 * Added inspection API to get project snapshot.
 
 ## Bug fixes and other changes
+* Fixed `SequentialRunner` iterating over iterable-but-non-generator node outputs (e.g. `mne.Epochs`, `numpy.ndarray`, `torch.utils.data.IterableDataset`) before saving them. Streaming behaviour is now restricted to actual generator objects, so custom business objects are passed to `catalog.save` unchanged.
+
 ## Documentation changes
 ## Community contributions
+* [victor-cali](https://github.com/victor-cali)
 
 
 # Release 1.3.1

--- a/kedro/runner/task.py
+++ b/kedro/runner/task.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import inspect
 import itertools as it
 import multiprocessing
-from collections.abc import Iterable, Iterator
 from concurrent.futures import (
     ALL_COMPLETED,
     Future,
@@ -23,6 +22,8 @@ from kedro.framework.hooks.manager import (
 from kedro.framework.project import settings
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from pluggy import PluginManager
 
     from kedro.io import CatalogProtocol
@@ -166,8 +167,13 @@ class Task:
         )
 
         items: Iterable = outputs.items()
-        # if all outputs are iterators, then the node is a generator node
-        if all(isinstance(d, Iterator) for d in outputs.values()):
+        # If all outputs are generator objects, treat this as a generator node
+        # and interleave the chunk streams into the catalog. We deliberately
+        # check for generators (not the broader ``Iterator`` ABC) so that
+        # iterable business objects -- e.g. ``mne.Epochs``, ``numpy.ndarray``,
+        # ``torch.utils.data.IterableDataset`` -- are passed through to
+        # ``catalog.save`` unchanged. See kedro-org/kedro#5412.
+        if outputs and all(inspect.isgenerator(d) for d in outputs.values()):
             # Python dictionaries are ordered, so we are sure
             # the keys and the chunk streams are in the same order
             # [a, b, c]

--- a/kedro/validation/parameter_validator.py
+++ b/kedro/validation/parameter_validator.py
@@ -8,8 +8,8 @@ from typing import TYPE_CHECKING, Any
 
 from .exceptions import ParameterValidationError
 from .model_factory import instantiate_model
-from .type_extractor import TypeExtractor
-from .utils import resolve_nested_dict_path, set_nested_dict_value
+from .type_extractor import ParamRequirement, TypeExtractor
+from .utils import MISSING, resolve_nested_dict_path, set_nested_dict_value
 
 if TYPE_CHECKING:
     from kedro.pipeline import Pipeline
@@ -46,15 +46,26 @@ class ParameterValidator:
         validation_errors = []
         instantiated_count = 0
 
-        for param_key, expected_type in requirements.items():
+        for param_key, requirement in requirements.items():
+            if isinstance(requirement, ParamRequirement):
+                expected_type = requirement.expected_type
+                allows_none = requirement.allows_none
+            else:
+                expected_type = requirement
+                allows_none = False
             try:
-                raw_value = resolve_nested_dict_path(raw_params, param_key)
+                raw_value = resolve_nested_dict_path(
+                    raw_params, param_key, default=MISSING
+                )
 
-                if raw_value is None:
+                if raw_value is MISSING:
                     logger.debug(
                         "Parameter '%s' not found in config, skipping validation",
                         param_key,
                     )
+                    continue
+
+                if raw_value is None and allows_none:
                     continue
 
                 validated_instance = instantiate_model(

--- a/kedro/validation/type_extractor.py
+++ b/kedro/validation/type_extractor.py
@@ -19,17 +19,26 @@ logger = logging.getLogger(__name__)
 _PARAMS_PREFIX = "params:"
 
 
-def _unwrap_optional(tp: type) -> type:
+@dataclasses.dataclass(frozen=True)
+class ParamRequirement:
+    expected_type: type
+    allows_none: bool = False
+
+
+def _unwrap_optional(tp: type) -> tuple[type, bool]:
     """Unwrap ``Optional[X]`` / ``X | None`` to ``X``.
 
     If the type is a union of exactly one non-None type and ``NoneType``,
     return the non-None type. Otherwise return the original type unchanged.
     """
+    allows_none = False
     if get_origin(tp) is Union or isinstance(tp, types.UnionType):
-        args = [a for a in get_args(tp) if a is not type(None)]
-        if len(args) == 1:
-            return args[0]  # type: ignore[no-any-return]
-    return tp
+        args = get_args(tp)
+        non_none_args = [a for a in args if a is not type(None)]
+        if len(non_none_args) == 1 and len(args) == 2:
+            allows_none = True
+            tp = non_none_args[0]
+    return tp, allows_none
 
 
 class TypeExtractor:
@@ -44,7 +53,7 @@ class TypeExtractor:
         self._pipelines = pipelines
         self._warned_union_types: set[type] = set()
 
-    def extract_types_from_pipelines(self) -> dict[str, type]:
+    def extract_types_from_pipelines(self) -> dict[str, ParamRequirement]:
         """Extract all type requirements from registered pipelines.
 
         Walks all pipelines (except ``__default__``) and inspects node
@@ -53,7 +62,7 @@ class TypeExtractor:
         Returns:
             Dictionary mapping parameter keys to their expected types.
         """
-        all_type_requirements: dict[str, type] = {}
+        all_type_requirements: dict[str, ParamRequirement] = {}
 
         for pipeline_name, pipeline in self._pipelines.items():
             if pipeline_name == "__default__":
@@ -64,16 +73,28 @@ class TypeExtractor:
             for key, new_type in pipeline_type_requirements.items():
                 if key in all_type_requirements:
                     existing_type = all_type_requirements[key]
-                    if existing_type != new_type:
+                    if existing_type.expected_type != new_type.expected_type:
                         logger.warning(
                             "Conflicting type requirements for parameter '%s': "
                             "%s (existing) vs %s (from pipeline '%s'). "
                             "Using %s.",
                             key,
-                            getattr(existing_type, "__name__", str(existing_type)),
-                            getattr(new_type, "__name__", str(new_type)),
+                            getattr(
+                                existing_type.expected_type,
+                                "__name__",
+                                str(existing_type.expected_type),
+                            ),
+                            getattr(
+                                new_type.expected_type,
+                                "__name__",
+                                str(new_type.expected_type),
+                            ),
                             pipeline_name,
-                            getattr(new_type, "__name__", str(new_type)),
+                            getattr(
+                                new_type.expected_type,
+                                "__name__",
+                                str(new_type.expected_type),
+                            ),
                         )
 
             all_type_requirements.update(pipeline_type_requirements)
@@ -84,9 +105,9 @@ class TypeExtractor:
         )
         return all_type_requirements
 
-    def _extract_types_from_pipeline(self, pipeline: Pipeline) -> dict[str, type]:
+    def _extract_types_from_pipeline(self, pipeline: Pipeline) -> dict[str, ParamRequirement]:
         """Extract type requirements from a single pipeline."""
-        type_requirements: dict[str, type] = {}
+        type_requirements: dict[str, ParamRequirement] = {}
 
         for node in getattr(pipeline, "nodes", []):
             node_type_requirements = self._extract_types_from_node(node)
@@ -94,7 +115,7 @@ class TypeExtractor:
 
         return type_requirements
 
-    def _extract_types_from_node(self, node: Node) -> dict[str, type]:
+    def _extract_types_from_node(self, node: Node) -> dict[str, ParamRequirement]:
         """Extract typed parameter requirements from a single node.
 
         Inspects the node's function signature and maps type-annotated
@@ -117,7 +138,7 @@ class TypeExtractor:
 
         dataset_to_arg = self._build_dataset_to_arg_mapping(node, sig)
 
-        all_requirements: dict[str, type] = {}
+        all_requirements: dict[str, ParamRequirement] = {}
 
         for ds_name, arg_name in dataset_to_arg.items():
             expected_type = type_hints.get(arg_name)
@@ -128,7 +149,7 @@ class TypeExtractor:
                 continue
 
             # Unwrap Optional[X] / X | None so we validate against the inner type
-            expected_type = _unwrap_optional(expected_type)
+            expected_type, allows_none = _unwrap_optional(expected_type)
 
             # Only record types we can actually validate (Pydantic models or dataclasses)
             if not (
@@ -153,7 +174,10 @@ class TypeExtractor:
                 continue
 
             param_key = ds_name.split(":", 1)[1]
-            all_requirements[param_key] = expected_type
+            all_requirements[param_key] = ParamRequirement(
+                expected_type=expected_type,
+                allows_none=allows_none,
+            )
             logger.debug(
                 "Found parameter requirement: %s -> %s",
                 param_key,

--- a/kedro/validation/utils.py
+++ b/kedro/validation/utils.py
@@ -43,13 +43,16 @@ def get_typed_fields(value: Any) -> dict[str, Any] | None:
     return None
 
 
-def resolve_nested_dict_path(data: dict, path: str) -> Any:
+MISSING = object()
+
+
+def resolve_nested_dict_path(data: dict, path: str, default: Any = None) -> Any:
     """Resolve a dot-separated path in a nested dictionary.
 
-    Returns None if any key in the path is missing.
+    Returns ``default`` if any key in the path is missing.
     """
     if "." not in path:
-        return data.get(path)
+        return data.get(path, default)
 
     keys = path.split(".")
     value = data
@@ -58,7 +61,7 @@ def resolve_nested_dict_path(data: dict, path: str) -> Any:
         if isinstance(value, dict) and key in value:
             value = value[key]
         else:
-            return None
+            return default
 
     return value
 

--- a/tests/runner/test_run_generator_node.py
+++ b/tests/runner/test_run_generator_node.py
@@ -1,3 +1,6 @@
+import inspect
+from collections.abc import Iterator
+
 from kedro.framework.hooks.manager import _NullPluginManager
 from kedro.pipeline import Pipeline, node
 from kedro.runner import SequentialRunner
@@ -100,3 +103,118 @@ class TestRunGeneratorNode:
         assert left.save.call_args_list == expected_left
         assert 10 == right.save.call_count
         assert right.save.call_args_list == expected_right
+
+
+class _IterableNotGenerator:
+    """Satisfies ``collections.abc.Iterator`` without being a Python generator.
+
+    Stand-in for real-world objects that users routinely pass through Kedro
+    nodes -- e.g. ``mne.Epochs``, ``numpy.ndarray``, and
+    ``torch.utils.data.IterableDataset`` -- which implement ``__iter__``/
+    ``__next__`` but must be saved as a single opaque object rather than
+    streamed chunk-by-chunk.
+    """
+
+    def __init__(self, label: str, size: int = 3):
+        self.label = label
+        self._size = size
+        self._idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._idx >= self._size:
+            raise StopIteration
+        self._idx += 1
+        return f"{self.label}_chunk_{self._idx}"
+
+
+class TestNonGeneratorIterables:
+    """Regression tests for kedro-org/kedro#5412.
+
+    The sequential runner used to treat any output that satisfied the
+    ``Iterator`` ABC as a streaming generator-node output and iterate over it
+    before saving, corrupting custom business objects. These tests pin the
+    contract that only real generator objects are streamed; every other
+    iterable is passed to ``catalog.save`` unchanged.
+    """
+
+    def test_fake_iterable_is_iterator_but_not_generator(self):
+        """Sanity check: our fixture reproduces the class of object
+        (iterable + non-generator) that triggered the original bug."""
+        obj = _IterableNotGenerator("x")
+        assert isinstance(obj, Iterator)
+        assert not inspect.isgenerator(obj)
+
+    def test_single_iterable_output_is_passed_through(self, mocker, catalog):
+        fake_dataset = mocker.Mock()
+        mocker.patch.object(catalog, "get", return_value=fake_dataset)
+
+        obj = _IterableNotGenerator("only")
+
+        def produce_one():
+            return obj
+
+        n = node(produce_one, inputs=None, outputs="result")
+        SequentialRunner().run(Pipeline([n]), catalog, _NullPluginManager())
+
+        assert fake_dataset.save.call_count == 1
+        (saved,), _ = fake_dataset.save.call_args
+        assert saved is obj, "Runner must not iterate a non-generator output"
+
+    def test_multiple_iterable_outputs_are_passed_through(self, mocker, catalog):
+        """The original #5412 repro: two outputs, both iterable-but-not-
+        generator, returned from a single node. Previously the runner's
+        ``all(isinstance(d, Iterator) ...)`` check fired and ``interleave``
+        pulled yielded chunks into ``catalog.save`` instead of the objects."""
+        left = mocker.Mock()
+        right = mocker.Mock()
+        mocker.patch.object(
+            catalog,
+            "get",
+            side_effect=lambda ds_name, **kwargs: left if ds_name == "left" else right,
+        )
+
+        left_obj = _IterableNotGenerator("left")
+        right_obj = _IterableNotGenerator("right")
+
+        def produce_two():
+            return left_obj, right_obj
+
+        n = node(produce_two, inputs=None, outputs=["left", "right"])
+        SequentialRunner().run(Pipeline([n]), catalog, _NullPluginManager())
+
+        assert left.save.call_count == 1
+        (saved_left,), _ = left.save.call_args
+        assert saved_left is left_obj
+
+        assert right.save.call_count == 1
+        (saved_right,), _ = right.save.call_args
+        assert saved_right is right_obj
+
+    def test_dict_mapped_iterable_outputs_are_passed_through(self, mocker, catalog):
+        """Explicit ``outputs={"a": "left", "b": "right"}`` mapping must also
+        short-circuit the streaming path -- this is the exact configuration
+        the #5412 reporter used to try to bypass tuple unpacking."""
+        left = mocker.Mock()
+        right = mocker.Mock()
+        mocker.patch.object(
+            catalog,
+            "get",
+            side_effect=lambda ds_name, **kwargs: left if ds_name == "left" else right,
+        )
+
+        a_obj = _IterableNotGenerator("a")
+        b_obj = _IterableNotGenerator("b")
+
+        def produce_dict():
+            return {"a": a_obj, "b": b_obj}
+
+        n = node(produce_dict, inputs=None, outputs={"a": "left", "b": "right"})
+        SequentialRunner().run(Pipeline([n]), catalog, _NullPluginManager())
+
+        (saved_left,), _ = left.save.call_args
+        (saved_right,), _ = right.save.call_args
+        assert saved_left is a_obj
+        assert saved_right is b_obj

--- a/tests/validation/test_parameter_validator.py
+++ b/tests/validation/test_parameter_validator.py
@@ -10,6 +10,7 @@ import pytest
 from kedro.pipeline import node as kedro_node
 from kedro.validation.exceptions import ParameterValidationError
 from kedro.validation.parameter_validator import ParameterValidator
+from kedro.validation.type_extractor import ParamRequirement
 
 from .conftest import SampleDataclass, SamplePydanticModel
 
@@ -64,6 +65,27 @@ class TestApplyValidation:
 
         result = parameter_validator._apply_validation(raw, requirements)
         assert result == {"other_key": "value"}
+
+    def test_none_param_raises_when_not_optional(self, parameter_validator):
+        raw = {"model_options": None}
+        requirements = {"model_options": SamplePydanticModel}
+
+        with pytest.raises(
+            ParameterValidationError, match="Parameter validation failed"
+        ):
+            parameter_validator._apply_validation(raw, requirements)
+
+    def test_none_param_allowed_when_optional(self, parameter_validator):
+        raw = {"model_options": None}
+        requirements = {
+            "model_options": ParamRequirement(
+                expected_type=SamplePydanticModel,
+                allows_none=True,
+            )
+        }
+
+        result = parameter_validator._apply_validation(raw, requirements)
+        assert result["model_options"] is None
 
     def test_unsupported_type_returns_raw(self, parameter_validator):
         raw = {"threshold": 0.5}

--- a/tests/validation/test_type_extractor.py
+++ b/tests/validation/test_type_extractor.py
@@ -7,7 +7,7 @@ import inspect
 from unittest.mock import MagicMock, patch
 
 from kedro.pipeline import node as kedro_node
-from kedro.validation.type_extractor import TypeExtractor
+from kedro.validation.type_extractor import ParamRequirement, TypeExtractor
 
 from .conftest import SampleDataclass, SamplePydanticModel
 
@@ -90,7 +90,7 @@ class TestExtractTypesFromPipelines:
         result = extractor.extract_types_from_pipelines()
 
         assert "eval_config" in result
-        assert result["eval_config"] == SampleDataclass
+        assert result["eval_config"].expected_type == SampleDataclass
 
     def test_conflicting_types_warns(self, caplog):
         """When two pipelines define different types for the same key, warn."""
@@ -141,7 +141,12 @@ class TestExtractTypesFromPipelines:
         )
 
         # Patch _extract_types_from_pipeline to return types without __name__
-        returns = iter([{"key": nameless_type}, {"key": _TypeA}])
+        returns = iter(
+            [
+                {"key": ParamRequirement(expected_type=nameless_type)},
+                {"key": ParamRequirement(expected_type=_TypeA)},
+            ]
+        )
         with patch.object(
             extractor,
             "_extract_types_from_pipeline",
@@ -205,11 +210,12 @@ class TestExtractTypesFromPipelines:
         result = extractor.extract_types_from_pipelines()
 
         assert "pydantic_cfg" in result
-        assert result["pydantic_cfg"] == SamplePydanticModel
+        assert result["pydantic_cfg"].expected_type == SamplePydanticModel
         assert "dc_cfg" in result
-        assert result["dc_cfg"] == SampleDataclass
+        assert result["dc_cfg"].expected_type == SampleDataclass
         assert "optional_cfg" in result
-        assert result["optional_cfg"] == SamplePydanticModel
+        assert result["optional_cfg"].expected_type == SamplePydanticModel
+        assert result["optional_cfg"].allows_none is True
         assert "threshold" not in result
         assert "union_cfg" not in result
 
@@ -248,7 +254,7 @@ class TestExtractTypesFromNode:
 
         result = type_extractor._extract_types_from_node(test_node)
         assert "model_options" in result
-        assert result["model_options"] == SamplePydanticModel
+        assert result["model_options"].expected_type == SamplePydanticModel
 
     def test_untyped_param_input(self, type_extractor):
         def my_func(data) -> None:
@@ -293,7 +299,7 @@ class TestExtractTypesFromNode:
 
         result = type_extractor._extract_types_from_node(node)
         assert "eval_config" in result
-        assert result["eval_config"] == SampleDataclass
+        assert result["eval_config"].expected_type == SampleDataclass
 
     def test_union_type_hint_skipped(self, type_extractor):
         def my_func(data: _UnionType) -> None:
@@ -324,7 +330,8 @@ class TestExtractTypesFromNode:
 
         result = type_extractor._extract_types_from_node(test_node)
         assert "config" in result
-        assert result["config"] == SamplePydanticModel
+        assert result["config"].expected_type == SamplePydanticModel
+        assert result["config"].allows_none is True
 
     def test_optional_dataclass_unwrapped(self, type_extractor):
         """Optional[Dataclass] should unwrap to Dataclass and be recorded."""
@@ -341,7 +348,8 @@ class TestExtractTypesFromNode:
 
         result = type_extractor._extract_types_from_node(test_node)
         assert "config" in result
-        assert result["config"] == SampleDataclass
+        assert result["config"].expected_type == SampleDataclass
+        assert result["config"].allows_none is True
 
     def test_builtin_type_hint_skipped(self, type_extractor):
         def my_func(data: int) -> None:


### PR DESCRIPTION
## Description
Fix parameter validation for optional typed params so explicit `None` values are preserved and do not trigger model instantiation/validation errors. This aligns behavior with `OptionalModel`/ `Model | None annotations`.

## Development notes
- Changes:
 - Introduced ParamRequirement dataclass to track both expected_type and allows_none flag during type extraction.
    - Modified _unwrap_optional() to return a tuple (type, allows_none) instead of just the unwrapped type.
    - Updated ParameterValidator._apply_validation() to skip instantiation when a param is explicitly None and allows_none=True.
    - Used a sentinel (MISSING) to distinguish between missing params and explicit None values.
    - Updated resolve_nested_dict_path() to support a configurable default instead of always returning None.

- Tests:
    - pytest tests/validation (all 80 tests pass).
    - Added tests for optional None cases: test_none_param_raises_when_not_optional and test_none_param_allowed_when_optional.
    - All existing generator-node and type-extraction tests continue to pass.
    
## Developer Certificate of Origin
 All commits are signed off with DCO.

## Checklist

- [X] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [X] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [X] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [X] Added tests to cover my changes
- [X] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
