### PR TITLE
fix(cli): unbreak nightly on click 8.4 `NoSuchCommand`

### DIFF
--- a/kedro/framework/cli/cli.py
+++ b/kedro/framework/cli/cli.py
@@ -175,10 +175,18 @@ class KedroCLI(CommandCollection):
                 project_metadata=self._metadata, command_args=args, exit_code=exc.code
             )
 
-            # When CLI is run outside of a project, project_groups are not registered
-            catch_exception = "click.exceptions.UsageError: No such command"
-            # click convert exception handles to error message
-            if catch_exception in traceback.format_exc() and not self.project_groups:
+            # When CLI is run outside of a project, project_groups are not registered.
+            # Click <8.4 raises ``UsageError``; Click >=8.4 raises the ``NoSuchCommand``
+            # subclass (pallets/click#3228).
+            catch_exceptions = (
+                "click.exceptions.UsageError: No such command",
+                "click.exceptions.NoSuchCommand: No such command",
+            )
+            formatted_tb = traceback.format_exc()
+            if (
+                any(exc_str in formatted_tb for exc_str in catch_exceptions)
+                and not self.project_groups
+            ):
                 warn = click.style(
                     "\nKedro project not found in this directory. ",
                     fg=ORANGE,


### PR DESCRIPTION
## Description
Fix for https://github.com/kedro-org/kedro/issues/5566

Click 8.4.0 (released 2026-05-17, [pallets/click#3228](https://github.com/pallets/click/pull/3228)) introduced a new `click.exceptions.NoSuchCommand` subclass of `UsageError. KedroCLI.main()` does a string-match on the traceback for the old click.exceptions.UsageError: No such command name, so the "Kedro project not found in this directory…" hint is no longer shown — breaking test_kedro_run_no_project and the nightly build ([#5566](https://github.com/kedro-org/kedro/issues/5566)).

## Development notes

Fix: also match the new `click.exceptions.NoSuchCommand` name. Backwards-compatible with `click <8.4`.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
