### PR TITLE
Fix custom logging filter class configuration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 
 ## Bug fixes and other changes
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.
+* Fixed project logging configuration so custom `logging.Filter` subclasses can be configured with the validated `class` key without using the unsafe `()` factory key.
 * Improved the `AbstractDataset.from_config()` error message for custom dataset classes that are still abstract, so it no longer suggests invalid constructor arguments when required dataset methods are missing.
 * Fixed `kedro new` accepting project names whose derived package name shadows a Python standard library module or is a Python keyword (e.g. `email`, `json`, `import`), which silently produced a broken, unimportable project. Such names are now rejected at creation time with a clear message.
 * Fixed `kedro pipeline create` accepting Python keywords (e.g. `for`, `import`, `return`) as pipeline names. Such names are now rejected at creation time with a clear error message.

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -301,7 +301,7 @@ class _ProjectLogging(UserDict):
         self.configure(yaml.safe_load(logging_config))
         logger.info(msg)
 
-    def _validate_logging_class(self, class_path: str) -> None:
+    def _validate_logging_class(self, class_path: str) -> type | None:
         """Validate that a class referenced in logging configuration is a legitimate
         logging class (i.e. a subclass of logging.Handler, logging.Formatter, or
         logging.Filter).
@@ -316,7 +316,7 @@ class _ProjectLogging(UserDict):
         module_path, _, class_name = class_path.rpartition(".")
         if not module_path:
             # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
-            return
+            return None
 
         try:
             module = importlib.import_module(module_path)
@@ -339,6 +339,8 @@ class _ProjectLogging(UserDict):
                 f"Got {type(cls).__name__!r}."
             )
 
+        return cls
+
     def _validate_logging_config(self, config: Any) -> Any:
         """Recursively check the logging configuration and raise an error if dangerous
         '()' factory keys are encountered or if any 'class' value is not a legitimate
@@ -359,13 +361,37 @@ class _ProjectLogging(UserDict):
         else:
             return config
 
+    def _prepare_logging_config(self, config: dict[str, Any]) -> dict[str, Any]:
+        """Prepare validated logging configuration for ``dictConfig``."""
+        filters = config.get("filters")
+        if not isinstance(filters, dict):
+            return config
+
+        prepared_config = {**config}
+        prepared_filters = {**filters}
+
+        for filter_name, filter_config in filters.items():
+            if not isinstance(filter_config, dict) or "class" not in filter_config:
+                continue
+
+            filter_class = self._validate_logging_class(filter_config["class"])
+            if filter_class and issubclass(filter_class, logging.Filter):
+                prepared_filter_config = {
+                    key: value for key, value in filter_config.items() if key != "class"
+                }
+                prepared_filter_config["()"] = filter_class
+                prepared_filters[filter_name] = prepared_filter_config
+
+        prepared_config["filters"] = prepared_filters
+        return prepared_config
+
     def configure(self, logging_config: dict[str, Any]) -> None:
         """Configure project logging using ``logging_config`` (e.g. from project
         logging.yml). We store this in the UserDict data so that it can be reconfigured
         in _bootstrap_subprocess.
         """
         validated_config = self._validate_logging_config(logging_config)
-        logging.config.dictConfig(validated_config)
+        logging.config.dictConfig(self._prepare_logging_config(validated_config))
         self.data = validated_config
 
     def set_project_logging(

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -9,11 +9,21 @@ import pytest
 import yaml
 from rich.console import Console
 
-from kedro.framework.project import LOGGING, configure_logging, configure_project
+from kedro.framework.project import (
+    LOGGING,
+    _ProjectLogging,
+    configure_logging,
+    configure_project,
+)
 from kedro.io import DataCatalog
 from kedro.logging import RichHandler, _format_rich
 from kedro.pipeline import node
 from kedro.utils import _has_rich_handler
+
+
+class KeepMessageFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "KEEP" in record.getMessage()
 
 
 @pytest.fixture
@@ -480,6 +490,53 @@ def test_validate_config_blocks_rce_via_class():
     logging_instance = _ProjectLogging()
     with pytest.raises(ValueError, match="Invalid logging class"):
         logging_instance.configure(malicious_config)
+
+
+def test_configure_logging_instantiates_custom_filter_class():
+    """Custom filter classes configured with 'class' must be attached to handlers."""
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {
+            "keep_message": {"class": f"{__name__}.KeepMessageFilter"},
+        },
+        "handlers": {
+            "console": {
+                "class": "logging.StreamHandler",
+                "filters": ["keep_message"],
+            },
+        },
+        "root": {"handlers": ["console"], "level": "INFO"},
+    }
+
+    logging_instance = _ProjectLogging()
+    logging_instance.configure(logging_config)
+
+    attached_filter = logging.getLogger().handlers[0].filters[0]
+    assert isinstance(attached_filter, KeepMessageFilter)
+    assert attached_filter.filter(
+        logging.LogRecord("kedro", logging.INFO, "", 1, "KEEP this", (), None)
+    )
+    assert not attached_filter.filter(
+        logging.LogRecord("kedro", logging.INFO, "", 1, "DROP this", (), None)
+    )
+    assert logging_instance.data == logging_config
+
+
+def test_prepare_logging_config_preserves_filter_config_without_class():
+    """Filter config without 'class' should not be rewritten for dictConfig."""
+    logging_config = {
+        "version": 1,
+        "filters": {
+            "plain_filter": {},
+            "disabled_filter": None,
+        },
+    }
+
+    prepared_config = _ProjectLogging()._prepare_logging_config(logging_config)
+
+    assert prepared_config == logging_config
+    assert prepared_config["filters"] is not logging_config["filters"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description
Fixes #5619.

Kedro validates `class` entries in logging config, but Python's stdlib `DictConfigurator.configure_filter()` ignores `class` for filters and only instantiates custom filters through the `()` factory key. Since Kedro blocks user-provided `()` for security, custom `logging.Filter` subclasses configured in `logging.yml` were silently replaced with a base no-op `logging.Filter`.

This PR keeps the user-facing config restricted to the validated `class` key, then internally converts top-level filter class configs to a safe callable only after validation confirms the target is an importable logging class. `LOGGING.data` remains the original validated config so subprocess reconfiguration can repeat the same safe preparation step.

## Development notes
- Added a regression test using an importable custom `logging.Filter` subclass.
- Added a release-note entry under Upcoming Release.

Validation performed:
- `python -m pytest tests/framework/project/test_logging.py -q --no-cov` -> 40 passed
- `ruff format kedro/framework/project/__init__.py tests/framework/project/test_logging.py` -> unchanged
- `ruff check kedro/framework/project/__init__.py` -> passed
- `git diff --check` -> passed

Notes:
- Running the focused pytest command without `--no-cov` executes all 40 tests successfully, then exits non-zero because the repo-wide coverage gate requires 100% total coverage for the entire package even when only this file is selected.
- A full `ruff check tests/framework/project/test_logging.py` with the latest downloaded Ruff reports existing local-import and long-line findings elsewhere in the file that are unrelated to this change; this PR avoids adding another local import by importing `_ProjectLogging` at module scope.

## Checklist

- [x] Read the contributing guidelines
- [x] Signed off each commit with DCO
- [x] Opened this PR as a Draft Pull Request if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [x] Added a description of this change in RELEASE.md
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team

Docs note: no docs update included because this restores the existing documented `class`-based logging configuration behavior without adding a new public option.
