### PR TITLE
docs: update --pipeline to --pipelines and document multi-pipeline execution

### DIFF
--- a/docs/build/pipeline_registry.md
+++ b/docs/build/pipeline_registry.md
@@ -25,7 +25,7 @@ def register_pipelines() -> Dict[str, Pipeline]:
     }
 ```
 
-As a reminder, [running `kedro run` without the `--pipeline` option runs the default pipeline](./run_a_pipeline.md#run-a-pipeline-by-name).
+As a reminder, [running `kedro run` without the `--pipelines` option runs the default pipeline](./run_a_pipeline.md#run-a-pipeline-by-name).
 
 !!! note
     The order in which you add the pipelines together is not significant (`data_science_pipeline + data_processing_pipeline` would produce the same result), since Kedro automatically detects the data-centric execution order for all the nodes in the resulting pipeline.

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -190,6 +190,13 @@ Then, from the command line, execute the following:
 kedro run --pipelines=my_pipeline
 ```
 
+To run multiple pipelines in a single command, pass a comma-separated 
+list of pipeline names:
+
+```bash
+kedro run --pipelines=data_processing,data_science
+```
+
 !!! note
     If you specify `kedro run` without the `--pipelines` option, it runs the `__default__` pipeline from the dictionary returned by `register_pipelines()`.
 

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -252,7 +252,7 @@ where `config.yml` is formatted as below (for example):
 ```yaml
 run:
   tags: tag1, tag2, tag3
-  pipeline: pipeline1
+  pipelines: pipeline1
   runner: ParallelRunner
   node_names: node1, node2
   env: env1

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -187,11 +187,11 @@ To run the pipeline by its name, you need to add your new pipeline to the `regis
 Then, from the command line, execute the following:
 
 ```bash
-kedro run --pipeline=my_pipeline
+kedro run --pipelines=my_pipeline
 ```
 
 !!! note
