### PR TITLE
Add reload kedro params plan

### DIFF
--- a/PR_DESCRIPTION.md
+++ b/PR_DESCRIPTION.md
@@ -1,0 +1,89 @@
+# Implementation plan for #4813
+
+Issue: https://github.com/kedro-org/kedro/issues/4813
+
+## Summary
+
+`%reload_kedro --params` fails when a runtime parameter value with spaces is wrapped in single quotes, for example:
+
+```ipython
+%reload_kedro --params foo='bar baz'
+```
+
+The normal Kedro CLI path already supports values with spaces. The bug is isolated to the IPython line magic argument parsing path.
+
+## Affected Code
+
+- `kedro/ipython/__init__.py`
+  - `magic_reload_kedro()` uses IPython's `parse_argstring()` to parse `%reload_kedro`.
+  - The `--params` argument uses `_split_params()` as its converter.
+- `kedro/framework/cli/utils.py`
+  - `_split_params()` correctly handles values with spaces once it receives a single `key=value` string.
+- `tests/ipython/test_ipython.py`
+  - Existing tests cover valid `%reload_kedro` arguments, but not single-quoted `--params` values with spaces.
+
+## Root Cause
+
+IPython splits the line magic argument string before Kedro's `_split_params()` receives it.
+
+Observed locally:
+
+```text
+--params foo="bar baz"  -> {'foo': 'bar baz'}
+--params "foo=bar baz"  -> {'foo': 'bar baz'}
+--params foo='bar baz'  -> ScannerError
+--params 'foo=bar baz'  -> parsed incorrectly
+```
+
+So the fix should be in the `%reload_kedro` parsing layer, not in the shared CLI `_split_params()` function.
+
+## Proposed Implementation
+
+1. Add regression tests in `tests/ipython/test_ipython.py` for:
+   - `%reload_kedro --params foo='bar baz'`
+   - `%reload_kedro --params 'foo=bar baz'`
+   - existing double-quoted and unquoted valid cases to guard against regressions.
+
+2. Add a small private helper in `kedro/ipython/__init__.py`, for example:
+
+   ```python
+   def _normalise_reload_kedro_params(line: str) -> str:
+       ...
+   ```
+
+3. Keep the helper narrow:
+   - only inspect and normalise the raw `--params` argument;
+   - do not replace all `%reload_kedro` parsing with `shlex.split()`;
+   - preserve existing handling for `path`, `--env`, and `--conf-source`.
+
+4. The helper should rewrite single-quoted `--params` values into a form IPython already parses correctly, for example:
+
+   ```text
+   --params foo='bar baz'
+   ```
+
+   becomes:
+
+   ```text
+   --params "foo=bar baz"
+   ```
+
+5. Leave `_split_params()` unchanged because the normal CLI path already depends on it and its current behavior is correct.
+
+## Validation Plan
+
+Run:
+
+```powershell
+.venv\Scripts\python.exe -m pytest --no-cov tests\ipython\test_ipython.py
+pre-commit run ruff --files kedro\ipython\__init__.py tests\ipython\test_ipython.py
+pre-commit run ruff-format --files kedro\ipython\__init__.py tests\ipython\test_ipython.py
+pre-commit run trailing-whitespace --files kedro\ipython\__init__.py tests\ipython\test_ipython.py
+pre-commit run end-of-file-fixer --files kedro\ipython\__init__.py tests\ipython\test_ipython.py
+.venv\Scripts\mypy.exe kedro\ipython\__init__.py --strict --allow-any-generics --no-warn-unused-ignores
+git diff --check
+```
+
+## Notes
+
+This issue is on Kedro's OS contribution board with status `Ready`, has no assignee, and currently has no active PR.


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fixes #5636.

This PR adds opt-in allowlists for remote `conf_source` values in `OmegaConfigLoader`. Teams that run Kedro in multi-tenant or network-facing services can restrict which remote URL schemes and hosts are allowed before Kedro creates an fsspec filesystem.

The default behaviour is unchanged. If no allowlist is configured, `OmegaConfigLoader` continues to accept the same local paths and supported remote URLs as before.

This PR also documents the `conf_source` trust boundary described in #5635: `conf_source` should be treated as trusted operator input and must not be derived from untrusted external data.


## Development notes
<!-- What have you changed, and how has this been tested? -->
Updated `OmegaConfigLoader` to accept:

- `allowed_schemes`: optional iterable of permitted remote URL schemes.
- `allowed_hosts`: optional iterable of permitted remote URL hosts.

When either allowlist is configured, `OmegaConfigLoader` validates remote `conf_source` values before constructing the fsspec filesystem and raises a clear `ValueError` if the scheme or host is not allowed. Local configuration paths are unaffected.

Added regression tests that verify:

- allowed remote schemes still initialise the expected filesystem;
- disallowed remote schemes fail before fsspec filesystem creation;
- allowed remote hosts still initialise the expected filesystem;
- disallowed remote hosts fail before fsspec filesystem creation;
- local `conf_source` paths ignore the remote allowlists.

Updated `docs/configure/advanced_configuration.md` with allowlist usage guidance and a warning that `conf_source` must not come from untrusted external input. Added a `RELEASE.md` entry for the new opt-in allowlist feature.

Tested with:

```powershell
.venv\Scripts\python.exe -m pytest --no-cov tests\config\test_omegaconf_config.py
.venv\Scripts\python.exe -m pytest -o addopts="" --cov=kedro.config.omegaconf_config --cov-config pyproject.toml --cov-report term-missing --cov-fail-under=0 tests\config\test_omegaconf_config.py
pre-commit run ruff --files kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run ruff-format --files kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run trailing-whitespace --files RELEASE.md docs\configure\advanced_configuration.md kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
pre-commit run end-of-file-fixer --files RELEASE.md docs\configure\advanced_configuration.md kedro\config\omegaconf_config.py tests\config\test_omegaconf_config.py
.venv\Scripts\mypy.exe kedro\config\omegaconf_config.py --strict --allow-any-generics --no-warn-unused-ignores
git diff --check
```

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
