### PR TITLE
Security fixes for HTTP Server

### DIFF
--- a/kedro/framework/cli/server.py
+++ b/kedro/framework/cli/server.py
@@ -42,7 +42,7 @@ def server_cli() -> None:
     "--reload",
     is_flag=True,
     default=False,
-    help="Enable auto-reload for development. Server restarts on code changes.",
+    help="Enable auto-reload for development. Server restarts on code changes. Should not be used in production.",
 )
 @click.option(
     "--env",

--- a/kedro/framework/cli/server.py
+++ b/kedro/framework/cli/server.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 import click
 
@@ -90,6 +91,14 @@ def server_start(  # noqa: PLR0913
         ) from exc
 
     project_path = metadata.project_path
+
+    if reload:
+        warnings.warn(
+            "--reload enables Uvicorn's auto-reload mode which is intended for "
+            "development only. Do not use it in production.",
+            UserWarning,
+            stacklevel=1,
+        )
 
     # Unset env and conf-source to avoid re-using them from previous runs if not provided in the current command
     if KEDRO_SERVER_ENV in os.environ:

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -6,7 +6,6 @@ import logging
 import os
 import threading
 import time
-import traceback
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -17,6 +16,7 @@ from kedro.framework.project import settings
 from kedro.framework.session.service_session import KedroServiceSession
 from kedro.framework.startup import bootstrap_project
 from kedro.io.core import generate_timestamp
+from kedro.runner import AbstractRunner
 from kedro.server.models import (
     ErrorDetail,
     HealthResponse,
@@ -103,11 +103,9 @@ def create_http_server(
 
         Returns server status and Kedro version information.
         """
-        project_path = app.state.project_path
         return HealthResponse(
             status="healthy",
             kedro_version=kedro_version,
-            project_path=str(project_path),
         )
 
     @app.post("/run", response_model=RunResponse, tags=["pipeline"])
@@ -162,6 +160,13 @@ def _execute_pipeline(
     try:
         runner_name = request.runner or "SequentialRunner"
         runner_class = load_obj(runner_name, "kedro.runner")
+        if not (
+            isinstance(runner_class, type) and issubclass(runner_class, AbstractRunner)
+        ):
+            raise ValueError(
+                f"Runner '{runner_name}' is not a subclass of AbstractRunner. "
+                "Only AbstractRunner subclasses are permitted."
+            )
         runner_obj = runner_class(is_async=request.is_async)
 
         session.run(
@@ -200,7 +205,6 @@ def _execute_pipeline(
         error_detail = ErrorDetail(
             type=type(exc).__qualname__,
             message=str(exc),
-            traceback=traceback.format_tb(exc.__traceback__),
         )
 
         return RunResponse(

--- a/kedro/server/models.py
+++ b/kedro/server/models.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+# Matches a valid Python dotted identifier, e.g. "SequentialRunner" or
+# "mypackage.runners.MyRunner".  Prevents passing arbitrary strings to
+# importlib.import_module before the AbstractRunner subclass check runs.
+_RUNNER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*(\.[A-Za-z_][A-Za-z0-9_]*)*$")
 
 
 class RunRequest(BaseModel):
@@ -39,6 +45,18 @@ class RunRequest(BaseModel):
         default=None,
         description="Runner to use. Any importable subclass of `kedro.runner.AbstractRunner`.",
     )
+
+    @field_validator("runner")
+    @classmethod
+    def _validate_runner_format(cls, v: str | None) -> str | None:
+        if v is not None and not _RUNNER_PATTERN.match(v):
+            raise ValueError(
+                f"runner '{v}' is not a valid Python dotted identifier. "
+                "Expected a class name or dotted module path, e.g. 'SequentialRunner' "
+                "or 'mypackage.runners.MyRunner'."
+            )
+        return v
+
     is_async: bool = Field(
         default=False,
         description="Load and save node inputs and outputs asynchronously with threads.",

--- a/kedro/server/models.py
+++ b/kedro/server/models.py
@@ -77,10 +77,6 @@ class ErrorDetail(BaseModel):
 
     type: str = Field(description="Exception type name.")
     message: str = Field(description="Error message.")
-    traceback: list[str] | None = Field(
-        default=None,
-        description="Stack trace lines, if available. Only included for errors raised during pipeline execution.",
-    )
 
 
 class RunResponse(BaseModel):
@@ -102,7 +98,3 @@ class HealthResponse(BaseModel):
         default="healthy", description="Server health status."
     )
     kedro_version: str = Field(description="Kedro version.")
-    project_path: str | None = Field(
-        default=None,
-        description="Path to the Kedro project being served.",
-    )

--- a/tests/framework/cli/test_server.py
+++ b/tests/framework/cli/test_server.py
@@ -1,5 +1,7 @@
 import types
+import warnings
 
+import pytest
 from click.testing import CliRunner
 
 from kedro.server.utils import DEFAULT_HOST, DEFAULT_HTTP_PORT, KEDRO_PROJECT_PATH_ENV
@@ -125,3 +127,38 @@ class TestServerCommand:
         assert result.exit_code == 0, result.output
         assert "KEDRO_SERVER_ENV" not in mock_environ
         assert "KEDRO_SERVER_CONF_SOURCE" not in mock_environ
+
+    def test_reload_emits_user_warning(self, fake_metadata, fake_project_cli, mocker):
+        """--reload must emit a UserWarning about development-only use."""
+
+        mocker.patch("os.environ", {})
+        mocker.patch.dict(
+            "sys.modules",
+            {
+                "uvicorn": types.SimpleNamespace(run=mocker.Mock()),
+                "fastapi": types.SimpleNamespace(),
+            },
+        )
+
+        with pytest.warns(UserWarning, match="--reload.*development only"):
+            CliRunner().invoke(
+                fake_project_cli, ["start", "--reload"], obj=fake_metadata
+            )
+
+    def test_no_warning_without_reload(self, fake_metadata, fake_project_cli, mocker):
+        """Starting without --reload must not emit the development-only warning."""
+
+        mocker.patch("os.environ", {})
+        mocker.patch.dict(
+            "sys.modules",
+            {
+                "uvicorn": types.SimpleNamespace(run=mocker.Mock()),
+                "fastapi": types.SimpleNamespace(),
+            },
+        )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            result = CliRunner().invoke(fake_project_cli, ["start"], obj=fake_metadata)
+
+        assert result.exit_code == 0, result.output

--- a/tests/server/test_http_server.py
+++ b/tests/server/test_http_server.py
@@ -431,6 +431,44 @@ class TestRunEndpoint:
         assert request.is_async is True
 
 
+class TestRunRequest:
+    """Tests for RunRequest model validation."""
+
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            "SequentialRunner",
+            "ParallelRunner",
+            "kedro.runner.SequentialRunner",
+            "mypackage.runners.MyRunner",
+            "my_package.sub_module.Runner",
+        ],
+    )
+    def test_valid_runner_formats(self, runner):
+        """Valid dotted-identifier runner strings must be accepted."""
+        req = RunRequest(runner=runner)
+        assert req.runner == runner
+
+    @pytest.mark.parametrize(
+        "runner",
+        [
+            "os; import sys",
+            "__import__('os')",
+            "os.system('rm -rf /')",
+            "../../etc/passwd",
+            "",
+            "has space",
+            "123invalid",
+        ],
+    )
+    def test_invalid_runner_formats_are_rejected(self, runner):
+        """Runner strings that are not valid dotted identifiers must be rejected."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            RunRequest(runner=runner)
+
+
 class TestExecutePipeline:
     def test_execute_pipeline_success_with_defaults(self, mocker):
         """Test successful pipeline execution loads SequentialRunner by default."""

--- a/tests/server/test_http_server.py
+++ b/tests/server/test_http_server.py
@@ -3,13 +3,23 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from kedro.runner import AbstractRunner
 from kedro.server.http_server import _execute_pipeline, create_http_server
 from kedro.server.models import ErrorDetail, RunRequest, RunResponse
 
 
-class _FakeRunner:
-    def __init__(self, *, is_async):
-        self.is_async = is_async
+class _FakeRunner(AbstractRunner):
+    """Minimal AbstractRunner subclass for testing."""
+
+    @property
+    def is_async(self) -> bool:
+        return self._is_async
+
+    def _get_executor(self, max_workers):
+        return None
+
+    def _run(self, pipeline, catalog, hook_manager=None, run_id=None):
+        pass
 
 
 class TestHTTPServerFactory:
@@ -139,7 +149,6 @@ class TestHTTPServerFactory:
 
         assert response.status_code == 200
         assert response.json()["status"] == "healthy"
-        assert response.json()["project_path"] == str(project_path)
 
     def test_health_endpoint_response_model_validation(self, mocker, tmp_path):
         """Test that health endpoint response validates against HealthResponse model."""
@@ -154,11 +163,12 @@ class TestHTTPServerFactory:
             response = client.get("/health")
 
         payload = response.json()
-        assert set(payload.keys()) == {"status", "kedro_version", "project_path"}
+        assert set(payload.keys()) == {"status", "kedro_version"}
         assert payload["status"] in ["healthy", "unhealthy"]
         assert "kedro_version" in payload
         assert isinstance(payload["kedro_version"], str)
         assert len(payload["kedro_version"]) > 0
+        assert "project_path" not in payload
 
 
 class TestRunEndpoint:
@@ -317,7 +327,6 @@ class TestRunEndpoint:
                 error=ErrorDetail(
                     type="ValueError",
                     message="bad run",
-                    traceback=["Traceback line"],
                 ),
             ),
         )
@@ -334,8 +343,8 @@ class TestRunEndpoint:
         assert payload["error"] == {
             "type": "ValueError",
             "message": "bad run",
-            "traceback": ["Traceback line"],
         }
+        assert "traceback" not in payload["error"]
 
     def test_run_endpoint_passes_parameters_to_execute_pipeline(self, mocker, tmp_path):
         """Test that RunRequest parameters are passed to _execute_pipeline."""
@@ -427,11 +436,9 @@ class TestExecutePipeline:
         """Test successful pipeline execution loads SequentialRunner by default."""
 
         mock_session = mocker.Mock()
-        mock_runner = _FakeRunner(is_async=False)
-        mock_runner_factory = mocker.Mock(return_value=mock_runner)
         mock_load_obj = mocker.patch(
             "kedro.server.http_server.load_obj",
-            return_value=mock_runner_factory,
+            return_value=_FakeRunner,
         )
 
         result = _execute_pipeline(session=mock_session, request=RunRequest())
@@ -441,18 +448,18 @@ class TestExecutePipeline:
         assert result.duration_ms > 0
         assert result.error is None
         mock_load_obj.assert_called_once_with("SequentialRunner", "kedro.runner")
-        mock_runner_factory.assert_called_once_with(is_async=False)
         mock_session.run.assert_called_once()
-        assert mock_session.run.call_args.kwargs["runner"] is mock_runner
+        runner_used = mock_session.run.call_args.kwargs["runner"]
+        assert isinstance(runner_used, _FakeRunner)
+        assert runner_used.is_async is False
 
     def test_execute_pipeline_success_with_custom_runner(self, mocker):
         """Test successful execution with custom runner class."""
 
         mock_session = mocker.Mock()
-        mock_runner = _FakeRunner(is_async=True)
         mock_load_obj = mocker.patch(
             "kedro.server.http_server.load_obj",
-            return_value=lambda is_async: mock_runner,
+            return_value=_FakeRunner,
         )
 
         result = _execute_pipeline(
@@ -463,18 +470,18 @@ class TestExecutePipeline:
         assert result.status == "success"
         mock_load_obj.assert_called_once_with("ParallelRunner", "kedro.runner")
         mock_session.run.assert_called_once()
-        call_kwargs = mock_session.run.call_args[1]
-        assert call_kwargs["runner"].is_async is True
+        runner_used = mock_session.run.call_args[1]["runner"]
+        assert isinstance(runner_used, _FakeRunner)
+        assert runner_used.is_async is True
 
     def test_execute_pipeline_failure_with_exception(self, mocker):
         """Test pipeline execution failure with exception."""
 
         mock_session = mocker.Mock()
         mock_session.run.side_effect = ValueError("Pipeline execution failed")
-        mock_runner = _FakeRunner(is_async=False)
         mocker.patch(
             "kedro.server.http_server.load_obj",
-            return_value=lambda is_async: mock_runner,
+            return_value=_FakeRunner,
         )
 
         result = _execute_pipeline(session=mock_session, request=RunRequest())
@@ -484,7 +491,7 @@ class TestExecutePipeline:
         assert result.error is not None
         assert result.error.type == "ValueError"
         assert result.error.message == "Pipeline execution failed"
-        assert isinstance(result.error.traceback, list)
+        assert not hasattr(result.error, "traceback")
 
     def test_execute_pipeline_runner_loading_failure(self, mocker):
         """Test failure when runner class cannot be loaded."""
@@ -504,14 +511,55 @@ class TestExecutePipeline:
         assert result.error.type == "AttributeError"
         assert "UnknownRunner" in result.error.message
 
+    def test_execute_pipeline_rejects_non_abstract_runner(self, mocker):
+        """Security: runner not subclassing AbstractRunner must be rejected."""
+
+        class _NotARunner:
+            def __init__(self, *, is_async=False):
+                pass
+
+        mock_session = mocker.Mock()
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=_NotARunner,
+        )
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="os.system"),
+        )
+
+        assert result.status == "failure"
+        assert result.error.type == "ValueError"
+        assert "AbstractRunner" in result.error.message
+        mock_session.run.assert_not_called()
+
+    def test_execute_pipeline_rejects_non_class_runner(self, mocker):
+        """Security: load_obj returning a non-class (e.g. a function) must be rejected."""
+
+        mock_session = mocker.Mock()
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=lambda is_async: None,  # a callable, not a class
+        )
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="some.function"),
+        )
+
+        assert result.status == "failure"
+        assert result.error.type == "ValueError"
+        assert "AbstractRunner" in result.error.message
+        mock_session.run.assert_not_called()
+
     def test_execute_pipeline_with_all_parameters(self, mocker):
         """Test pipeline execution with all parameters provided."""
 
         mock_session = mocker.Mock()
-        mock_runner = _FakeRunner(is_async=False)
         mocker.patch(
             "kedro.server.http_server.load_obj",
-            return_value=lambda is_async: mock_runner,
+            return_value=_FakeRunner,
         )
 
         result = _execute_pipeline(


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Did a quick security review for the HTTP server code and it flagged some issues which are resolved in this:
- Check if the `runner` provided is a subclass of `AbstractRunner` to avoid arbitrary code execution
- Remove full traceback from `ErrorDetail` - it is still logged server side
- Remove `project_path` from health endpoint 
- Add a warning for `--reload` functionality of `uvicorn` as it's not fit for use in production
- Updated tests wherever necessary, added tests for the warning

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
