### PR TITLE
Fix logging filter class configuration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
 * Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.
+* Fixed custom `logging.Filter` subclasses configured with `class:` in `logging.yml`, so they are instantiated and applied.
 
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
@@ -21,6 +22,7 @@
 ## Community contributions
 * [Feng Jikui](https://github.com/fengjikui)
 * [Rudra Dudhat](https://github.com/RudraDudhat2509)
+* [samiat4911](https://github.com/samiat4911)
 
 Many thanks to the following Kedroids for contributing PRs to this release:
 

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -144,6 +144,41 @@ Besides the `rich` handler defined in Kedro's framework, we provide two addition
 
 The following section illustrates some common examples of how to change your project's logging configuration.
 
+## How to add a custom logging filter
+
+Add a custom [`logging.Filter`](https://docs.python.org/3/library/logging.html#filter-objects) subclass to your project logging configuration. Define the filter in your project code:
+
+```python
+import logging
+
+
+class KeepOnlyFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "KEEP" in record.getMessage()
+```
+
+Then reference the filter with the `class` key in `conf/logging.yml` and attach it to the relevant handler:
+
+```yaml
+filters:
+  keep_only:
+    class: your_project.logging.KeepOnlyFilter
+
+handlers:
+  console:
+    class: logging.StreamHandler
+    filters: [keep_only]
+    stream: ext://sys.stdout
+
+root:
+  handlers: [console]
+  level: INFO
+```
+
+!!! note
+    Standard Python logging configuration also supports the `()` factory key for custom objects. Kedro does not allow `()` in `logging.yml` because it can execute arbitrary code.
+    Use `class` for custom `logging.Filter` subclasses instead.
+
 ## How to customise the `rich` handler
 
 Kedro's `kedro.logging.RichHandler` is a subclass of [`rich.logging.RichHandler`](https://rich.readthedocs.io/en/stable/reference/logging.html#rich.logging.RichHandler) and supports the same set of arguments. By default, `rich_tracebacks` is set to `True` to use `rich` to render exceptions. You can disable it by setting `rich_tracebacks: False`.

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -361,7 +361,11 @@ class _ProjectLogging(UserDict):
         without allowing user-provided factories.
         """
         prepared_config = logging_config.copy()
-        filters = logging_config.get("filters", {})
+
+        if "filters" not in logging_config:
+            return prepared_config
+
+        filters = logging_config["filters"]
 
         if not isinstance(filters, dict):
             return prepared_config

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -282,13 +282,16 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
         logger.info(msg)
 
-    def _validate_logging_class(self, class_path: str) -> None:
-        """Validate that a class referenced in logging configuration is a legitimate
-        logging class (i.e. a subclass of logging.Handler, logging.Formatter, or
-        logging.Filter).
+    def _resolve_logging_class(self, class_path: str) -> type[Any] | None:
+        """Resolve and validate that a class referenced in logging configuration is
+        a legitimate logging class (i.e. a subclass of logging.Handler,
+        logging.Formatter, or logging.Filter).
 
         Args:
             class_path: Dotted import path to the class, e.g. ``logging.StreamHandler``.
+
+        Returns:
+            Resolved class, or ``None`` for bare names resolved internally by logging.
 
         Raises:
             ValueError: If the class cannot be imported or is not a logging base class.
@@ -297,7 +300,7 @@ class _ProjectLogging(UserDict):
         module_path, _, class_name = class_path.rpartition(".")
         if not module_path:
             # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
-            return
+            return None
 
         try:
             module = importlib.import_module(module_path)
@@ -320,6 +323,14 @@ class _ProjectLogging(UserDict):
                 f"Got {type(cls).__name__!r}."
             )
 
+        return cls
+
+    def _validate_logging_class(self, class_path: str) -> None:
+        """Validate that a class referenced in logging configuration is a legitimate
+        logging class (i.e. a subclass of logging.Handler, logging.Formatter, or
+        logging.Filter)."""
+        self._resolve_logging_class(class_path)
+
     def _validate_logging_config(self, config: Any) -> Any:
         """Recursively check the logging configuration and raise an error if dangerous
         '()' factory keys are encountered or if any 'class' value is not a legitimate
@@ -340,13 +351,55 @@ class _ProjectLogging(UserDict):
         else:
             return config
 
+    def _prepare_logging_config(self, logging_config: dict[str, Any]) -> dict[str, Any]:
+        """Prepare a validated logging configuration for ``dictConfig``.
+
+        ``logging.config.dictConfig`` only instantiates custom filters through the
+        ``()`` factory key, which Kedro rejects in user configuration for security
+        reasons. For validated top-level filter definitions, convert ``class`` to an
+        internal callable so custom ``logging.Filter`` subclasses are instantiated
+        without allowing user-provided factories.
+        """
+        prepared_config = logging_config.copy()
+        filters = logging_config.get("filters", {})
+
+        if not isinstance(filters, dict):
+            return prepared_config
+
+        prepared_filters = filters.copy()
+        prepared_config["filters"] = prepared_filters
+
+        for filter_name, filter_config in prepared_filters.items():
+            if not isinstance(filter_config, dict) or "class" not in filter_config:
+                continue
+
+            class_path = filter_config["class"]
+            filter_class = self._resolve_logging_class(class_path)
+
+            if filter_class is None:
+                continue
+
+            if not issubclass(filter_class, logging.Filter):
+                raise ValueError(
+                    f"Invalid logging filter class '{class_path}' for filter "
+                    f"'{filter_name}'. Must be a subclass of logging.Filter."
+                )
+
+            prepared_filter_config = {
+                key: value for key, value in filter_config.items() if key != "class"
+            }
+            prepared_filter_config["()"] = filter_class
+            prepared_filters[filter_name] = prepared_filter_config
+
+        return prepared_config
+
     def configure(self, logging_config: dict[str, Any]) -> None:
         """Configure project logging using ``logging_config`` (e.g. from project
         logging.yml). We store this in the UserDict data so that it can be reconfigured
         in _bootstrap_subprocess.
         """
         validated_config = self._validate_logging_config(logging_config)
-        logging.config.dictConfig(validated_config)
+        logging.config.dictConfig(self._prepare_logging_config(validated_config))
         self.data = validated_config
 
     def set_project_logging(

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -501,7 +501,24 @@ def test_configure_logging_instantiates_custom_filter_class():
     handler.handle(drop_record)
     handler.handle(keep_record)
 
-    assert stream.getvalue() == "KEEP this message\n"
+    logged_messages = stream.getvalue()
+    assert "DROP this message" not in logged_messages
+    assert logged_messages == "KEEP this message\n"
+
+
+def test_prepare_logging_config_without_filters_does_not_add_filters_key():
+    from kedro.framework.project import _ProjectLogging
+
+    logging_config = {
+        "version": 1,
+        "handlers": {"stream": {"class": "logging.StreamHandler"}},
+        "root": {"handlers": ["stream"], "level": "INFO"},
+    }
+
+    logging_instance = _ProjectLogging()
+    prepared_config = logging_instance._prepare_logging_config(logging_config)
+
+    assert "filters" not in prepared_config
 
 
 def test_configure_logging_rejects_non_filter_class_in_filters():

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -521,6 +521,50 @@ def test_prepare_logging_config_without_filters_does_not_add_filters_key():
     assert "filters" not in prepared_config
 
 
+def test_prepare_logging_config_with_non_dict_filters_is_unchanged():
+    from kedro.framework.project import _ProjectLogging
+
+    logging_config = {
+        "version": 1,
+        "filters": ["not-a-filter-config"],
+    }
+
+    logging_instance = _ProjectLogging()
+    prepared_config = logging_instance._prepare_logging_config(logging_config)
+
+    assert prepared_config == logging_config
+    assert prepared_config is not logging_config
+
+
+@pytest.mark.parametrize("filter_config", [{"name": "kedro"}, "not-a-dict"])
+def test_prepare_logging_config_ignores_filters_without_class(filter_config):
+    from kedro.framework.project import _ProjectLogging
+
+    logging_config = {
+        "version": 1,
+        "filters": {"passthrough": filter_config},
+    }
+
+    logging_instance = _ProjectLogging()
+    prepared_config = logging_instance._prepare_logging_config(logging_config)
+
+    assert prepared_config["filters"]["passthrough"] == filter_config
+
+
+def test_prepare_logging_config_ignores_bare_filter_class_name():
+    from kedro.framework.project import _ProjectLogging
+
+    logging_config = {
+        "version": 1,
+        "filters": {"keep_only": {"class": "Filter"}},
+    }
+
+    logging_instance = _ProjectLogging()
+    prepared_config = logging_instance._prepare_logging_config(logging_config)
+
+    assert prepared_config["filters"]["keep_only"] == {"class": "Filter"}
+
+
 def test_configure_logging_rejects_non_filter_class_in_filters():
     from kedro.framework.project import _ProjectLogging
 

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -16,6 +16,11 @@ from kedro.pipeline import node
 from kedro.utils import _has_rich_handler
 
 
+class KeepOnlyFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "KEEP" in record.getMessage()
+
+
 @pytest.fixture
 def default_logging_config_with_project():
     logging_config = {
@@ -459,6 +464,64 @@ def test_validate_logging_class_bare_name_passes():
 
     logging_instance = _ProjectLogging()
     logging_instance._validate_logging_class("StreamHandler")  # should not raise
+
+
+def test_configure_logging_instantiates_custom_filter_class():
+    from kedro.framework.project import _ProjectLogging
+
+    stream = io.StringIO()
+    filter_class = f"{__name__}.KeepOnlyFilter"
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {"keep_only": {"class": filter_class}},
+        "handlers": {
+            "stream": {
+                "class": "logging.StreamHandler",
+                "filters": ["keep_only"],
+                "stream": stream,
+            }
+        },
+        "root": {"handlers": ["stream"], "level": "INFO"},
+    }
+
+    logging_instance = _ProjectLogging()
+    logging_instance.configure(logging_config)
+
+    [handler] = logging.getLogger().handlers
+    assert isinstance(handler.filters[0], KeepOnlyFilter)
+    assert logging_instance.data["filters"]["keep_only"] == {"class": filter_class}
+
+    drop_record = logging.LogRecord(
+        "test_logger", logging.INFO, __file__, 1, "DROP this message", (), None
+    )
+    keep_record = logging.LogRecord(
+        "test_logger", logging.INFO, __file__, 1, "KEEP this message", (), None
+    )
+    handler.handle(drop_record)
+    handler.handle(keep_record)
+
+    assert stream.getvalue() == "KEEP this message\n"
+
+
+def test_configure_logging_rejects_non_filter_class_in_filters():
+    from kedro.framework.project import _ProjectLogging
+
+    logging_config = {
+        "version": 1,
+        "filters": {"not_a_filter": {"class": "logging.StreamHandler"}},
+        "handlers": {
+            "stream": {
+                "class": "logging.StreamHandler",
+                "filters": ["not_a_filter"],
+            }
+        },
+        "root": {"handlers": ["stream"], "level": "INFO"},
+    }
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Must be a subclass of logging.Filter"):
+        logging_instance.configure(logging_config)
 
 
 def test_validate_config_blocks_rce_via_class():


### PR DESCRIPTION
# Fix logging filter class configuration

## Description
Fixes #5619.

Custom `logging.Filter` subclasses configured with `class:` in `logging.yml` were validated by Kedro but were not actually instantiated by Python's `logging.config.dictConfig()`. This meant a configuration such as:

```yaml
filters:
  my_filter:
    class: my_package.logging.MyFilter
```

silently attached a base no-op `logging.Filter` instead of the requested custom filter.

This PR keeps the existing security guardrail that rejects user-supplied `()` factory keys, while allowing validated `logging.Filter` subclasses configured with `class:` to be instantiated and applied.

## Development notes
Updated `_ProjectLogging` so it:

- resolves and validates logging classes through a shared helper;
- preserves the existing rejection of user-provided `()` keys;
- prepares a separate `dictConfig()` configuration where top-level filter definitions using a validated `logging.Filter` subclass are converted to an internal callable factory;
- keeps `LOGGING.data` in the original validated `class:` form, without storing internal `()` keys;
- preserves logging configurations that do not define a `filters` section.

Added regression tests that verify:

- a custom `logging.Filter` subclass configured with `class:` is attached and filters records;
- filtered records do not appear in the handler output;
- config preparation does not add an empty `filters` section when the user has not configured filters;
- non-filter classes are rejected when used inside the top-level `filters:` section;
- the existing `()` factory-key and non-logging-class security checks still pass.

Updated `docs/develop/logging.md` to explain how to configure custom filters with `class:` and why Kedro does not support the standard `()` factory key in `logging.yml`.

Tested with:

```powershell
.venv\Scripts\python.exe -m pytest --no-cov tests\framework\project\test_logging.py
pre-commit run ruff --files kedro\framework\project\__init__.py tests\framework\project\test_logging.py
pre-commit run ruff-format --files kedro\framework\project\__init__.py tests\framework\project\test_logging.py
pre-commit run trailing-whitespace --files docs\develop\logging.md kedro\framework\project\__init__.py tests\framework\project\test_logging.py
pre-commit run end-of-file-fixer --files docs\develop\logging.md kedro\framework\project\__init__.py tests\framework\project\test_logging.py
git diff --check
.venv\Scripts\mypy.exe kedro\framework\project\__init__.py --strict --allow-any-generics --no-warn-unused-ignores
```

Vale was not available in my local environment, so I used the Kedro docs manual style checklist for the docs update.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
