### PR TITLE
Validate runner modules before loading for http server

### DIFF
--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -174,7 +174,7 @@ The first `/run` request creates a `KedroServiceSession` which the following req
 
 #### Runner security
 
-Short names (e.g. `SequentialRunner`) always resolve against `kedro.runner`. Fully-qualified names (e.g. `mypackage.runners.MyRunner`) must belong to `kedro.runner`, the project's own package, or a module listed in `RUNNER_MODULES_WHITELIST` in `settings.py` — the module is never imported otherwise.
+Short names (for example, `SequentialRunner`) always resolve against `kedro.runner`. Fully-qualified names (for example, `mypackage.runners.MyRunner`) must belong to `kedro.runner`, the project's own package, or a module listed in `RUNNER_MODULES_WHITELIST` in `settings.py`. The module is never imported otherwise.
 
 ```python
 # settings.py

--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -172,6 +172,15 @@ The first `/run` request creates a `KedroServiceSession` which the following req
 !!! note
     `env` and `conf_source` are not accepted per-request. Set them at server startup through the `--env` and `--conf-source` options instead.
 
+#### Runner security
+
+Short names (e.g. `SequentialRunner`) always resolve against `kedro.runner`. Fully-qualified names (e.g. `mypackage.runners.MyRunner`) must belong to `kedro.runner`, the project's own package, or a module listed in `RUNNER_MODULES_WHITELIST` in `settings.py` — the module is never imported otherwise.
+
+```python
+# settings.py
+RUNNER_MODULES_WHITELIST = ["external_lib.runners"]
+```
+
 ### Interactive API reference
 
 When the server is running, [FastAPI](https://fastapi.tiangolo.com/) automatically generates interactive API documentation at `http://127.0.0.1:8000/docs`. This page lists all available endpoints, their request and response schemas, and lets you try them out directly in the browser.

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -138,7 +138,7 @@ class _ProjectSettings(LazySettings):
     )
     _SESSION_STORE_ARGS = Validator("SESSION_STORE_ARGS", default={})
     _DISABLE_HOOKS_FOR_PLUGINS = Validator("DISABLE_HOOKS_FOR_PLUGINS", default=tuple())
-    _RUNNER_MODULES_WHITELIST = Validator("RUNNER_MODULES_WHITELIST", default=[])
+    _RUNNER_MODULES_WHITELIST = Validator("RUNNER_MODULES_WHITELIST", default=tuple())
     _CONFIG_LOADER_CLASS = _HasSharedParentClassValidator(
         "CONFIG_LOADER_CLASS",
         default=_get_default_class("kedro.config.OmegaConfigLoader"),

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -138,6 +138,7 @@ class _ProjectSettings(LazySettings):
     )
     _SESSION_STORE_ARGS = Validator("SESSION_STORE_ARGS", default={})
     _DISABLE_HOOKS_FOR_PLUGINS = Validator("DISABLE_HOOKS_FOR_PLUGINS", default=tuple())