-    If you specify `kedro run` without the `--pipeline` option, it runs the `__default__` pipeline from the dictionary returned by `register_pipelines()`.
+    If you specify `kedro run` without the `--pipelines` option, it runs the `__default__` pipeline from the dictionary returned by `register_pipelines()`.
 
 
 Further information about `kedro run` can be found in the [Kedro CLI documentation](../getting-started/commands_reference.md#kedro-run).

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -190,8 +190,7 @@ Then, from the command line, execute the following:
 kedro run --pipelines=my_pipeline
 ```
 
-To run multiple pipelines in a single command, pass a comma-separated 
-list of pipeline names:
+To run multiple pipelines in a single command, pass a comma-separated list of pipeline names:
 
 ```bash
 kedro run --pipelines=data_processing,data_science

--- a/docs/deploy/nodes_grouping.md
+++ b/docs/deploy/nodes_grouping.md
@@ -8,19 +8,22 @@ If your project contains different pipelines, you can use them as predefined nod
 <br>
 ![Switching between different pipelines in Kedro Viz](../meta/images/kedro_viz_switching_pipeline.gif)
 
-If you want to group nodes differently from the existing pipeline structure, you can use tags or namespaces instead of creating a new pipeline. The `kedro run --pipeline` command allows running one pipeline at a time, so multiple pipelines cannot be executed in a single step. While you can switch between pipelines in Kedro Viz, the flowchart view does not support collapsing or expanding them.
+If you want to group nodes differently from the existing pipeline structure, you can use tags or namespaces instead of creating a new pipeline. The `--pipelines` flag supports running one or more pipelines in a single command. While you can switch between pipelines in Kedro Viz, the flowchart view does not support collapsing or expanding them.
 
 **Best used when**
-- You have already separated your logic into different pipelines, and your project is structured to execute them independently in the deployment environment.
+- You have already separated your logic into different pipelines, and your project is structured to execute them independently or together in sequence in the deployment environment.
 
 **Not to use when**
-- You need to run more than one pipeline at a time.
 - You want to use the expand and collapse functionality in Kedro Viz.
 
 **How to use**
 
 ```bash
-  kedro run --pipeline=<your_pipeline_name>
+  # Run a single pipeline
+kedro run --pipelines=<pipeline_name>
+
+# Run multiple pipelines in one command
+kedro run --pipelines=<pipeline_name1>,<pipeline_name2>
 ```
 
 More information: [Run a pipeline by name](https://docs.kedro.org/en/stable/build/run_a_pipeline/#run-a-pipeline-by-name)
@@ -110,5 +113,6 @@ This reduces the number of Airflow tasks and keeps logically related nodes toget
 |--------|-----------|------|-----------|
 | **What Works** | If you're happy with how the nodes are structured in your existing pipeline, or your pipeline is low complexity and a new grouping view is not required then you don't have to use any alternatives | Tagging individual nodes or the entire pipeline allows flexible execution of specific sections without altering the pipeline structure, and Kedro-Viz offers clear visualisation of these tagged nodes for better understanding. | Namespaces group nodes to ensure clear dependencies and separation within a pipeline, allow selective execution, and can be visualised using Kedro-Viz. |
 | **What Doesn't Work** | If you want to group nodes differently from the current pipeline structure, instead of creating a new pipeline, you can use alternative grouping methods such as tags or namespaces. | Lack of hierarchical structure, using tags makes debugging and maintaining the codebase more challenging | Defining namespaces at the node level behaves like tags without ensuring execution consistency, while defining them at the pipeline level helps create a modular structure by renaming inputs, outputs, and parameters but can introduce naming conflicts if the pipeline is connected elsewhere or parameters are referenced outside the pipeline. |
-| **Syntax** | `kedro run --pipeline=<your_pipeline_name>` | `kedro run --tags=<your_tag_name>` | `kedro run --namespaces=< namespace1,namespace2 >` |
+| **Syntax** | `kedro run --pipelines=<your_pipeline_names>` | `kedro run --tags=<your_tag_name>` | `kedro run --namespaces=< namespace1,namespace2 >` |
 | **Deployment Plugin Support** | N/A | N/A | `kedro airflow create --group-by namespace`; [AWS Step Functions](./supported-platforms/aws_step_functions.md) |
+

--- a/docs/deploy/nodes_grouping.md
+++ b/docs/deploy/nodes_grouping.md
@@ -116,3 +116,4 @@ This reduces the number of Airflow tasks and keeps logically related nodes toget
 | **Syntax** | `kedro run --pipelines=<your_pipeline_names>` | `kedro run --tags=<your_tag_name>` | `kedro run --namespaces=< namespace1,namespace2 >` |
 | **Deployment Plugin Support** | N/A | N/A | `kedro airflow create --group-by namespace`; [AWS Step Functions](./supported-platforms/aws_step_functions.md) |
 
+

--- a/docs/deploy/nodes_grouping.md
+++ b/docs/deploy/nodes_grouping.md
@@ -19,7 +19,7 @@ If you want to group nodes differently from the existing pipeline structure, you
 **How to use**
 
 ```bash
-  # Run a single pipeline
+# Run a single pipeline
 kedro run --pipelines=<pipeline_name>
 
 # Run multiple pipelines in one command

--- a/docs/deploy/nodes_grouping.md
+++ b/docs/deploy/nodes_grouping.md
@@ -115,5 +115,3 @@ This reduces the number of Airflow tasks and keeps logically related nodes toget
 | **What Doesn't Work** | If you want to group nodes differently from the current pipeline structure, instead of creating a new pipeline, you can use alternative grouping methods such as tags or namespaces. | Lack of hierarchical structure, using tags makes debugging and maintaining the codebase more challenging | Defining namespaces at the node level behaves like tags without ensuring execution consistency, while defining them at the pipeline level helps create a modular structure by renaming inputs, outputs, and parameters but can introduce naming conflicts if the pipeline is connected elsewhere or parameters are referenced outside the pipeline. |
 | **Syntax** | `kedro run --pipelines=<your_pipeline_names>` | `kedro run --tags=<your_tag_name>` | `kedro run --namespaces=< namespace1,namespace2 >` |
 | **Deployment Plugin Support** | N/A | N/A | `kedro airflow create --group-by namespace`; [AWS Step Functions](./supported-platforms/aws_step_functions.md) |
-
-

--- a/docs/deploy/package_a_project.md
+++ b/docs/deploy/package_a_project.md
@@ -56,7 +56,7 @@ To run your packaged project interactively using code, you can import `main` fro
 from <package_name>.__main__ import main
 
 main(
-    ["--pipeline", "__default__"]
+    ["--pipelines", "__default__"]
 )  # or simply main() if you don't want to provide any arguments
 ```
 

--- a/docs/deploy/supported-platforms/amazon_emr_serverless.md
+++ b/docs/deploy/supported-platforms/amazon_emr_serverless.md
@@ -179,7 +179,7 @@ aws emr-serverless start-job-run \
     --job-driver '{
         "sparkSubmit": {
             "entryPoint": "<s3-path-to-entrypoint-script>",
-            "entryPointArguments": ["--env", "<emr-conf>", "--runner", "ThreadRunner", "--pipelines", "<kedro-pipeline-name>"],
+            "entryPointArguments": ["--env", "<emr-conf>", "--runner", "ThreadRunner", "--pipelines", "<kedro-pipeline-names>"],
             "sparkSubmitParameters": "--conf spark.emr-serverless.driverEnv.PYSPARK_DRIVER_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python --conf spark.emr-serverless.driverEnv.PYSPARK_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python --conf spark.executorEnv.PYSPARK_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python"
         }
     }'

--- a/docs/deploy/supported-platforms/amazon_emr_serverless.md
+++ b/docs/deploy/supported-platforms/amazon_emr_serverless.md
@@ -179,7 +179,7 @@ aws emr-serverless start-job-run \
     --job-driver '{
         "sparkSubmit": {
             "entryPoint": "<s3-path-to-entrypoint-script>",
-            "entryPointArguments": ["--env", "<emr-conf>", "--runner", "ThreadRunner", "--pipeline", "<kedro-pipeline-name>"],
+            "entryPointArguments": ["--env", "<emr-conf>", "--runner", "ThreadRunner", "--pipelines", "<kedro-pipeline-name>"],
             "sparkSubmitParameters": "--conf spark.emr-serverless.driverEnv.PYSPARK_DRIVER_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python --conf spark.emr-serverless.driverEnv.PYSPARK_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python --conf spark.executorEnv.PYSPARK_PYTHON=/usr/.pyenv/versions/3.9.16/bin/python"
         }
     }'

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -38,7 +38,7 @@ cd spaceflights
 Lastly, verify that everything works:
 
 ```bash
-uv run kedro run --pipeline __default__
+uv run kedro run --pipelines __default__
 ```
 
 ## How to verify your Kedro installation

