### PR TITLE
http server: Split response models into success and failure

### DIFF
--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -98,20 +98,15 @@ curl http://127.0.0.1:8000/snapshot
       "filepath": "data/01_raw/iris.csv"
     }
   },
-  "parameters": ["example_learning_rate", "example_num_train_iter"],
-  "error": null
+  "parameters": ["example_learning_rate", "example_num_train_iter"]
 }
 ```
 
-If the snapshot cannot be built (for example, due to a catalog error), the response still returns HTTP 200 with `"status": "failure"`. The `error` field contains the exception type and message:
+If the snapshot cannot be built (for example, due to a catalog error), the response still returns HTTP 200 with `"status": "failure"`. The `error` field contains the exception type and message, and the data fields (`metadata`, `pipelines`, `datasets`, `parameters`) are absent:
 
 ```json
 {
   "status": "failure",
-  "metadata": null,
-  "pipelines": null,
-  "datasets": null,
-  "parameters": null,
   "error": {
     "type": "MissingConfigException",
     "message": "No config files found matching the pattern(s) 'catalog*'"
@@ -162,7 +157,29 @@ Key request fields:
 | `params` | `dict` | Runtime parameters passed to the context |
 | `only_missing_outputs` | `bool` | Skip nodes whose outputs already exist and are persisted |
 
-The response includes a `run_id`, `status` (`"success"` or `"failure"`), `duration_ms`, and an `error` object on failure.
+On success the response contains `run_id`, `status`, and `duration_ms`:
+
+```json
+{
+  "status": "success",
+  "run_id": "2024-01-01T00.00.00.000Z",
+  "duration_ms": 142.3
+}
+```
+
+On failure the response additionally contains an `error` object with the exception type and message:
+
+```json
+{
+  "status": "failure",
+  "run_id": "2024-01-01T00.00.00.000Z",
+  "duration_ms": 12.1,
+  "error": {
+    "type": "DatasetError",
+    "message": "Failed to load dataset 'raw_data'"
+  }
+}
+```
 
 !!! note
     `RunRequest` model uses strict validation, unknown fields return an error rather than being ignored.

--- a/docs/inspect/inspect-project.md
+++ b/docs/inspect/inspect-project.md
@@ -179,6 +179,6 @@ snapshot = get_project_snapshot("/path/to/my_project", conf_source="conf/custom"
 
 ## How to access the snapshot through the HTTP server
 
-The Kedro HTTP server exposes the same snapshot data at `GET /snapshot`. The response contains the same `metadata`, `pipelines`, `datasets`, and `parameters` fields as `ProjectSnapshot`, serialised as JSON.
+The Kedro HTTP server exposes the same snapshot data at `GET /snapshot`. On success, the response contains the same `metadata`, `pipelines`, `datasets`, and `parameters` fields as `ProjectSnapshot`, serialised as JSON. On failure, only `status` and `error` are returned — the data fields are absent.
 
-See [Serving Kedro pipelines over HTTP](../extend/serving.md#get-snapshot) for the full endpoint reference, example response, and failure behaviour.
+See [Serving Kedro pipelines over HTTP](../extend/serving.md#get-snapshot) for the full endpoint reference, example responses, and failure behaviour.

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -21,9 +21,13 @@ from kedro.runner import AbstractRunner
 from kedro.server.models import (
     ErrorDetail,
     HealthResponse,
+    RunFailure,
     RunRequest,
     RunResponse,
+    RunSuccess,
+    SnapshotFailure,
     SnapshotResponse,
+    SnapshotSuccess,
 )
 from kedro.server.utils import (
     KEDRO_SERVER_CONF_SOURCE,
@@ -128,7 +132,7 @@ def create_http_server(
                 conf_source=app.state.default_conf_source,
                 metadata=app.state.metadata,
             )
-            return SnapshotResponse(
+            return SnapshotSuccess(
                 status="success",
                 metadata=snapshot.metadata,
                 pipelines=snapshot.pipelines,
@@ -137,9 +141,12 @@ def create_http_server(
             )
         except Exception as exc:
             logger.error("Snapshot request failed: %s", str(exc), exc_info=True)
-            return SnapshotResponse(
+            return SnapshotFailure(
                 status="failure",
-                error=ErrorDetail(type=type(exc).__qualname__, message=str(exc)),
+                error=ErrorDetail(
+                    type=type(exc).__qualname__,
+                    message=str(exc),
+                ),
             )
 
     @app.post("/run", response_model=RunResponse, tags=["pipeline"])
@@ -250,7 +257,7 @@ def _execute_pipeline(
 
         duration_ms = (time.perf_counter() - start_time) * 1000
         logger.info("Pipeline run %s completed in %.2fms", run_id, duration_ms)
-        return RunResponse(
+        return RunSuccess(
             run_id=run_id,
             status="success",
             duration_ms=round(duration_ms, 2),
@@ -265,14 +272,12 @@ def _execute_pipeline(
             exc_info=True,
         )
 
-        error_detail = ErrorDetail(
-            type=type(exc).__qualname__,
-            message=str(exc),
-        )
-
-        return RunResponse(
+        return RunFailure(
             run_id=run_id,
             status="failure",
             duration_ms=round(duration_ms, 2),
-            error=error_detail,
+            error=ErrorDetail(
+                type=type(exc).__qualname__,
+                message=str(exc),
+            ),
         )

--- a/kedro/server/models.py
+++ b/kedro/server/models.py
@@ -106,7 +106,7 @@ class ErrorDetail(BaseModel):
 class RunSuccess(BaseModel):
     """Response model for a successful pipeline run."""
 
-    status: Literal["success"]
+    status: Literal["success"] = Field(description="Run status.")
     run_id: str = Field(description="Unique identifier for this pipeline run.")
     duration_ms: float = Field(description="Total execution time in milliseconds.")
 
@@ -114,7 +114,7 @@ class RunSuccess(BaseModel):
 class RunFailure(BaseModel):
     """Response model for a failed pipeline run."""
 
-    status: Literal["failure"]
+    status: Literal["failure"] = Field(description="Run status.")
     run_id: str = Field(description="Unique identifier for this pipeline run.")
     duration_ms: float = Field(description="Total execution time in milliseconds.")
     error: ErrorDetail = Field(description="Error details.")
@@ -135,7 +135,7 @@ class HealthResponse(BaseModel):
 class SnapshotSuccess(BaseModel):
     """Response model for a successful project snapshot."""
 
-    status: Literal["success"]
+    status: Literal["success"] = Field(description="Snapshot status.")
     metadata: ProjectMetadataSnapshot = Field(description="Project metadata snapshot.")
     pipelines: list[PipelineSnapshot] = Field(
         description="Registered pipeline snapshots."
@@ -151,7 +151,7 @@ class SnapshotSuccess(BaseModel):
 class SnapshotFailure(BaseModel):
     """Response model for a failed project snapshot."""
 
-    status: Literal["failure"]
+    status: Literal["failure"] = Field(description="Snapshot status.")
     error: ErrorDetail = Field(description="Error details.")
 
 

--- a/kedro/server/models.py
+++ b/kedro/server/models.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -103,16 +103,24 @@ class ErrorDetail(BaseModel):
     message: str = Field(description="Error message.")
 
 
-class RunResponse(BaseModel):
-    """Response model for pipeline execution."""
+class RunSuccess(BaseModel):
+    """Response model for a successful pipeline run."""
 
+    status: Literal["success"]
     run_id: str = Field(description="Unique identifier for this pipeline run.")
-    status: Literal["success", "failure"] = Field(description="Run status.")
     duration_ms: float = Field(description="Total execution time in milliseconds.")
-    error: ErrorDetail | None = Field(
-        default=None,
-        description="Error details if status is 'failure'.",
-    )
+
+
+class RunFailure(BaseModel):
+    """Response model for a failed pipeline run."""
+
+    status: Literal["failure"]
+    run_id: str = Field(description="Unique identifier for this pipeline run.")
+    duration_ms: float = Field(description="Total execution time in milliseconds.")
+    error: ErrorDetail = Field(description="Error details.")
+
+
+RunResponse = Annotated[RunSuccess | RunFailure, Field(discriminator="status")]
 
 
 class HealthResponse(BaseModel):
@@ -124,22 +132,29 @@ class HealthResponse(BaseModel):
     kedro_version: str = Field(description="Kedro version.")
 
 
-class SnapshotResponse(BaseModel):
-    """Response model for the project snapshot endpoint."""
+class SnapshotSuccess(BaseModel):
+    """Response model for a successful project snapshot."""
 
-    status: Literal["success", "failure"] = Field(description="Snapshot status.")
-    metadata: ProjectMetadataSnapshot | None = Field(
-        default=None, description="Project metadata snapshot."
+    status: Literal["success"]
+    metadata: ProjectMetadataSnapshot = Field(description="Project metadata snapshot.")
+    pipelines: list[PipelineSnapshot] = Field(
+        description="Registered pipeline snapshots."
     )
-    pipelines: list[PipelineSnapshot] | None = Field(
-        default=None, description="Registered pipeline snapshots."
+    datasets: dict[str, DatasetSnapshot] = Field(
+        description="Catalog dataset snapshots keyed by dataset name."
     )
-    datasets: dict[str, DatasetSnapshot] | None = Field(
-        default=None, description="Catalog dataset snapshots keyed by dataset name."
+    parameters: list[str] = Field(
+        description="Sorted list of top-level parameter keys."
     )
-    parameters: list[str] | None = Field(
-        default=None, description="Sorted list of top-level parameter keys."
-    )
-    error: ErrorDetail | None = Field(
-        default=None, description="Error details if status is 'failure'."
-    )
+
+
+class SnapshotFailure(BaseModel):
+    """Response model for a failed project snapshot."""
+
+    status: Literal["failure"]
+    error: ErrorDetail = Field(description="Error details.")
+
+
+SnapshotResponse = Annotated[
+    SnapshotSuccess | SnapshotFailure, Field(discriminator="status")
+]

--- a/tests/server/test_http_server.py
+++ b/tests/server/test_http_server.py
@@ -4,7 +4,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from kedro.server.http_server import create_http_server
-from kedro.server.models import RunResponse
+from kedro.server.models import RunSuccess
 
 
 class TestHTTPServerFactory:
@@ -71,9 +71,7 @@ class TestHTTPServerFactory:
         )
         mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
-                run_id="run-1", status="success", duration_ms=10.0
-            ),
+            return_value=RunSuccess(run_id="run-1", status="success", duration_ms=10.0),
         )
 
         app = create_http_server()

--- a/tests/server/test_run_endpoint.py
+++ b/tests/server/test_run_endpoint.py
@@ -6,7 +6,7 @@ from fastapi.testclient import TestClient
 from kedro.framework.project import settings
 from kedro.runner import AbstractRunner
 from kedro.server.http_server import _execute_pipeline, create_http_server
-from kedro.server.models import ErrorDetail, RunRequest, RunResponse
+from kedro.server.models import ErrorDetail, RunFailure, RunRequest, RunSuccess
 
 
 class _FakeRunner(AbstractRunner):
@@ -39,7 +39,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mock_execute = mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-1",
                 status="success",
                 duration_ms=10.0,
@@ -70,7 +70,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-2",
                 status="success",
                 duration_ms=10.0,
@@ -102,7 +102,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-3",
                 status="success",
                 duration_ms=10.0,
@@ -134,7 +134,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-4",
                 status="success",
                 duration_ms=10.0,
@@ -172,7 +172,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunFailure(
                 run_id="run-fail",
                 status="failure",
                 duration_ms=12.34,
@@ -212,7 +212,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mock_execute = mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-params",
                 status="success",
                 duration_ms=15.0,
@@ -256,7 +256,7 @@ class TestRunEndpoint:
         mocker.patch("kedro.server.http_server.bootstrap_project")
         mock_execute = mocker.patch(
             "kedro.server.http_server._execute_pipeline",
-            return_value=RunResponse(
+            return_value=RunSuccess(
                 run_id="run-partial",
                 status="success",
                 duration_ms=8.5,
@@ -336,7 +336,7 @@ class TestExecutePipeline:
         assert result.status == "success"
         assert result.run_id is not None
         assert result.duration_ms > 0
-        assert result.error is None
+        assert not hasattr(result, "error")
         mock_load_obj.assert_called_once_with("SequentialRunner", "kedro.runner")
         mock_session.run.assert_called_once()
         runner_used = mock_session.run.call_args.kwargs["runner"]

--- a/tests/server/test_snapshot_endpoint.py
+++ b/tests/server/test_snapshot_endpoint.py
@@ -118,10 +118,10 @@ class TestSnapshotEndpoint:
         )
         with TestClient(app) as client:
             payload = client.get("/snapshot").json()
-        assert payload["metadata"] is None
-        assert payload["pipelines"] is None
-        assert payload["datasets"] is None
-        assert payload["parameters"] is None
+        assert "metadata" not in payload
+        assert "pipelines" not in payload
+        assert "datasets" not in payload
+        assert "parameters" not in payload
 
     def test_snapshot_passes_conf_source_to_get_project_snapshot(
         self, mocker, make_http_server


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Resolve https://github.com/kedro-org/kedro/issues/5557

## Development notes
<!-- What have you changed, and how has this been tested? -->
- Split `RunResponse` into `RunSuccess` and `RunFailure`
- Split `SnapshotResponse` into `SnapshotSuccess` and `SnapshotFailure`
- Updated tests
- Updated docs

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
