### PR TITLE
Improve error message for abstract dataset classes

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes and other changes
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.
+* Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
 

--- a/kedro/io/core.py
+++ b/kedro/io/core.py
@@ -14,7 +14,7 @@ from collections import namedtuple
 from datetime import datetime, timezone
 from functools import wraps
 from glob import iglob
-from inspect import getcallargs
+from inspect import getcallargs, isabstract
 from pathlib import Path, PurePath, PurePosixPath
 from typing import (  # noqa: UP035
     TYPE_CHECKING,
@@ -194,6 +194,12 @@ class AbstractDataset(abc.ABC, Generic[_DI, _DO]):
         try:
             dataset = class_obj(**config)
         except TypeError as err:
+            if isabstract(class_obj):
+                raise DatasetError(
+                    f"\n{err}.\nDataset '{name}' cannot be instantiated. "
+                    f"Please implement the missing abstract methods in "
+                    f"'{class_obj.__module__}.{class_obj.__qualname__}'."
+                ) from err
             raise DatasetError(
                 f"\n{err}.\nDataset '{name}' must only contain arguments valid for the "
                 f"constructor of '{class_obj.__module__}.{class_obj.__qualname__}'."

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -67,6 +67,11 @@ class MyDataset(AbstractDataset):
             file.write(data)
 
 
+class IncompleteDataset(AbstractDataset):
+    def load(self):
+        return None
+
+
 class MyVersionedDataset(AbstractVersionedDataset[str, str]):
     def __init__(
         self,
@@ -438,6 +443,29 @@ class TestAbstractDataset:
                 save_version=None,
             )
             assert "must only contain arguments valid" in str(exc_info.value)
+
+    def test_from_config_abstract_dataset_type_error(self, mocker):
+        mocker.patch(
+            "kedro.io.core.parse_dataset_definition",
+            return_value=(IncompleteDataset, {}),
+        )
+
+        with pytest.raises(DatasetError) as exc_info:
+            MyDataset.from_config(
+                name="abstract_dataset",
+                config={"type": "IncompleteDataset"},
+                load_version=None,
+                save_version=None,
+            )
+
+        message = str(exc_info.value)
+        assert "abstract class IncompleteDataset" in message
+        assert "Dataset 'abstract_dataset' cannot be instantiated" in message
+        assert (
+            "Please implement the missing abstract methods in "
+            f"'{IncompleteDataset.__module__}.{IncompleteDataset.__qualname__}'"
+        ) in message
+        assert "must only contain arguments valid" not in message
 
     def test_from_config_class_obj_exception(self, mocker):
         mock_class_obj = mocker.Mock()


### PR DESCRIPTION
## Description
Fixes #3385.

When `AbstractDataset.from_config()` catches a `TypeError`, it currently always appends the constructor-argument guidance. That is useful for invalid dataset constructor parameters, but misleading when the real cause is that a custom dataset class is still abstract because required methods were not implemented.

This change detects abstract dataset classes with `inspect.isabstract()` and preserves the abstract-class instantiation error without appending the constructor-argument hint.

## Development notes
- Added a regression test for an incomplete `AbstractDataset` subclass.
- Kept the existing constructor-argument `TypeError` path unchanged for non-abstract classes.
- Added an Upcoming Release note under bug fixes.

Validation run locally:
- `.venv/bin/python - <<'PY' ...` minimal reproduction script confirmed the constructor-argument hint is no longer appended for abstract dataset classes.
- `.venv/bin/python -m pytest tests/io/test_core.py -q --no-cov` -> 90 passed.
- `.venv/bin/python -m pytest tests/io/test_core.py -q` -> 90 tests passed, then failed only because the repository default coverage gate requires full-suite 100% coverage for this single-file run.
- `.venv/bin/ruff format --check kedro/io/core.py tests/io/test_core.py` -> 2 files already formatted.
- `.venv/bin/ruff check kedro/io/core.py tests/io/test_core.py` is blocked by three pre-existing lint findings in `tests/io/test_core.py` outside this diff: PLC0415 at line 356 and RUF043 at lines 375 and 689.
- `git diff --check`

## Developer Certificate of Origin
- [x] Signed off each commit with a Developer Certificate of Origin (DCO).

## Checklist

- [x] Read the contributing guidelines
- [x] Signed off each commit with a Developer Certificate of Origin (DCO)
- [x] Opened this PR as a Draft Pull Request if it is work-in-progress
- [x] Updated the documentation to reflect the code changes - not needed for this error-message fix
- [x] Added a description of this change in the RELEASE.md file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team - not applicable