### PR TITLE
Issue 5314 parameter validation benchmarks

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
 * Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.
+* Added ASV benchmarks for the parameter validation framework.
 
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
@@ -32,6 +33,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 * [Jean-Baptiste Braun](https://github.com/jbbqqf)
 * [Gargi](https://github.com/Kaliagargi)
 * [Simon](https://github.com/simon-b)
+* [samiat4911](https://github.com/samiat4911)
 
 
 # Release 1.4.0

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -4,7 +4,7 @@
     "project_url": "https://kedro.org/",
     "repo": ".",
     "install_command": [
-        "pip install -e .  kedro-datasets[pandas-csvdataset]"
+        "pip install -e .[pydantic] kedro-datasets[pandas-csvdataset]"
     ],
     "branches": [
         "main"

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -7,7 +7,7 @@
         "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
     ],
     "install_command": [
-        "pip install -e .[pydantic] kedro-datasets[pandas-csvdataset]"
+        "pip install -e .[benchmark] kedro-datasets[pandas-csvdataset]"
     ],
     "branches": [
         "main"

--- a/kedro/ipython/__init__.py
+++ b/kedro/ipython/__init__.py
@@ -13,6 +13,7 @@ import os
 import sys
 import typing
 import warnings
+from collections import OrderedDict
 from pathlib import Path
 from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, Final
@@ -20,7 +21,6 @@ from typing import TYPE_CHECKING, Any, Final
 from kedro.framework.session.session import KedroSession
 
 if TYPE_CHECKING:
-    from collections import OrderedDict
     from collections.abc import Callable
 
     from IPython.core.interactiveshell import InteractiveShell
@@ -405,7 +405,9 @@ def _get_node_bound_arguments(node: Node) -> _NodeBoundArguments:
     args, kwargs = Node._process_inputs_for_bind(node_inputs)
     signature = inspect.signature(node_func)
     bound_arguments = signature.bind(*args, **kwargs)
-    return _NodeBoundArguments(bound_arguments.signature, bound_arguments.arguments)
+    return _NodeBoundArguments(
+        bound_arguments.signature, OrderedDict(bound_arguments.arguments)
+    )
 
 
 def _prepare_node_inputs(

--- a/kedro_benchmarks/benchmark_validation.py
+++ b/kedro_benchmarks/benchmark_validation.py
@@ -1,0 +1,191 @@
+import dataclasses
+import inspect
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel
+
+from kedro.framework.context import KedroContext
+from kedro.pipeline import node, pipeline
+from kedro.validation.model_factory import instantiate_model
+from kedro.validation.parameter_validator import ParameterValidator
+from kedro.validation.type_extractor import TypeExtractor
+
+
+class BenchmarkPydanticModel(BaseModel):
+    field_0: int
+    field_1: str
+    field_2: float
+    field_3: bool
+    field_4: list[int]
+
+
+@dataclasses.dataclass
+class BenchmarkDataclassModel:
+    field_0: int
+    field_1: str
+    field_2: float
+    field_3: bool
+    field_4: list[int]
+
+
+class _BenchmarkConfigLoader:
+    def __init__(self, parameters: dict[str, Any]) -> None:
+        self._parameters = parameters
+
+    def __getitem__(self, key: str) -> dict[str, Any]:
+        if key == "parameters":
+            return self._parameters
+        return {}
+
+
+def _make_raw_value(index: int) -> dict[str, Any]:
+    return {
+        "field_0": index,
+        "field_1": f"value_{index}",
+        "field_2": index / 10,
+        "field_3": bool(index % 2),
+        "field_4": [index, index + 1, index + 2],
+    }
+
+
+def _make_node_func(name: str, model_type: type, typed_params_per_node: int):
+    def typed_node(*args):
+        return None
+
+    typed_node.__name__ = name
+    typed_node.__annotations__ = {
+        f"options_{index}": model_type for index in range(typed_params_per_node)
+    }
+    typed_node.__annotations__["return"] = None
+    typed_node.__signature__ = inspect.Signature(
+        [
+            inspect.Parameter(
+                f"options_{index}",
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+            for index in range(typed_params_per_node)
+        ]
+    )
+    return typed_node
+
+
+def _make_pipeline(node_count: int, typed_params_per_node: int = 1):
+    nodes = []
+    for node_index in range(node_count):
+        node_func = _make_node_func(
+            f"typed_node_{node_index}",
+            BenchmarkPydanticModel,
+            typed_params_per_node,
+        )
+        node_inputs = [
+            f"params:model_options_{node_index}_{param_index}"
+            for param_index in range(typed_params_per_node)
+        ]
+        nodes.append(
+            node(
+                node_func,
+                node_inputs,
+                f"output_{node_index}",
+                name=f"typed_node_{node_index}",
+            )
+        )
+    return pipeline(nodes)
+
+
+def _make_pipeline_dict(node_count: int, typed_params_per_node: int = 1):
+    return {"data_science": _make_pipeline(node_count, typed_params_per_node)}
+
+
+def _make_raw_params(node_count: int, typed_params_per_node: int = 1):
+    return {
+        f"model_options_{node_index}_{param_index}": _make_raw_value(
+            node_index + param_index
+        )
+        for node_index in range(node_count)
+        for param_index in range(typed_params_per_node)
+    }
+
+
+class InstantiateModelTimeSuite:
+    params = ("pydantic", "dataclass")
+    param_names = ("model_kind",)
+
+    def setup(self, model_kind):
+        self.raw_value = _make_raw_value(1)
+        self.model_type = (
+            BenchmarkPydanticModel
+            if model_kind == "pydantic"
+            else BenchmarkDataclassModel
+        )
+
+    def time_instantiate_model(self, model_kind):
+        instantiate_model("model_options", self.raw_value, self.model_type)
+
+
+class TypeExtractorTimeSuite:
+    params = ([10, 100, 500], [1, 5])
+    param_names = ("node_count", "typed_params_per_node")
+
+    def setup(self, node_count, typed_params_per_node):
+        self.pipelines = _make_pipeline_dict(node_count, typed_params_per_node)
+
+    def time_extract_types_from_pipelines(self, node_count, typed_params_per_node):
+        TypeExtractor(self.pipelines).extract_types_from_pipelines()
+
+
+class ParameterValidatorTimeSuite:
+    params = ([10, 100, 500], [1, 5])
+    param_names = ("node_count", "typed_params_per_node")
+
+    def setup(self, node_count, typed_params_per_node):
+        self.pipelines = _make_pipeline_dict(node_count, typed_params_per_node)
+        self.raw_params = _make_raw_params(node_count, typed_params_per_node)
+        self.validator = ParameterValidator(self.pipelines)
+
+    def time_validate_raw_params(self, node_count, typed_params_per_node):
+        self.validator.validate_raw_params(self.raw_params)
+
+
+class ContextParamsTimeSuite:
+    params = ([10, 100, 500], [1, 5])
+    param_names = ("node_count", "typed_params_per_node")
+
+    def setup(self, node_count, typed_params_per_node):
+        import kedro.framework.project as project_module
+
+        self.project_module = project_module
+        self.original_pipelines = project_module.pipelines
+        self.pipelines = _make_pipeline_dict(node_count, typed_params_per_node)
+        project_module.pipelines = self.pipelines
+
+        self.context = KedroContext(
+            project_path=Path.cwd(),
+            config_loader=_BenchmarkConfigLoader(
+                _make_raw_params(node_count, typed_params_per_node)
+            ),
+            env="base",
+            package_name="benchmark_project",
+            hook_manager=None,
+        )
+        self.cached_context = KedroContext(
+            project_path=Path.cwd(),
+            config_loader=_BenchmarkConfigLoader(
+                _make_raw_params(node_count, typed_params_per_node)
+            ),
+            env="base",
+            package_name="benchmark_project",
+            hook_manager=None,
+        )
+        self.cached_context.params
+
+    def teardown(self, node_count, typed_params_per_node):
+        self.project_module.pipelines = self.original_pipelines
+
+    def time_context_params_uncached(self, node_count, typed_params_per_node):
+        self.context._validated_params_cache = None
+        self.context._cached_validation_scope = None
+        self.context.params
+
+    def time_context_params_cached(self, node_count, typed_params_per_node):
+        self.cached_context.params

--- a/kedro_benchmarks/benchmark_validation.py
+++ b/kedro_benchmarks/benchmark_validation.py
@@ -1,3 +1,6 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+
 import dataclasses
 import inspect
 from pathlib import Path
@@ -97,6 +100,40 @@ def _make_pipeline_dict(node_count: int, typed_params_per_node: int = 1):
     return {"data_science": _make_pipeline(node_count, typed_params_per_node)}
 
 
+def _make_scoped_pipeline(pipeline_name: str, node_count: int, typed_params_per_node: int):
+    nodes = []
+    for node_index in range(node_count):
+        node_func = _make_node_func(
+            f"{pipeline_name}_typed_node_{node_index}",
+            BenchmarkPydanticModel,
+            typed_params_per_node,
+        )
+        node_inputs = [
+            f"params:{pipeline_name}_model_options_{node_index}_{param_index}"
+            for param_index in range(typed_params_per_node)
+        ]
+        nodes.append(
+            node(
+                node_func,
+                node_inputs,
+                f"{pipeline_name}_output_{node_index}",
+                name=f"{pipeline_name}_typed_node_{node_index}",
+            )
+        )
+    return pipeline(nodes)
+
+
+def _make_scoped_pipeline_dict(node_count: int, typed_params_per_node: int = 1):
+    return {
+        "data_science": _make_scoped_pipeline(
+            "data_science", node_count, typed_params_per_node
+        ),
+        "data_engineering": _make_scoped_pipeline(
+            "data_engineering", node_count, typed_params_per_node
+        ),
+    }
+
+
 def _make_raw_params(node_count: int, typed_params_per_node: int = 1):
     return {
         f"model_options_{node_index}_{param_index}": _make_raw_value(
@@ -107,7 +144,21 @@ def _make_raw_params(node_count: int, typed_params_per_node: int = 1):
     }
 
 
+def _make_scoped_raw_params(node_count: int, typed_params_per_node: int = 1):
+    pipeline_names = ("data_science", "data_engineering")
+    return {
+        f"{pipeline_name}_model_options_{node_index}_{param_index}": _make_raw_value(
+            node_index + param_index
+        )
+        for pipeline_name in pipeline_names
+        for node_index in range(node_count)
+        for param_index in range(typed_params_per_node)
+    }
+
+
 class InstantiateModelTimeSuite:
+    """Benchmark model instantiation for supported typed parameter models."""
+
     params = ("pydantic", "dataclass")
     param_names = ("model_kind",)
 
@@ -124,6 +175,8 @@ class InstantiateModelTimeSuite:
 
 
 class TypeExtractorTimeSuite:
+    """Benchmark extracting typed parameter requirements from pipelines."""
+
     params = ([10, 100, 500], [1, 5])
     param_names = ("node_count", "typed_params_per_node")
 
@@ -135,6 +188,8 @@ class TypeExtractorTimeSuite:
 
 
 class ParameterValidatorTimeSuite:
+    """Benchmark validating raw parameters against pipeline type hints."""
+
     params = ([10, 100, 500], [1, 5])
     param_names = ("node_count", "typed_params_per_node")
 
@@ -148,6 +203,8 @@ class ParameterValidatorTimeSuite:
 
 
 class ContextParamsTimeSuite:
+    """Benchmark context parameter validation and cached parameter access."""
+
     params = ([10, 100, 500], [1, 5])
     param_names = ("node_count", "typed_params_per_node")
 
@@ -189,3 +246,37 @@ class ContextParamsTimeSuite:
 
     def time_context_params_cached(self, node_count, typed_params_per_node):
         self.cached_context.params
+
+
+class ScopedContextParamsTimeSuite:
+    """Benchmark context parameter validation scoped to selected pipelines."""
+
+    params = ([10, 100, 500], [1, 5])
+    param_names = ("node_count", "typed_params_per_node")
+
+    def setup(self, node_count, typed_params_per_node):
+        import kedro.framework.project as project_module
+
+        self.project_module = project_module
+        self.original_pipelines = project_module.pipelines
+        self.pipelines = _make_scoped_pipeline_dict(node_count, typed_params_per_node)
+        project_module.pipelines = self.pipelines
+
+        self.context = KedroContext(
+            project_path=Path.cwd(),
+            config_loader=_BenchmarkConfigLoader(
+                _make_scoped_raw_params(node_count, typed_params_per_node)
+            ),
+            env="base",
+            package_name="benchmark_project",
+            hook_manager=None,
+        )
+        self.context._pipelines_to_validate = ["data_science"]
+
+    def teardown(self, node_count, typed_params_per_node):
+        self.project_module.pipelines = self.original_pipelines
+
+    def time_context_params_scoped_validation(self, node_count, typed_params_per_node):
+        self.context._validated_params_cache = None
+        self.context._cached_validation_scope = None
+        self.context.params

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,8 @@ jupyter = [
     "notebook>=7.0.0"  # requires the new share backend of notebook and labs"
 ]
 benchmark = [
-    "asv"
+    "asv",
+    "kedro[pydantic]",
 ]
 
 pydantic = ["pydantic>=2.13"]


### PR DESCRIPTION
# Issue 5314 parameter validation benchmarks

## Description
Fixes #5314.

This PR adds ASV benchmark coverage for Kedro's parameter validation framework. It measures the main validation path introduced for typed parameters, including model instantiation, pipeline type extraction, raw parameter validation, `KedroContext.params` access with and without the validation cache, and validation scoped to selected pipelines.

The benchmark coverage should make it easier to track performance changes in the parameter validation flow as the implementation evolves.

## Development notes
Added `kedro_benchmarks/benchmark_validation.py` with benchmark suites for:

- `instantiate_model()` for Pydantic and dataclass-backed parameter models.
- `TypeExtractor.extract_types_from_pipelines()` across synthetic pipelines with 10, 100, and 500 nodes.
- `ParameterValidator.validate_raw_params()` for matching raw parameter dictionaries.
- `KedroContext.params` for uncached validation and cached parameter access.
- `KedroContext.params` scoped with `_pipelines_to_validate` on a multi-pipeline registry.

Updated `asv.conf.json` so ASV installs Kedro with the `pydantic` extra, which is required by the new validation benchmark suite.

The largest parameter combination currently benchmarks 500 nodes with 5 typed params per node, which means 2500 typed parameter validations for the largest validation cases.

Tested with:

```powershell
.venv\Scripts\python.exe -c "from kedro_benchmarks.benchmark_validation import ContextParamsTimeSuite, InstantiateModelTimeSuite, ParameterValidatorTimeSuite, ScopedContextParamsTimeSuite, TypeExtractorTimeSuite; s=InstantiateModelTimeSuite(); s.setup('pydantic'); s.time_instantiate_model('pydantic'); s=TypeExtractorTimeSuite(); s.setup(10, 1); s.time_extract_types_from_pipelines(10, 1); s=ParameterValidatorTimeSuite(); s.setup(10, 1); s.time_validate_raw_params(10, 1); s=ContextParamsTimeSuite(); s.setup(10, 1); s.time_context_params_uncached(10, 1); s.time_context_params_cached(10, 1); s.teardown(10, 1); s=ScopedContextParamsTimeSuite(); s.setup(10, 1); s.time_context_params_scoped_validation(10, 1); s.teardown(10, 1); print('ok')"
.venv\Scripts\python.exe -m compileall kedro_benchmarks\benchmark_validation.py
.venv\Scripts\python.exe -m asv check -E existing:.venv\Scripts\python.exe
.venv\Scripts\python.exe -m asv run --quick --show-stderr --dry-run -E existing:.venv\Scripts\python.exe --machine local-windows --bench benchmark_validation
pre-commit run ruff --files kedro_benchmarks\benchmark_validation.py
pre-commit run ruff-format --files kedro_benchmarks\benchmark_validation.py
pre-commit run trailing-whitespace --files kedro_benchmarks\benchmark_validation.py
pre-commit run end-of-file-fixer --files kedro_benchmarks\benchmark_validation.py
pre-commit run check-added-large-files --files kedro_benchmarks\benchmark_validation.py
git diff --check
```

To run the benchmark suite locally, use:

```powershell
.venv\Scripts\python.exe -m asv run --bench benchmark_validation
```

For a quicker local smoke run, use:

```powershell
.venv\Scripts\python.exe -m asv run --quick --show-stderr --dry-run -E existing:.venv\Scripts\python.exe --bench benchmark_validation
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
