### PR TITLE
fix: reject dunder names as pipeline names and skip them in find_pipelines

### DIFF
--- a/kedro/framework/cli/pipeline.py
+++ b/kedro/framework/cli/pipeline.py
@@ -66,6 +66,12 @@ def _assert_pkg_name_ok(pkg_name: str) -> None:
             base_message + " It must contain only letters, digits, and/or underscores."
         )
         raise KedroCliError(message)
+    if pkg_name.startswith("__") and pkg_name.endswith("__"):
+        message = (
+            base_message
+            + f" '{pkg_name}' is a reserved dunder name and cannot be used as a pipeline name."
+        )
+        raise KedroCliError(message)
 
 
 def _check_pipeline_name(ctx: click.Context, param: Any, value: str) -> str:

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -556,6 +556,10 @@ def find_pipelines(  # noqa: PLR0912, PLR0915
         # Prevent imports of hidden directories/files
         if pipeline_name.startswith("."):
             continue
+        # Skip dunder directories — importing e.g. package.pipelines.__init__
+        # resolves to the pipelines package itself, not the subdirectory.
+        if pipeline_name.startswith("__") and pipeline_name.endswith("__"):
+            continue
 
         if requested_pipelines is not None and pipeline_name not in requested_pipelines:
             continue

--- a/tests/framework/cli/pipeline/test_pipeline.py
+++ b/tests/framework/cli/pipeline/test_pipeline.py
@@ -43,6 +43,7 @@ def make_pipelines(request, fake_repo_path, fake_package_path, mocker):
 LETTER_ERROR = "It must contain only letters, digits, and/or underscores."
 FIRST_CHAR_ERROR = "It must start with a letter or underscore."
 TOO_SHORT_ERROR = "It must be at least 2 characters long."
+DUNDER_ERROR = "is a reserved dunder name and cannot be used as a pipeline name."
 
 
 @pytest.mark.usefixtures("chdir_to_dummy_project")
@@ -276,6 +277,8 @@ class TestPipelineCreateCommand:
             ("bad%name", LETTER_ERROR),
             ("1bad", FIRST_CHAR_ERROR),
             ("a", TOO_SHORT_ERROR),
+            ("__init__", DUNDER_ERROR),
+            ("__main__", DUNDER_ERROR),
         ],
     )
     def test_bad_pipeline_name(

--- a/tests/framework/project/test_pipeline_discovery.py
+++ b/tests/framework/project/test_pipeline_discovery.py
@@ -119,6 +119,38 @@ def test_find_pipelines_skips_hidden_modules(
     [(x, x) for x in [set(), {"my_pipeline"}]],
     indirect=True,
 )
+def test_find_pipelines_skips_dunder_directories(
+    mock_package_name_with_pipelines, pipeline_names
+):
+    pipelines_dir = Path(sys.path[0]) / mock_package_name_with_pipelines / "pipelines"
+    for dunder_name in ("__init__", "__main__"):
+        pipeline_dir = pipelines_dir / dunder_name
+        pipeline_dir.mkdir()
+        (pipeline_dir / "__init__.py").write_text(
+            textwrap.dedent(
+                """
+                from __future__ import annotations
+
+                from kedro.pipeline import Pipeline, node, pipeline
+
+
+                def create_pipeline(**kwargs) -> Pipeline:
+                    return pipeline([node(lambda: 1, None, "simple_pipeline")])
+                """
+            )
+        )
+
+    configure_project(mock_package_name_with_pipelines)
+    pipelines = find_pipelines()
+    assert set(pipelines) == pipeline_names | {"__default__"}
+    assert sum(pipelines.values()).outputs() == pipeline_names
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines,pipeline_names",
+    [(x, x) for x in [set(), {"my_pipeline"}]],
+    indirect=True,
+)
 def test_find_pipelines_skips_modules_with_unexpected_return_value_type(
     mock_package_name_with_pipelines, pipeline_names
 ):


### PR DESCRIPTION
## Description

Closes #5611

`kedro pipeline create __init__` (and `__main__`) succeeded silently, creating a pipeline that is never discovered at runtime. Two things were missing:

1. `_assert_pkg_name_ok` did not reject dunder names (`__init__`, `__main__`, etc.)
2. `find_pipelines` only skipped `__pycache__` when it encountered an `__init__` directory, `importlib.import_module("project.pipelines.__init__")` resolved to the pipelines package itself, not the subdirectory, so the pipeline was silently dropped with no error

## Changes

- `kedro/framework/cli/pipeline.py`: added a dunder check in `_assert_pkg_name_ok`  any name starting and ending with `__` is rejected at creation time with a clear error
- `kedro/framework/project/__init__.py`: added a dunder skip in `find_pipelines` alongside the existing `__pycache__` skip acts as a runtime safety net for projects that may already have dunder-named pipeline directories
- `tests/framework/cli/pipeline/test_pipeline.py`: added `__init__` and `__main__` to the existing `test_bad_pipeline_name` parametrize list

## What was tested

```
tests/framework/cli/pipeline/test_pipeline.py::TestPipelineCreateCommand::test_bad_pipeline_name
6 passed
```

Before the fix:
```
kedro pipeline create __init__  ->  Pipeline '__init__' was successfully created.
# pipeline exists on disk but find_pipelines silently never discovers it
```

After the fix:
```
kedro pipeline create __init__  ->  Error: '__init__' is not a valid Python package name.
'__init__' is a reserved dunder name and cannot be used as a pipeline name.
```