### PR TITLE
Fix Rich logging markup handling

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,6 +12,7 @@
 * Documented hooks limitation when using `ParallelRunner`.
 
 ## Community contributions
+* [Feng Jikui](https://github.com/fengjikui)
 
 Many thanks to the following Kedroids for contributing PRs to this release:
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,6 +7,7 @@
 
 
 ## Bug fixes and other changes
+* Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.
 ## Documentation changes
 ## Community contributions
 

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -29,7 +29,6 @@ from kedro.io.core import (
 )
 from kedro.io.memory_dataset import MemoryDataset, _is_memory_dataset
 from kedro.io.shared_memory_dataset import SharedMemoryDataset
-from kedro.utils import _format_rich, _has_rich_handler
 
 if TYPE_CHECKING:
     from multiprocessing.managers import SyncManager
@@ -265,8 +264,6 @@ class DataCatalog(CatalogProtocol):
         self._load_versions, self._save_version = self._validate_versions(
             datasets, load_versions or {}, save_version
         )
-
-        self._use_rich_markup = _has_rich_handler()
 
         for ds_name in list(self._config_resolver.config):
             if ds_name in self._datasets:
@@ -1008,9 +1005,9 @@ class DataCatalog(CatalogProtocol):
 
         self._logger.info(
             "Saving data to %s (%s)...",
-            _format_rich(ds_name, "dark_orange") if self._use_rich_markup else ds_name,
+            ds_name,
             type(dataset).__name__,
-            extra={"markup": True},
+            extra={"rich_format": ["dark_orange"]},
         )
 
         try:
@@ -1052,9 +1049,9 @@ class DataCatalog(CatalogProtocol):
 
         self._logger.info(
             "Loading data from %s (%s)...",
-            _format_rich(ds_name, "dark_orange") if self._use_rich_markup else ds_name,
+            ds_name,
             type(dataset).__name__,
-            extra={"markup": True},
+            extra={"rich_format": ["dark_orange"]},
         )
 
         try:

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -443,7 +443,7 @@ class Node:
                 mermaid = "graph LR\\n"
                 for i, step in enumerate(steps):
                     if i < len(steps) - 1:
-                        mermaid += f"    {step} --> {steps[i+1]}\\n"
+                        mermaid += f"    {step} --> {steps[i + 1]}\\n"
 
                 return MermaidPreview(content=mermaid)
 
@@ -528,7 +528,7 @@ class Node:
             keys are defined by the node outputs.
 
         """
-        self._logger.info("Running node: %s", str(self))
+        self._logger.info("Running node: %s", str(self), extra={"markup": False})
 
         outputs = None
 
@@ -557,7 +557,7 @@ class Node:
                 "Node %s failed with error: \n%s",
                 str(self),
                 str(exc),
-                extra={"markup": True},
+                extra={"markup": False},
             )
             raise exc
 

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -1,4 +1,5 @@
 import importlib
+import io
 import logging
 import sys
 from pathlib import Path
@@ -6,10 +7,12 @@ from unittest import mock
 
 import pytest
 import yaml
+from rich.console import Console
 
 from kedro.framework.project import LOGGING, configure_logging, configure_project
 from kedro.io import DataCatalog
 from kedro.logging import RichHandler, _format_rich
+from kedro.pipeline import node
 from kedro.utils import _has_rich_handler
 
 
@@ -224,6 +227,68 @@ def test_logger_without_rich_markup():
 
     for record in custom_handler.records:
         assert "[dark_orange]" not in record.message
+
+
+def test_data_catalog_rich_markup_does_not_leak_to_plain_handlers():
+    class CustomHandler(logging.Handler):
+        def __init__(self):
+            super().__init__()
+            self.messages = []
+
+        def emit(self, record):
+            self.messages.append(record.getMessage())
+
+    stream = io.StringIO()
+    rich_handler = RichHandler(
+        console=Console(file=stream, force_terminal=True, color_system=None, width=120),
+        show_time=False,
+        show_level=False,
+        show_path=False,
+    )
+    custom_handler = CustomHandler()
+    root_logger = logging.getLogger()
+    original_handlers = root_logger.handlers[:]
+    original_level = root_logger.level
+
+    try:
+        root_logger.handlers[:] = [rich_handler, custom_handler]
+        root_logger.setLevel(logging.INFO)
+
+        catalog = DataCatalog.from_config({"dummy": {"type": "MemoryDataset"}})
+        catalog.save("dummy", ("data",))
+
+        assert any("Saving data to dummy" in msg for msg in custom_handler.messages)
+        assert all("[dark_orange]" not in msg for msg in custom_handler.messages)
+    finally:
+        root_logger.handlers[:] = original_handlers
+        root_logger.setLevel(original_level)
+
+
+def test_rich_handler_preserves_node_brackets():
+    stream = io.StringIO()
+    rich_handler = RichHandler(
+        console=Console(file=stream, force_terminal=True, color_system=None, width=120),
+        show_time=False,
+        show_level=False,
+        show_path=False,
+    )
+    logger = logging.getLogger("kedro.pipeline.node")
+    original_handlers = logger.handlers[:]
+    original_level = logger.level
+    original_propagate = logger.propagate
+
+    try:
+        logger.handlers[:] = [rich_handler]
+        logger.setLevel(logging.INFO)
+        logger.propagate = False
+
+        node(lambda x: x, "in", "out").run({"in": "value"})
+
+        assert "Running node: <lambda>([in]) -> [out]" in stream.getvalue()
+    finally:
+        logger.handlers[:] = original_handlers
+        logger.setLevel(original_level)
+        logger.propagate = original_propagate
 
 
 def test_configure_project_preserve_logging_keeps_runtime_handlers():


### PR DESCRIPTION
## Description
Fixes #5199.

Kedro's Rich logging integration currently treats node input/output brackets such as `[companies]` as Rich markup in console logs, so the bracketed names can disappear from the rendered message. At the same time, `DataCatalog.load()` and `DataCatalog.save()` pre-format dataset names with Rich tags when a Rich handler exists, which leaks strings such as `[dark_orange]dataset[/dark_orange]` into plain/file log handlers.

## Development notes
- Keep `Node.__str__()` unchanged and disable Rich markup only for the node log records that interpolate the node string.
- Use the existing `rich_format` mechanism for `DataCatalog` load/save messages so only `kedro.logging.RichHandler` colours the dataset argument on its copied log record.
- Remove the catalog-level `_use_rich_markup` state because plain log records no longer need preformatted markup.
- Add regression tests for both behaviours.

Validation run locally:

```bash
../kedro/.venv/bin/python -m pytest tests/framework/project/test_logging.py tests/pipeline/test_node.py tests/io/test_data_catalog.py -q --no-cov
../kedro/.venv/bin/ruff format --check kedro/io/data_catalog.py kedro/pipeline/node.py tests/framework/project/test_logging.py
../kedro/.venv/bin/ruff check --select F401,I kedro/io/data_catalog.py kedro/pipeline/node.py tests/framework/project/test_logging.py
git diff --check
```

Results:
- `pytest`: 226 passed
- `ruff format --check`: passed
- `ruff check --select F401,I`: passed
- `git diff --check`: passed

## Developer Certificate of Origin
All commits are signed off with `Signed-off-by`.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
