### PR TITLE
Improve pipeline mapping error message

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -9,6 +9,7 @@
 ## Bug fixes and other changes
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
+* Improved the `pipeline()` error message when a mapped dataset or parameter does not exist in the pipeline.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
 * Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.
 
@@ -18,6 +19,7 @@
 ## Community contributions
 * [Feng Jikui](https://github.com/fengjikui)
 * [Rudra Dudhat](https://github.com/RudraDudhat2509)
+* [samiat4911](https://github.com/samiat4911)
 
 Many thanks to the following Kedroids for contributing PRs to this release:
 

--- a/kedro/pipeline/pipeline.py
+++ b/kedro/pipeline/pipeline.py
@@ -89,8 +89,12 @@ def _validate_datasets_exist(
     if non_existent:
         sorted_non_existent = sorted(non_existent)
         possible_matches = get_close_matches(sorted_non_existent, existing)
+        verb = "does" if len(sorted_non_existent) == 1 else "do"
 
-        error_msg = f"Failed to map datasets and/or parameters onto the nodes provided: {', '.join(sorted_non_existent)}"
+        error_msg = (
+            "Failed to map datasets and/or parameters onto the nodes provided: "
+            f"{', '.join(sorted_non_existent)} {verb} not exist in the pipeline."
+        )
         suggestions = (
             f" - did you mean one of these instead: {', '.join(possible_matches)}"
             if possible_matches

--- a/tests/pipeline/test_pipeline_namespacing.py
+++ b/tests/pipeline/test_pipeline_namespacing.py
@@ -472,6 +472,55 @@ class TestPipelineHelper:
         with pytest.raises(PipelineError, match=pattern):
             pipeline(raw_pipeline, parameters={"parameters": "some_yaml_dataset"})
 
+    def test_non_existent_parameter_mapping_does_not_report_intermediate_datasets(self):
+        def split_data(model_input_table, model_options):
+            return None
+
+        def train_model(X_train, y_train):
+            return None
+
+        def evaluate_model(regressor, X_test, y_test):
+            return None
+
+        raw_pipeline = pipeline(
+            [
+                node(
+                    split_data,
+                    ["model_input_table", "params:model_options"],
+                    ["X_train", "X_test", "y_train", "y_test"],
+                    name="split_data_node",
+                ),
+                node(
+                    train_model,
+                    ["X_train", "y_train"],
+                    "regressor",
+                    name="train_model_node",
+                ),
+                node(
+                    evaluate_model,
+                    ["regressor", "X_test", "y_test"],
+                    "metrics",
+                    name="evaluate_model_node",
+                ),
+            ]
+        )
+
+        with pytest.raises(PipelineError) as exc:
+            pipeline(
+                raw_pipeline,
+                parameters={"params:model_options_1": "params:model_options"},
+            )
+
+        error_message = str(exc.value)
+        assert "params:model_options_1 does not exist in the pipeline" in error_message
+        assert (
+            "did you mean one of these instead: params:model_options" in error_message
+        )
+        assert "X_train" not in error_message
+        assert "X_test" not in error_message
+        assert "regressor" not in error_message
+        assert "metrics" not in error_message
+
     def test_bad_inputs_mapping(self):
         raw_pipeline = pipeline(
             [


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fixes #3953.

This PR clarifies the `PipelineError` raised when a dataset or parameter passed to `pipeline()` mapping arguments does not exist in the provided pipeline.

Previously, the error message only listed the unmapped name, which could be confusing in parameter remapping cases. The updated message now states that the supplied dataset or parameter does not exist in the pipeline, while preserving the existing close-match suggestion.
## Development notes
<!-- What have you changed, and how has this been tested? -->
Changed `_validate_datasets_exist()` to include `does/do not exist in the pipeline` in the error message.

Added a regression test covering a parameter remapping typo similar to the issue example. The test verifies that the error reports the invalid parameter mapping and does not incorrectly report intermediate pipeline datasets such as `X_train`, `X_test`, `regressor`, or `metrics`.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
