### PR TITLE
Add note on ParallelRunner hooks limitation

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,8 @@
 
 ## Bug fixes and other changes
 ## Documentation changes
+* Documented hooks limitation when using `ParallelRunner`.
+
 ## Community contributions
 
 # Release 1.4.0

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,10 @@
 
 ## Community contributions
 
+Many thanks to the following Kedroids for contributing PRs to this release:
+
+* [Simon Bull](https://github.com/simon-b)
+
 # Release 1.4.0
 
 ## Major features and improvements

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -57,6 +57,9 @@ kedro run --runner=ThreadRunner
 
 For more information on how to maximise concurrency when using Kedro with PySpark, read our guide on [how to build a Kedro pipeline with PySpark](../integrations-and-plugins/pyspark_integration.md).
 
+!!! note
+    Hooks may not work as expected with `ParallelRunner` because worker processes may not execute `node` and `dataset` hooks. All hooks execute with `ThreadRunner`.
+
 ## Custom runners
 
 If the built-in Kedro runners do not meet your requirements, you can also define your own runner within your project. For example, you may want to add a dry runner, which lists which nodes would run without executing them:

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -28,8 +28,6 @@ kedro run --runner=SequentialRunner
 
 ### `ParallelRunner`
 
-#### Multiprocessing
-
 You can also run the nodes within the pipeline concurrently, using a `ParallelRunner` as follows:
 ```bash
 kedro run --runner=ParallelRunner
@@ -45,7 +43,11 @@ For the `ParallelRunner`, it is possible to manually select which multiprocessin
 
 To control which multiprocessing start method is used by `ParallelRunner`, set `KEDRO_MP_CONTEXT` to `fork`, `forkserver`, or `spawn`. If the variable is not set, the runner uses the system default.
 
-#### Multithreading
+!!! warning
+    `ParallelRunner` does not execute `node` and `dataset` hooks. If your project relies on these hooks, use `SequentialRunner` or `ThreadRunner` instead.
+
+### ThreadRunner
+
 While `ParallelRunner` uses multiprocessing, you can also run the pipeline with multithreading for concurrent execution by specifying `ThreadRunner` as follows:
 
 ```bash
@@ -56,9 +58,6 @@ kedro run --runner=ThreadRunner
     `SparkDataset` doesn't work as expected with `ParallelRunner`. To add concurrency to the pipeline with `SparkDataset`, you must use `ThreadRunner`.
 
 For more information on how to maximise concurrency when using Kedro with PySpark, read our guide on [how to build a Kedro pipeline with PySpark](../integrations-and-plugins/pyspark_integration.md).
-
-!!! note
-    Hooks may not work as expected with `ParallelRunner` because worker processes may not execute `node` and `dataset` hooks. All hooks execute with `ThreadRunner`.
 
 ## Custom runners
 

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -46,6 +46,11 @@ To control which multiprocessing start method is used by `ParallelRunner`, set `
 !!! warning
     `ParallelRunner` does not execute `node` and `dataset` hooks. If your project relies on these hooks, use `SequentialRunner` or `ThreadRunner` instead.
 
+!!! note
+    `SparkDataset` doesn't work as expected with `ParallelRunner`. To add concurrency to the pipeline with `SparkDataset`, you must use `ThreadRunner`.
+
+For more information on how to maximise concurrency when using Kedro with PySpark, read our guide on [how to build a Kedro pipeline with PySpark](../integrations-and-plugins/pyspark_integration.md).
+
 ### ThreadRunner
 
 While `ParallelRunner` uses multiprocessing, you can also run the pipeline with multithreading for concurrent execution by specifying `ThreadRunner` as follows:
@@ -53,11 +58,6 @@ While `ParallelRunner` uses multiprocessing, you can also run the pipeline with 
 ```bash
 kedro run --runner=ThreadRunner
 ```
-
-!!! note
-    `SparkDataset` doesn't work as expected with `ParallelRunner`. To add concurrency to the pipeline with `SparkDataset`, you must use `ThreadRunner`.
-
-For more information on how to maximise concurrency when using Kedro with PySpark, read our guide on [how to build a Kedro pipeline with PySpark](../integrations-and-plugins/pyspark_integration.md).
 
 ## Custom runners
 

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -51,7 +51,7 @@ To control which multiprocessing start method is used by `ParallelRunner`, set `
 
 For more information on how to maximise concurrency when using Kedro with PySpark, read our guide on [how to build a Kedro pipeline with PySpark](../integrations-and-plugins/pyspark_integration.md).
 
-### ThreadRunner
+### `ThreadRunner`
 
 While `ParallelRunner` uses multiprocessing, you can also run the pipeline with multithreading for concurrent execution by specifying `ThreadRunner` as follows:
 

--- a/docs/extend/hooks/introduction.md
+++ b/docs/extend/hooks/introduction.md
@@ -35,6 +35,11 @@ The full specifications for which you can inject additional behaviours by provid
 This diagram illustrates the execution order of hooks during `kedro run`:
 ![Kedro run hook execution order](../../meta/images/kedro_run_lifecycle.png)
 
+
+!!! warning
+    Some hooks may not execute when using `ParallelRunner`. Specifically, `catalog`, `context`, and `pipeline` hooks that run in the main process will execute, but `dataset` and `node` hooks may not run in the worker processes that run nodes in parallel.
+
+
 ### CLI Hooks
 
 Kedro defines a small set of CLI hooks that inject additional behaviour around execution of a Kedro CLI command:

--- a/docs/extend/hooks/introduction.md
+++ b/docs/extend/hooks/introduction.md
@@ -35,10 +35,8 @@ The full specifications for which you can inject additional behaviours by provid
 This diagram illustrates the execution order of hooks during `kedro run`:
 ![Kedro run hook execution order](../../meta/images/kedro_run_lifecycle.png)
 
-
 !!! warning
     Some hooks will not execute when using `ParallelRunner`. Specifically, `catalog`, `context`, and `pipeline` hooks that run in the main process will execute, but `dataset` and `node` hooks do not run in the worker processes that run nodes in parallel. Use `SequentialRunner` or `ThreadRunner` if your project relies on these hooks.
-
 
 ### CLI Hooks
 

--- a/docs/extend/hooks/introduction.md
+++ b/docs/extend/hooks/introduction.md
@@ -37,7 +37,7 @@ This diagram illustrates the execution order of hooks during `kedro run`:
 
 
 !!! warning
-    Some hooks may not execute when using `ParallelRunner`. Specifically, `catalog`, `context`, and `pipeline` hooks that run in the main process will execute, but `dataset` and `node` hooks may not run in the worker processes that run nodes in parallel.
+    Some hooks will not execute when using `ParallelRunner`. Specifically, `catalog`, `context`, and `pipeline` hooks that run in the main process will execute, but `dataset` and `node` hooks do not run in the worker processes that run nodes in parallel. Use `SequentialRunner` or `ThreadRunner` if your project relies on these hooks.
 
 
 ### CLI Hooks

--- a/kedro/runner/parallel_runner.py
+++ b/kedro/runner/parallel_runner.py
@@ -42,6 +42,11 @@ class ParallelRunner(AbstractRunner):
     Please note that this `runner` implementation validates dataset using the
     ``_validate_catalog`` method, which checks if any of the datasets are
     single process only using the `_SINGLE_PROCESS` dataset attribute.
+
+    !!! warning
+        This runner will not execute `node` and `dataset` hooks. Use
+        `SequentialRunner` or `ThreadRunner` if your project relies on these
+        hooks.
     """
 
     def __init__(


### PR DESCRIPTION
## Description

Some hooks do not run with ParallelRunner. This is noted in #4602, "Document that hooks don't work with ParallelRunner" but this has not been done yet.

## Development notes

- Verified hooks that work and don't [on mac]
- Did not test differences in linux where `fork` is used by `ParallelRunner`

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
