### PR TITLE
Fix build failure caused by Pytest 9. 1.0 release.

### DIFF
--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -15,11 +15,13 @@ PACKAGE_NAME = "dummy_package"
 PIPELINE_NAME = "my_pipeline"
 
 
-@pytest.fixture(params=["base"])
+@pytest.fixture
 def make_pipelines(request, fake_repo_path, fake_package_path, mocker):
     source_path = fake_package_path / "pipelines" / PIPELINE_NAME
     tests_path = fake_repo_path / "tests" / "pipelines" / PIPELINE_NAME
-    conf_path = fake_repo_path / settings.CONF_SOURCE / request.param
+    conf_path = (
+        fake_repo_path / settings.CONF_SOURCE / getattr(request, "param", "base")
+    )
     # old conf structure for 'pipeline delete' command backward compatibility
     old_conf_path = conf_path / "parameters"
 

--- a/tests/framework/context/test_context.py
+++ b/tests/framework/context/test_context.py
@@ -109,9 +109,9 @@ def local_config(tmp_path):
     }
 
 
-@pytest.fixture(params=[None])
+@pytest.fixture
 def env(request):
-    return request.param
+    return getattr(request, "param", None)
 
 
 @pytest.fixture
@@ -181,9 +181,9 @@ pyproject_toml_payload = {
 }
 
 
-@pytest.fixture(params=[None])
+@pytest.fixture
 def runtime_params(request):
-    return request.param
+    return getattr(request, "param", None)
 
 
 @pytest.fixture

--- a/tests/io/test_core.py
+++ b/tests/io/test_core.py
@@ -165,14 +165,14 @@ class MyOtherVersionedDataset(MyLocalVersionedDataset):
         return self._fs.exists(load_path)
 
 
-@pytest.fixture(params=[None])
+@pytest.fixture
 def load_version(request):
-    return request.param
+    return getattr(request, "param", None)
 
 
-@pytest.fixture(params=[None])
+@pytest.fixture
 def save_version(request):
-    return request.param or generate_timestamp()
+    return getattr(request, "param", None) or generate_timestamp()
 
 
 @pytest.fixture(params=[None])

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -111,9 +111,6 @@ class TestMemoryDataset:
 
         assert not _check_equals(memory_dataset.load(), new_data)
 
-    @pytest.mark.parametrize(
-        "input_data", ["dummy_dataframe", "dummy_numpy_array"], indirect=True
-    )
     def test_load_returns_new_object(self, memory_dataset, input_data):
         """Test that consecutive loads point to different objects in case of a
         pandas DataFrame and numpy array"""
@@ -141,22 +138,13 @@ class TestMemoryDataset:
         with pytest.raises(DatasetError, match=pattern):
             MemoryDataset().save(None)
 
-    @pytest.mark.parametrize(
-        "input_data,expected",
-        [
-            (
-                "dummy_dataframe",
-                "kedro.io.memory_dataset.MemoryDataset(data='<DataFrame>')",
-            ),
-            (
-                "dummy_numpy_array",
-                "kedro.io.memory_dataset.MemoryDataset(data='<ndarray>')",
-            ),
-        ],
-        indirect=["input_data"],
-    )
-    def test_str_repr_representation(self, memory_dataset, input_data, expected):
+    def test_str_repr_representation(self, memory_dataset, input_data):
         """Test string representation of the dataset"""
+        _expected = {
+            pd.DataFrame: "kedro.io.memory_dataset.MemoryDataset(data='<DataFrame>')",
+            np.ndarray: "kedro.io.memory_dataset.MemoryDataset(data='<ndarray>')",
+        }
+        expected = _expected[type(input_data)]
         assert expected in str(memory_dataset)
         assert expected in repr(memory_dataset)
 

--- a/tests/io/test_shared_memory_dataset.py
+++ b/tests/io/test_shared_memory_dataset.py
@@ -45,9 +45,6 @@ class TestSharedMemoryDataset:
 
         assert not _check_equals(shared_memory_dataset.load(), new_data)
 
-    @pytest.mark.parametrize(
-        "input_data", ["dummy_dataframe", "dummy_numpy_array"], indirect=True
-    )
     def test_load_returns_new_object(self, shared_memory_dataset, input_data):
         """Test that consecutive loads point to different objects in case of a
         pandas DataFrame and numpy array"""


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Pytest 9.1.0 was released on June 13th and it caused our CI to fail.

Specifically, it was triggered by this PR: https://github.com/pytest-dev/pytest/pull/14566

Before, override chains were resolved by registration order in a "last registered wins" manner. When a test used `@pytest.mark.parametrize("fixture_name", [...], indirect=True)`, that indirect parametrize registered after the fixture's own `params=[...]`, so it quietly won and the fixture's params were ignored for that test.

After the PR, override chains are now ordered by visibility in the collection tree. The side effect is that pytest now sees both parametrizations as active simultaneously, which it correctly rejects as duplicate parametrization, causing the error we are seeing: https://github.com/kedro-org/kedro/actions/runs/27483651658/job/81235700803

Fixtures that need to be overridable per-test can just have `getattr(request, "param", default)`.

## Development notes
<!-- What have you changed, and how has this been tested? -->


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
