### PR TITLE
Add conf source allowlists

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -5,6 +5,7 @@
 * Added a new CLI command `kedro server start` to run the server.
 * Added an HTTP endpoint `/snapshot` for accessing project snapshot.
 * Added selective pipeline loading: when `--pipelines` is specified, only the requested pipeline modules are imported.
+* Added opt-in `OmegaConfigLoader` allowlists for remote `conf_source` schemes and hosts.
 
 ## Bug fixes and other changes
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.

--- a/docs/configure/advanced_configuration.md
+++ b/docs/configure/advanced_configuration.md
@@ -16,6 +16,7 @@ This page also contains a set of guidance for advanced configuration requirement
 - [How to use resolvers in the `OmegaConfigLoader`](#how-to-use-resolvers-in-the-omegaconfigloader)
 - [How to load credentials through environment variables with `OmegaConfigLoader`](#how-to-load-credentials-through-environment-variables)
 - [How to change the merge strategy used by `OmegaConfigLoader`](#how-to-change-the-merge-strategy-used-by-omegaconfigloader)
+- [How to restrict remote configuration sources with `OmegaConfigLoader`](#how-to-restrict-remote-configuration-sources-with-omegaconfigloader)
 
 
 ### How to use a custom configuration loader
@@ -347,6 +348,26 @@ CONFIG_LOADER_ARGS = {
 
 If no merge strategy is defined, the default destructive strategy will be applied. **Note**: this merge strategy setting applies when configuration files are located in **different** environments.
 When files are part of the same environment, they are always merged in a soft way. An error is thrown when files in the same environment contain the same top-level keys.
+
+### How to restrict remote configuration sources with `OmegaConfigLoader`
+`OmegaConfigLoader` can load configuration from local paths and from remote URLs such as `s3://` and `https://` sources. Treat `conf_source` as trusted operator input. Do not derive it from untrusted external data such as HTTP request parameters, queue messages, or user-controlled environment variables.
+
+For multi-tenant or network-facing deployments, you can restrict remote configuration sources by passing `allowed_schemes` or `allowed_hosts` to `OmegaConfigLoader` through `CONFIG_LOADER_ARGS`:
+
+```python
+from kedro.config import OmegaConfigLoader
+
+CONFIG_LOADER_CLASS = OmegaConfigLoader
+
+CONFIG_LOADER_ARGS = {
+    "allowed_schemes": ["s3"],
+    "allowed_hosts": ["trusted-config-bucket"],
+}
+```
+
+When these allowlists are set, `OmegaConfigLoader` raises a `ValueError` if a remote `conf_source` uses a scheme or host that is not allowed. Local configuration paths are unaffected.
+
+If your catalog uses `PickleDataset`, only point it at trusted data. This requirement is especially important when the configuration source itself is remote.
 
 
 ## Advanced configuration without a full Kedro project

--- a/kedro/config/omegaconf_config.py
+++ b/kedro/config/omegaconf_config.py
@@ -12,6 +12,7 @@ from collections.abc import Callable, Iterable, KeysView
 from enum import Enum, auto
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlsplit
 
 import fsspec
 from omegaconf import DictConfig, OmegaConf
@@ -100,6 +101,8 @@ class OmegaConfigLoader(AbstractConfigLoader):
         custom_resolvers: dict[str, Callable] | None = None,
         merge_strategy: dict[str, str] | None = None,
         ignore_hidden: bool = True,
+        allowed_schemes: Iterable[str] | None = None,
+        allowed_hosts: Iterable[str] | None = None,
     ):
         if isinstance(conf_source, Path):
             conf_source = str(conf_source)
@@ -129,6 +132,10 @@ class OmegaConfigLoader(AbstractConfigLoader):
                 The accepted merging strategies are `soft` and `destructive`. Defaults to `destructive`.
             ignore_hidden: A boolean flag that determines whether hidden files and directories should be
                 ignored when loading configuration files. If True, ignore hidden files and files in hidden directories.
+            allowed_schemes: Optional iterable of URL schemes that remote ``conf_source``
+                values may use. Defaults to None, which allows all supported schemes.
+            allowed_hosts: Optional iterable of hosts that remote ``conf_source`` values
+                may use. Defaults to None, which allows all hosts.
         """
         self.ignore_hidden = ignore_hidden
         self.base_env = base_env or ""
@@ -154,6 +161,9 @@ class OmegaConfigLoader(AbstractConfigLoader):
         self._register_globals_resolver()
 
         # Setup file system and protocol
+        self._validate_allowed_remote_conf_source(
+            conf_source, allowed_schemes, allowed_hosts
+        )
         self._fs, self._protocol = self._initialise_filesystem_and_protocol(conf_source)
 
         # Store remote root path if using cloud protocol
@@ -413,6 +423,41 @@ class OmegaConfigLoader(AbstractConfigLoader):
         else:
             # Default to local filesystem
             return fsspec.filesystem(protocol="file", fo=conf_source), "file"
+
+    @staticmethod
+    def _validate_allowed_remote_conf_source(
+        conf_source: str,
+        allowed_schemes: Iterable[str] | None,
+        allowed_hosts: Iterable[str] | None,
+    ) -> None:
+        """Validate remote configuration sources against optional allowlists."""
+        if allowed_schemes is None and allowed_hosts is None:
+            return
+
+        options = _parse_filepath(conf_source)
+        protocol = options["protocol"].lower()
+
+        if protocol == "file":
+            return
+
+        if allowed_schemes is not None:
+            allowed_scheme_set = {
+                scheme.lower().removesuffix("://") for scheme in allowed_schemes
+            }
+            if protocol not in allowed_scheme_set:
+                raise ValueError(
+                    f"Configuration source scheme '{protocol}' is not allowed. "
+                    f"Allowed schemes are: {sorted(allowed_scheme_set)}."
+                )
+
+        if allowed_hosts is not None:
+            host = urlsplit(conf_source).hostname
+            allowed_host_set = {host.lower() for host in allowed_hosts}
+            if host is None or host.lower() not in allowed_host_set:
+                raise ValueError(
+                    f"Configuration source host '{host}' is not allowed. "
+                    f"Allowed hosts are: {sorted(allowed_host_set)}."
+                )
 
     def _merge_configs(
         self,

--- a/tests/config/test_omegaconf_config.py
+++ b/tests/config/test_omegaconf_config.py
@@ -1685,6 +1685,65 @@ class TestRemotePathHandling:
         ):
             conf["catalog"]
 
+    def test_remote_conf_source_allowed_scheme(self, mocker):
+        mock_fs = mocker.patch("fsspec.filesystem")
+        mock_filesystem = mocker.MagicMock()
+        mock_fs.return_value = mock_filesystem
+
+        config_loader = OmegaConfigLoader(
+            "s3://trusted-bucket/configs", allowed_schemes=["s3"]
+        )
+
+        mock_fs.assert_called_once_with(protocol="s3")
+        assert config_loader._protocol == "s3"
+
+    def test_remote_conf_source_disallowed_scheme(self, mocker):
+        mock_fs = mocker.patch("fsspec.filesystem")
+
+        with pytest.raises(
+            ValueError,
+            match="Configuration source scheme 'http' is not allowed",
+        ):
+            OmegaConfigLoader("http://example.com/configs", allowed_schemes=["s3"])
+
+        mock_fs.assert_not_called()
+
+    def test_remote_conf_source_allowed_host(self, mocker):
+        mock_fs = mocker.patch("fsspec.filesystem")
+        mock_filesystem = mocker.MagicMock()
+        mock_fs.return_value = mock_filesystem
+
+        config_loader = OmegaConfigLoader(
+            "https://trusted.example.com:443/configs",
+            allowed_hosts=["trusted.example.com"],
+        )
+
+        mock_fs.assert_called_once_with(protocol="https")
+        assert config_loader._protocol == "https"
+
+    def test_remote_conf_source_disallowed_host(self, mocker):
+        mock_fs = mocker.patch("fsspec.filesystem")
+
+        with pytest.raises(
+            ValueError,
+            match="Configuration source host 'example.com' is not allowed",
+        ):
+            OmegaConfigLoader(
+                "https://example.com/configs",
+                allowed_hosts=["trusted.example.com"],
+            )
+
+        mock_fs.assert_not_called()
+
+    def test_local_conf_source_ignores_remote_allowlists(self, tmp_path):
+        config_loader = OmegaConfigLoader(
+            conf_source=tmp_path,
+            allowed_schemes=["s3"],
+            allowed_hosts=["trusted.example.com"],
+        )
+
+        assert config_loader._protocol == "file"
+
     def test_hidden_files_ignored_by_default(self, tmp_path):
         base_dir = tmp_path / "base"
         base_dir.mkdir()


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fixes #5636.

This PR adds opt-in allowlists for remote `conf_source` values in `OmegaConfigLoader`. Teams that run Kedro in multi-tenant or network-facing services can now restrict which remote URL schemes and hosts are allowed before Kedro creates an fsspec filesystem.

The default behavior is unchanged: if no allowlist is configured, `OmegaConfigLoader` continues to accept the same local paths and supported remote URLs as before.

This PR also documents the `conf_source` trust boundary described in #5635: `conf_source` should be treated as trusted operator input and must not be derived from untrusted external data.

## Development notes
<!-- What have you changed, and how has this been tested? -->
Updated `OmegaConfigLoader` to accept:

- `allowed_schemes`: optional iterable of permitted remote URL schemes.
- `allowed_hosts`: optional iterable of permitted remote URL hosts.

When either allowlist is configured, `OmegaConfigLoader` validates remote `conf_source` values before constructing the fsspec filesystem and raises a clear `ValueError` if the scheme or host is not allowed. Local configuration paths are unaffected.

Added regression tests that verify:

- allowed remote schemes still initialise the expected filesystem;
- disallowed remote schemes fail before fsspec filesystem creation;
- allowed remote hosts still initialise the expected filesystem;
- disallowed remote hosts fail before fsspec filesystem creation;
- local `conf_source` paths ignore the remote allowlists.

Updated `docs/configure/advanced_configuration.md` with allowlist usage guidance and a warning that `conf_source` must not come from untrusted external input. Added a `RELEASE.md` entry for the new opt-in allowlist feature.

Tested with:

```powershell
.venv\Scripts\python.exe -m pytest --no-cov tests\config\test_omegaconf_config.py
.venv\Scripts\python.exe -m pytest -o addopts="" --cov=kedro.config.omegaconf_config --cov-config pyproject.toml --cov-report term-missing --cov-fail-under=0 tests\config\test_omegaconf_config.py
pre-commit run ruff --files kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run ruff-format --files kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run trailing-whitespace --files RELEASE.md docs\configure\advanced_configuration.md kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run end-of-file-fixer --files RELEASE.md docs\configure\advanced_configuration.md kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
.venv\Scripts\mypy.exe kedro\config\omegaconf_config.py --strict --allow-any-generics --no-warn-unused-ignores
git diff --check
```
## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