--- a/docs/ide/set_up_vscode.md
+++ b/docs/ide/set_up_vscode.md
@@ -275,7 +275,7 @@ Edit the `launch.json` that opens in the editor with:
             "module": "kedro",
             "args": ["run"]
             // Any other arguments should be passed as a comma-separated-list
-            // e.g "args": ["run", "--pipeline", "pipeline_name"]
+            // e.g "args": ["run", "--pipelines", "pipeline_name"]
         }
     ]
 }

--- a/docs/tutorials/add_another_pipeline.md
+++ b/docs/tutorials/add_another_pipeline.md
@@ -229,10 +229,10 @@ As you can see, the `data_processing` and `data_science` pipelines ran without e
 
 There may be occasions when you want to run part of the default pipeline. For example, you could skip `data_processing` execution and run the `data_science` pipeline to tune the hyperparameters of the price prediction model.
 
-You can 'slice' the pipeline and specify the part you want to run by using the `--pipeline` option. For example, to run the pipeline named `data_science` (as labelled automatically in `register_pipelines`), execute the following command:
+You can 'slice' the pipeline and specify the part you want to run by using the `--pipelines` option. For example, to run the pipeline named `data_science` (as labelled automatically in `register_pipelines`), execute the following command:
 
 ```bash
-kedro run --pipeline=data_science
+kedro run --pipelines=data_science
 ```
 
 There are a range of options to run sections of the default pipeline as described in the [pipeline slicing documentation](../build/slice_a_pipeline.md) and the ``kedro run`` [CLI documentation](../getting-started/commands_reference.md#kedro-run).

--- a/docs/tutorials/spaceflights_tutorial_faqs.md
+++ b/docs/tutorials/spaceflights_tutorial_faqs.md
@@ -53,7 +53,7 @@ To run the pipeline, ensure all required input datasets exist; otherwise you may
 
 
 ```bash
-kedro run --pipeline=data_science
+kedro run --pipelines=data_science
 
 2019-10-04 12:36:12,158 - kedro.io.data_catalog - INFO - Loading data from `model_input_table` (CSVDataset)...
 2019-10-04 12:36:12,158 - kedro.runner.sequential_runner - WARNING - There are 3 nodes that have not run.


### PR DESCRIPTION
## Description
Updates documentation to reflect the deprecation of `--pipeline` 
and the introduction of `--pipelines` in kedro run.

Closes #4950

## Changes Made

### Updated flag references
- `build/run_a_pipeline.md` — updated `--pipeline` to `--pipelines` 
  in CLI examples
- `build/pipeline_registry.md` — updated flag reference and example
- `tutorials/add_another_pipeline.md` — updated tutorial command
- `tutorials/spaceflights_tutorial_faqs.md` — updated FAQ example
- `getting-started/install.md` — updated quickstart example

### Corrected factually incorrect statement
- `deploy/nodes_grouping.md` — removed the claim that "multiple 
  pipelines cannot be executed in a single step" which is no longer 
  true. Updated to document `--pipelines` comma-separated behaviour 
  with example input.

### Left unchanged (intentionally)
- `about/telemetry.md` — historical telemetry example, not user-facing
- `deploy/supported-platforms/argo.md` — custom Click code, 
  not a docs example
- `deploy/supported-platforms/prefect.md` — same reason
- `getting-started/commands_reference.md` — Click option definition

## Testing
Tested `--pipelines` flag against spaceflights tutorial:

- `kedro run` → 9 tasks, 13.4 seconds
- `kedro run --pipelines data_processing,data_science` → 6 tasks, 
  3.3 seconds

Confirmed that `--pipelines` correctly executes only nodes belonging 
to specified pipelines, skipping unspecified pipeline nodes.