+    _RUNNER_MODULES_WHITELIST = Validator("RUNNER_MODULES_WHITELIST", default=[])
     _CONFIG_LOADER_CLASS = _HasSharedParentClassValidator(
         "CONFIG_LOADER_CLASS",
         default=_get_default_class("kedro.config.OmegaConfigLoader"),
@@ -160,6 +161,7 @@ class _ProjectSettings(LazySettings):
                 self._SESSION_STORE_CLASS,
                 self._SESSION_STORE_ARGS,
                 self._DISABLE_HOOKS_FOR_PLUGINS,
+                self._RUNNER_MODULES_WHITELIST,
                 self._CONFIG_LOADER_CLASS,
                 self._CONFIG_LOADER_ARGS,
                 self._DATA_CATALOG_CLASS,

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -169,7 +169,7 @@ def create_http_server(
     return app
 
 
-def _validate_runner_module(runner_name: str, package_name: str) -> bool:
+def _validate_runner_module(runner_name: str | None, package_name: str) -> bool:
     """Return True when the runner's module prefix is in the allowlist.
 
     A runner name without a module prefix (e.g. ``SequentialRunner``) always
@@ -177,7 +177,7 @@ def _validate_runner_module(runner_name: str, package_name: str) -> bool:
     Allowed prefixes are ``kedro.runner``, the project <package_name>, and any
     additional entries in ``settings.RUNNER_MODULES_WHITELIST``.
     """
-    if "." not in runner_name:
+    if runner_name is None or "." not in runner_name:
         return True
     module = runner_name.rsplit(".", 1)[0]
     allowed_prefixes = [

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -169,6 +169,28 @@ def create_http_server(
     return app
 
 
+def _validate_runner_module(runner_name: str, package_name: str) -> bool:
+    """Return True when the runner's module prefix is in the allowlist.
+
+    A runner name without a module prefix (e.g. ``SequentialRunner``) always
+    passes because ``load_obj`` will resolve it against ``kedro.runner``.
+    Allowed prefixes are ``kedro.runner``, the project <package_name>, and any
+    additional entries in ``settings.RUNNER_MODULES_WHITELIST``.
+    """
+    if "." not in runner_name:
+        return True
+    module = runner_name.rsplit(".", 1)[0]
+    allowed_prefixes = [
+        "kedro.runner",
+        package_name,
+        *settings.RUNNER_MODULES_WHITELIST,
+    ]
+    return any(
+        module == prefix or module.startswith(prefix + ".")
+        for prefix in allowed_prefixes
+    )
+
+
 def _execute_pipeline(
     session: KedroServiceSession,
     *,
@@ -193,6 +215,13 @@ def _execute_pipeline(
 
     try:
         runner_name = request.runner or "SequentialRunner"
+        if not _validate_runner_module(runner_name, session._package_name):
+            module = runner_name.rsplit(".", 1)[0]
+            raise ValueError(
+                f"Runner module '{module}' is not allowed. "
+                "Only 'kedro.runner', the project package, or modules listed in "
+                "'RUNNER_MODULES_WHITELIST' via settings.py are permitted."
+            )
         runner_class = load_obj(runner_name, "kedro.runner")
         if not (
             isinstance(runner_class, type) and issubclass(runner_class, AbstractRunner)

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -169,7 +169,7 @@ def create_http_server(
     return app
 
 
-def _validate_runner_module(runner_name: str | None, package_name: str) -> bool:
+def _validate_runner_module(runner_name: str | None, package_name: str | None) -> bool:
     """Return True when the runner's module prefix is in the allowlist.
 
     A runner name without a module prefix (e.g. ``SequentialRunner``) always

--- a/tests/server/test_run_endpoint.py
+++ b/tests/server/test_run_endpoint.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
+from kedro.framework.project import settings
 from kedro.runner import AbstractRunner
 from kedro.server.http_server import _execute_pipeline, create_http_server
 from kedro.server.models import ErrorDetail, RunRequest, RunResponse
@@ -413,9 +414,11 @@ class TestExecutePipeline:
             return_value=_NotARunner,
         )
 
+        # Use a kedro.runner-namespaced path so the module check passes;
+        # the AbstractRunner subclass check must still catch it.
         result = _execute_pipeline(
             session=mock_session,
-            request=RunRequest(runner="os.system"),
+            request=RunRequest(runner="kedro.runner.FakeNonRunner"),
         )
 
         assert result.status == "failure"
@@ -432,15 +435,72 @@ class TestExecutePipeline:
             return_value=lambda is_async: None,  # a callable, not a class
         )
 
+        # Use a kedro.runner-namespaced path so the module check passes;
+        # the isinstance check must still catch it.
         result = _execute_pipeline(
             session=mock_session,
-            request=RunRequest(runner="some.function"),
+            request=RunRequest(runner="kedro.runner.some_function"),
         )
 
         assert result.status == "failure"
         assert result.error.type == "ValueError"
         assert "AbstractRunner" in result.error.message
         mock_session.run.assert_not_called()
+
+    def test_execute_pipeline_rejects_disallowed_module(self, mocker):
+        """Security: runner whose module is not in the allowlist must be rejected before load_obj."""
+        mock_session = mocker.Mock()
+        mock_session._package_name = "mypackage"
+        mock_load_obj = mocker.patch("kedro.server.http_server.load_obj")
+        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="os.system"),
+        )
+
+        assert result.status == "failure"
+        assert result.error.type == "ValueError"
+        assert "os" in result.error.message
+        assert "not allowed" in result.error.message
+        mock_load_obj.assert_not_called()
+        mock_session.run.assert_not_called()
+
+    def test_execute_pipeline_allows_whitelisted_module(self, mocker):
+        """Runner from a module listed in RUNNER_MODULES_WHITELIST is permitted."""
+        mock_session = mocker.Mock()
+        mock_session._package_name = "mypackage"
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=_FakeRunner,
+        )
+        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", ["external.runners"])
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="external.runners.MyRunner"),
+        )
+
+        assert result.status == "success"
+        mock_session.run.assert_called_once()
+
+    def test_execute_pipeline_allows_project_package_module(self, mocker):
+        """Runner from the project's own package namespace is permitted without whitelisting."""
+        mock_session = mocker.Mock()
+        mock_session._package_name = "mypackage"
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=_FakeRunner,
+        )
+        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="mypackage.runners.CustomRunner"),
+        )
+
+        assert result.status == "success"
+        mock_session.run.assert_called_once()
 
     def test_execute_pipeline_with_all_parameters(self, mocker):
         """Test pipeline execution with all parameters provided."""

--- a/tests/server/test_run_endpoint.py
+++ b/tests/server/test_run_endpoint.py
@@ -502,6 +502,24 @@ class TestExecutePipeline:
         assert result.status == "success"
         mock_session.run.assert_called_once()
 
+    def test_execute_pipeline_allows_project_subpackage_module(self, mocker):
+        """Runner from a subpackage of the project package is permitted without whitelisting."""
+        mock_session = mocker.Mock()
+        mock_session._package_name = "mypackage"
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=_FakeRunner,
+        )
+        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="mypackage.sub.runners.CustomRunner"),
+        )
+
+        assert result.status == "success"
+        mock_session.run.assert_called_once()
+
     def test_execute_pipeline_with_all_parameters(self, mocker):
         """Test pipeline execution with all parameters provided."""
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Address a possible vulnerability re: `runner` modules. 

## Development notes
<!-- What have you changed, and how has this been tested? -->
This allows the user to optionally set a white list for runner modules incase they are using a custom runner to check the `runner` argument in a `RunRequest` against. Otherwise, the runner specified must belong to `kedro.runner`, or `<package_name>` (user project).

Added tests + docs

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
