### PR TITLE
fix: reject Python keywords as pipeline names in kedro pipeline create

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,6 +10,7 @@
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
+* Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
 * Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.
+
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
 

--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import keyword
 import re
 import shutil
 from pathlib import Path
@@ -64,6 +65,12 @@ def _assert_pkg_name_ok(pkg_name: str) -> None:
     if not re.match(r"^\w+$", pkg_name[1:]):
         message = (
             base_message + " It must contain only letters, digits, and/or underscores."
+        )
+        raise KedroCliError(message)
+    if keyword.iskeyword(pkg_name):
+        message = (
+            base_message
+            + f" '{pkg_name}' is a Python keyword and cannot be used as a package name."
         )
         raise KedroCliError(message)
 

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -43,6 +43,7 @@ def make_pipelines(request, fake_repo_path, fake_package_path, mocker):
 LETTER_ERROR = "It must contain only letters, digits, and/or underscores."
 FIRST_CHAR_ERROR = "It must start with a letter or underscore."
 TOO_SHORT_ERROR = "It must be at least 2 characters long."
+KEYWORD_ERROR = "is a Python keyword and cannot be used as a package name."
 
 
 @pytest.mark.usefixtures("chdir_to_dummy_project")
@@ -276,6 +277,10 @@ class TestPipelineCreateCommand:
             ("bad%name", LETTER_ERROR),
             ("1bad", FIRST_CHAR_ERROR),
             ("a", TOO_SHORT_ERROR),
+            ("for", KEYWORD_ERROR),
+            ("if", KEYWORD_ERROR),
+            ("import", KEYWORD_ERROR),
+            ("return", KEYWORD_ERROR),
         ],
     )
     def test_bad_pipeline_name(


### PR DESCRIPTION
## Description

Closes #5610

`kedro pipeline create` accepted Python reserved keywords (`for`, `if`, `while`, `import`, `return`, `class`, etc.) as valid pipeline names. The existing `_assert_pkg_name_ok` validator only checked character set and minimum length, it never called `keyword.iskeyword()`. This allowed creating a pipeline directory on disk that cannot be imported with standard Python syntax.

## Changes

- Added `import keyword` to `kedro/framework/cli/pipeline.py`
- Added a `keyword.iskeyword()` check at the end of `_assert_pkg_name_ok`, raising `KedroCliError` with a clear message — reusing the same validation pattern introduced in PR #5608 for `kedro new`
- Added `for`, `if`, `import`, `return` to the existing `test_bad_pipeline_name` parametrize list

## What was tested

```
tests/framework/cli/pipeline/test_pipeline.py::TestPipelineCreateCommand::test_bad_pipeline_name
8 passed
```

Before the fix:
```
kedro pipeline create for  ->  Pipeline 'for' was successfully created.
```

After the fix:
```
kedro pipeline create for  ->  Error: 'for' is not a valid Python package name. 'for' is a Python keyword and cannot be used as a package name.
```