### PR TITLE
Fix ASV benchmark failure with asv 0.6.6+

### DIFF
--- a/.github/styles/Kedro/headings.yml
+++ b/.github/styles/Kedro/headings.yml
@@ -16,7 +16,6 @@ exceptions:
   - AWS Batch
   - AWS Step Functions
   - AWS Systems Manager
-  - AWS
   - Azure
   - Azure App Service
   - Azure App Service Plan

--- a/.github/styles/Kedro/ignore-names.txt
+++ b/.github/styles/Kedro/ignore-names.txt
@@ -18,6 +18,7 @@ Cvetanka
 Czakon
 Chan
 Chaves
+Cima
 Comym
 Couto
 da
@@ -59,6 +60,7 @@ Kaltsas
 Kanchwala
 Katiyar
 Khan
+Khaustova
 Kirilenko
 Kiyohito
 Klein

--- a/.github/styles/Kedro/ignore.txt
+++ b/.github/styles/Kedro/ignore.txt
@@ -2,11 +2,14 @@ agentic
 Aneira
 AMI
 AMIs
+anonymised
 APIs
 Astro
 async
 autodiscovery
 breakpoint
+callables
+callouts
 chonky
 Claypot
 Colab
@@ -31,6 +34,8 @@ docstrings
 doxenix
 ethanknights
 filepath
+filesystem
+filesystem's
 fsspec
 gif
 Globals
@@ -38,6 +43,8 @@ globals
 Grafana
 hyperparameter
 hyperparameters
+initialiser
+interdependencies
 ipdb
 IPython
 Jupyter
@@ -84,6 +91,7 @@ Printify
 Pylint
 pyenv
 pytest
+reformats
 regressors
 Repo
 Repos

--- a/.github/styles/Kedro/ignore.txt
+++ b/.github/styles/Kedro/ignore.txt
@@ -117,6 +117,7 @@ transcoding
 untyped
 untrusted
 validators
+vCPUs
 Unsplash
 uv
 VSCode

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -3,8 +3,7 @@ name: ASV Benchmark
 on:
   push:
     branches:
-      - main
-      - fix/asv-benchmark-multiple-wheels # for testing  # Run benchmarks on every commit to the main branch
+      - main  # Run benchmarks on every commit to the main branch
   workflow_dispatch:
 
 

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -3,7 +3,8 @@ name: ASV Benchmark
 on:
   push:
     branches:
-      - main  # Run benchmarks on every commit to the main branch
+      - main
+      - fix/asv-benchmark-multiple-wheels # for testing  # Run benchmarks on every commit to the main branch
   workflow_dispatch:
 
 

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -3,8 +3,7 @@ name: ASV Benchmark
 on:
   push:
     branches:
-      - main
-      - fix/asv-benchmark-multiple-wheels # for testing  # Run benchmarks on every commit to the main branch
+      - main  # Run benchmarks on every commit to the main branch
   workflow_dispatch:
 
 
@@ -34,8 +33,8 @@ jobs:
       - name: Run ASV benchmarks
         run: |
           cd kedro
-          asv machine --machine=github-actions
-          asv run -v --machine=github-actions
+          asv machine --yes --machine=github-actions
+          asv run -v --machine=github-actions HEAD
 
       - name: Set git email and name
         run: |

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install "asv>=0.6.6"  # Install ASV (0.6.6+ requires --no-deps build_command in asv.conf.json)
+          pip install "asv>=0.6.6"
 
       - name: Run ASV benchmarks
         run: |

--- a/.github/workflows/benchmark-performance.yml
+++ b/.github/workflows/benchmark-performance.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install asv  # Install ASV
+          pip install "asv>=0.6.6"  # Install ASV (0.6.6+ requires --no-deps build_command in asv.conf.json)
 
       - name: Run ASV benchmarks
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,9 +1,16 @@
 # Upcoming Release
-
 ## Major features and improvements
-* Added a new HTTP Server layer which uses the `KedroServiceSession` to execute pipelines from HTTP requests.
+## Bug fixes and other changes
+## Documentation changes
+## Community contributions
+
+# Release 1.5.0
+## Major features and improvements
+* Added a new HTTP Server layer which uses the `KedroServiceSession` to execute pipelines from HTTP requests. It offers the following endpoints:
+  * `/run` to run pipelines with optional runtime parameters.
+  * `/health` to check the server's health status.
+  * `/snapshot` to retrieve the current project snapshot.
 * Added a new CLI command `kedro server start` to run the server.
-* Added an HTTP endpoint `/snapshot` for accessing project snapshot.
 * Added selective pipeline loading: when `--pipelines` is specified, only the requested pipeline modules are imported.
 
 ## Bug fixes and other changes
@@ -19,12 +26,13 @@
 * Updated the AWS Batch deployment guide with a strategy-first layout, custom `AWSBatchRunner` usage, namespace-based job submission, and S3-backed catalog configuration.
 
 ## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
 * [Feng Jikui](https://github.com/fengjikui)
 * [Rudra Dudhat](https://github.com/RudraDudhat2509)
+* [Jean-Baptiste Braun](https://github.com/jbbqqf)
+* [Gargi](https://github.com/Kaliagargi)
+* [Simon](https://github.com/simon-b)
 
-Many thanks to the following Kedroids for contributing PRs to this release:
-
-* [Simon Bull](https://github.com/simon-b)
 
 # Release 1.4.0
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 * Added a new HTTP Server layer which uses the `KedroServiceSession` to execute pipelines from HTTP requests.
 * Added a new CLI command `kedro server start` to run the server.
 * Added an HTTP endpoint `/snapshot` for accessing project snapshot.
-
+* Added selective pipeline loading: when `--pipelines` is specified, only the requested pipeline modules are imported.
 
 ## Bug fixes and other changes
 * Fixed Rich logging integration so node input/output brackets render correctly in console logs and dataset colour markup does not leak into plain log handlers.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -14,6 +14,9 @@
 
 ## Documentation changes
 * Documented hooks limitation when using `ParallelRunner`.
+* Updated the Amazon EMR Serverless deployment guide with a strategy-first layout, custom container images, Spark catalog configuration, and troubleshooting for common deployment issues.
+* Updated the AWS Step Functions deployment guide with a strategy-first layout, pipeline-level namespace grouping, Lambda container deployment, and an end-to-end Spaceflights walkthrough.
+* Updated the AWS Batch deployment guide with a strategy-first layout, custom `AWSBatchRunner` usage, namespace-based job submission, and S3-backed catalog configuration.
 
 ## Community contributions
 * [Feng Jikui](https://github.com/fengjikui)

--- a/asv.conf.json
+++ b/asv.conf.json
@@ -3,6 +3,9 @@
     "project": "Kedro",
     "project_url": "https://kedro.org/",
     "repo": ".",
+    "build_command": [
+        "PIP_NO_BUILD_ISOLATION=false python -m pip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    ],
     "install_command": [
         "pip install -e .  kedro-datasets[pandas-csvdataset]"
     ],

--- a/docs/about/migration.md
+++ b/docs/about/migration.md
@@ -71,7 +71,7 @@ You should now use the following:
 kedro run --namespaces=preprocessing
 ```
 - `kedro catalog create` command was removed in Kedro 1.0.0.
-- If you were using the experimental `KedroDataCatalog` class, it was renamed to `DataCatalog` in Kedro 1.0.0. You would need to remove the following lines from your `settings.py` file:
+- If you were using the experimental `KedroDataCatalog` class, note that it has been renamed to `DataCatalog` in Kedro 1.0.0. You should remove the following lines from your `settings.py` file:
 
 ```diff
 - from kedro.io import KedroDataCatalog
@@ -236,7 +236,7 @@ You now need to install and import datasets from the [`kedro-datasets`](https://
 
 ### Configuration changes in 0.19
 
-The `ConfigLoader` and `TemplatedConfigLoader` classes were deprecated in Kedro 0.18.12 and were removed in Kedro 0.19.0. To use that release or later, you must now adopt the `OmegaConfigLoader`. The [configuration migration guide](../configure/config_loader_migration.md) outlines the primary distinctions between the old loaders and the OmegaConfigLoader, and provides step-by-step instructions on updating your code base to use the new class effectively.
+The `ConfigLoader` and `TemplatedConfigLoader` classes were deprecated in Kedro 0.18.12 and were removed in Kedro 0.19.0. To use that release or later, you must now adopt the `OmegaConfigLoader`. The [configuration migration guide](../configure/config_loader_migration.md) outlines the primary distinctions between the old loaders and the OmegaConfigLoader. It also provides step-by-step instructions on updating your code base to use the new class effectively.
 
 
 #### Changes to the default environments

--- a/docs/about/technical_steering_committee.md
+++ b/docs/about/technical_steering_committee.md
@@ -4,7 +4,7 @@ Kedro is a graduate-stage project within [LF AI & Data](https://lfaidata.foundat
 
 The term "Technical Steering Committee" (TSC) describes the group of Kedro maintainers, committers, and advisors. We list Kedro's [current](#current-tsc-members) and [past](#past-tsc-members) TSC members on this page.
 
-The TSC is responsible for the project's future development; you can read about our duties in our [Technical Charter](https://github.com/kedro-org/kedro/blob/main/kedro_technical_charter.pdf). We accept new members into the TSC to fuel Kedro's continued development.
+The TSC oversees the project's future development; you can read about our duties in our [Technical Charter](https://github.com/kedro-org/kedro/blob/main/kedro_technical_charter.pdf). We accept new members into the TSC to fuel Kedro's continued development.
 
 On this page we describe:
 
@@ -22,7 +22,7 @@ On this page we describe:
 
 ## Kedro TSC roles
 
-The Kedro TSC is responsible for the project's future development. The TSC is made up of the following roles:
+The Kedro TSC oversees the project's future development. The TSC is made up of the following roles:
 
 ### Maintainers
 
@@ -155,37 +155,38 @@ Advisors may be automatically removed after 6 months of inactivity. Inactivity i
 
 Kedro was originally designed by [Aris Valtazanos](https://github.com/arisvqb) and [Nikolaos Tsaousis](https://github.com/tsanikgr) at [QuantumBlack](https://www.mckinsey.com/capabilities/quantumblack) to solve challenges they faced in their project work. Their work was later turned into an internal product by [Peteris Erins](https://github.com/Pet3ris), [Ivan Danov](https://github.com/idanov), [Nikolaos Kaltsas](https://github.com/nikos-kal), [Meisam Emamjome](https://github.com/misamae) and [Nikolaos Tsaousis](https://github.com/tsanikgr).
 
-Former core team members with significant contributions include
-[Ahdra Merali](https://github.com/AhdraMeraliQB),
-[Amanda Koh](https://github.com/amandakys),
-[Andrew Mackay](https://github.com/Mackay031),
-[Andrii Ivaniuk](https://github.com/andrii-ivaniuk),
-[Anton Kirilenko](https://github.com/Flid),
-[Antony Milne](https://github.com/antonymilne),
-[Cvetanka Nechevska](https://github.com/cvetankanechevska),
-[Dmitrii Deriabin](https://github.com/dmder),
-[Dmitry Sorokin](https://github.com/DimedS),
-[Gabriel Comym](https://github.com/comym),
-[Gordon Wrigley](https://github.com/tolomea),
-[Hamza Oza](https://github.com/hamzaoza),
-[Ignacio Paricio](https://github.com/ignacioparicio),
-[Jannic Holzer](https://github.com/jmholzer),
-[Jo Stichbury](https://github.com/stichbury),
-[Juan Luis Cano](https://github.com/astrojuanlu),
-[Jiri Klein](https://github.com/jiriklein),
-[Kiyohito Kunii](https://github.com/921kiyo),
-[Laís Carvalho](https://github.com/laisbsc),
-[Liam Brummitt](https://github.com/bru5),
-[Lim Hoang](https://github.com/limdauto),
-[Lorena Bălan](https://github.com/lorenabalan),
-[Mehdi Naderi Varandi](https://github.com/MehdiNV),
-[Nasef Khan](https://github.com/nakhan98),
-[Nero Okwa](https://github.com/NeroOkwa),
-[Richard Westenra](https://github.com/richardwestenra),
-[Stephanie Kaiser](https://github.com/stephkaiser),
-[Susanna Wong](https://github.com/studioswong),
-[Vladimir Nikolic](https://github.com/vladimir-mck) and
-[Zain Patel](https://github.com/mzjp2).
+Former core team members with significant contributions include:
+
+- [Ahdra Merali](https://github.com/AhdraMeraliQB)
+- [Amanda Koh](https://github.com/amandakys)
+- [Andrew Mackay](https://github.com/Mackay031)
+- [Andrii Ivaniuk](https://github.com/andrii-ivaniuk)
+- [Anton Kirilenko](https://github.com/Flid)
+- [Antony Milne](https://github.com/antonymilne)
+- [Cvetanka Nechevska](https://github.com/cvetankanechevska)
+- [Dmitrii Deriabin](https://github.com/dmder)
+- [Dmitry Sorokin](https://github.com/DimedS)
+- [Gabriel Comym](https://github.com/comym)
+- [Gordon Wrigley](https://github.com/tolomea)
+- [Hamza Oza](https://github.com/hamzaoza)
+- [Ignacio Paricio](https://github.com/ignacioparicio)
+- [Jannic Holzer](https://github.com/jmholzer)
+- [Jo Stichbury](https://github.com/stichbury)
+- [Juan Luis Cano](https://github.com/astrojuanlu)
+- [Jiri Klein](https://github.com/jiriklein)
+- [Kiyohito Kunii](https://github.com/921kiyo)
+- [Laís Carvalho](https://github.com/laisbsc)
+- [Liam Brummitt](https://github.com/bru5)
+- [Lim Hoang](https://github.com/limdauto)
+- [Lorena Bălan](https://github.com/lorenabalan)
+- [Mehdi Naderi Varandi](https://github.com/MehdiNV)
+- [Nasef Khan](https://github.com/nakhan98)
+- [Nero Okwa](https://github.com/NeroOkwa)
+- [Richard Westenra](https://github.com/richardwestenra)
+- [Stephanie Kaiser](https://github.com/stephkaiser)
+- [Susanna Wong](https://github.com/studioswong)
+- [Vladimir Nikolic](https://github.com/vladimir-mck)
+- [Zain Patel](https://github.com/mzjp2)
 
 
 ## Voting process
@@ -209,7 +210,7 @@ Any member may choose to step out of their current role at any time by communica
 Any member may request to step down to a non voting category at any time if they believe they can contribute more effectively in that role. This change does not require a vote.
 
 ### Step-up procedure
-Members who wish to move up to a category that requires a higher commitment (advisor to maintainer or committer, or committer to maintainer) must receive formal approval through a TSC vote. The member must also have an active TSC [maintainer](#maintainers) advocate to support their nomination.
+Members who wish to move up to a category that requires a higher commitment (advisor to maintainer, or committer to maintainer) must receive formal approval through a TSC vote. The member must also have an active TSC [maintainer](#maintainers) advocate to support their nomination.
 
 ### Automatic removal and transition option
 If a member is automatically removed from their current category (due to inactivity), they can request placement in the next lower level within two weeks of their removal. If no request is made within that time frame, the member will be removed from the TSC entirely.

--- a/docs/about/telemetry.md
+++ b/docs/about/telemetry.md
@@ -19,7 +19,7 @@ which is installed as one of Kedro’s dependencies.
 ## Collected data fields
 
 - **Unique User Identifier (UUID):** The UUID is a randomly generated anonymous identifier, stored within an OS-specific configuration folder for Kedro, named `telemetry.toml`. If a UUID does not already exist, the telemetry plugin generates a new one, stores it, and then uses this UUID in following telemetry events.
-- **CLI Command (Masked Arguments):** The command used, with sensitive arguments masked for privacy. Example Input: `kedro run --pipeline=ds --env=test` What we receive: `kedro run --pipeline ***** --env *****`
+- **CLI Command (Masked Arguments):** The command used, with sensitive arguments masked for privacy. Example Input: `kedro run --pipelines=ds --env=test` What we receive: `kedro run --pipelines ***** --env *****`
 - **Project UUID:** The hash of project UUID (randomly generated anonymous project identifier) and the package name. If project UUID does not already exist, the telemetry plugin generates a new one, stores it in `pyproject.toml`, and then joins this project UUID with the package name, hashes the joined result and uses it in following telemetry events.
 - **Kedro Project Version:** The version of Kedro being used.
 - **Kedro-Telemetry Version:** The version of the Kedro-Telemetry plugin.

--- a/docs/about/telemetry.md
+++ b/docs/about/telemetry.md
@@ -38,7 +38,7 @@ For technical information on how the telemetry collection works, you can browse
 To withdraw consent, you have several options:
 
 1 - **Set Environment Variables**:
-   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of any of these environment variables will disable telemetry for all Kedro projects in that environment and will override any consent specified in the `.telemetry` file of the specific project.
+   Set the environment variables `DO_NOT_TRACK` or `KEDRO_DISABLE_TELEMETRY` to any value. The presence of any of these environment variables disables telemetry for all Kedro projects in that environment. It overrides any consent specified in the `.telemetry` file of the specific project.
 
 2 - **CLI Option When Creating a New Project**:
    When creating a new project, you can use the command:

--- a/docs/build/modular_pipelines.md
+++ b/docs/build/modular_pipelines.md
@@ -119,7 +119,7 @@ It is your responsibility to create functional Cookiecutter templates for custom
 Make sure you understand the basic structure of a pipeline before you start.
 Your template should render to a valid, importable Python module containing a `create_pipeline` function at the top level that returns a `Pipeline` object.
 You will also need appropriate `config` and `tests` subdirectories; Kedro copies them to the project `config` and `tests` directories when the pipeline is created.
-The `config` and `tests` directories need to follow the same layout as in the default template and cannot be customised, although the contents of the parameters and the actual test file can be changed.
+The `config` and `tests` directories need to follow the same layout as in the default template and cannot be customised. You can still change the contents of the parameters and the actual test file.
 File and folder names or structure do not matter beyond that and can be customised according to your needs.
 You can use [the default template that Kedro](https://github.com/kedro-org/kedro/tree/main/kedro/templates/pipeline) uses as a starting point.
 

--- a/docs/build/namespaces.md
+++ b/docs/build/namespaces.md
@@ -8,7 +8,7 @@ In this section, we introduce namespaces - a powerful tool for grouping and isol
 
 ## How to reuse your pipelines
 
-If you want to create a new pipeline that performs similar tasks with different inputs/outputs/parameters as your `existing_pipeline`, you can use the same `Pipeline` class as described in [How to structure your pipeline creation](modular_pipelines.md#how-to-structure-your-pipeline-creation). This function allows you to overwrite inputs, outputs, and parameters. Your new pipeline creation code should look like this:
+To create a new pipeline that performs similar tasks with different inputs, outputs, or parameters as your `existing_pipeline`, you can use the same `Pipeline` class. See [How to structure your pipeline creation](modular_pipelines.md#how-to-structure-your-pipeline-creation). This function allows you to overwrite inputs, outputs, and parameters. Your new pipeline creation code should look like this:
 
 ```python
 def create_pipeline(**kwargs) -> Pipeline:
@@ -20,7 +20,7 @@ def create_pipeline(**kwargs) -> Pipeline:
     )
 ```
 
-This means you can create multiple pipelines based on the `existing_pipeline` pipeline to test different approaches with various input datasets and model training parameters. For example, for the `data_science` pipeline from our [Spaceflights tutorial](../tutorials/add_another_pipeline.md#data-science-pipeline), you can restructure the `src/project_name/pipelines/data_science/pipeline.py` file by separating the `data_science` pipeline creation code into a separate `base_data_science` pipeline object, then reusing it inside the `create_pipeline()` function:
+This means you can create multiple pipelines based on the `existing_pipeline` pipeline to test different approaches with various input datasets and model training parameters. For example, take the `data_science` pipeline from our [Spaceflights tutorial](../tutorials/add_another_pipeline.md#data-science-pipeline). You can restructure the `src/project_name/pipelines/data_science/pipeline.py` file by separating the `data_science` pipeline creation code into a `base_data_science` pipeline object, then reusing it inside the `create_pipeline()` function:
 
 ```python
 #src/project_name/pipelines/data_science/pipeline.py
@@ -84,7 +84,7 @@ If you want to execute `base_data_science` and `data_science` pipelines together
 A namespace is a way to isolate nodes, inputs, outputs, and parameters inside your pipeline. If you put `namespace="namespace_name"` attribute inside the `Pipeline` class, it will add the `namespace_name.` prefix to all nodes, inputs, outputs, and parameters inside your new pipeline.
 
 !!! note
-    If you don't want to change the names of your inputs, outputs, or parameters with the `namespace_name.` prefix while using a namespace, you can disable it by setting the `prefix_datasets_with_namespace` parameter to `False`. This keeps the original names of your inputs, outputs, and parameters. The nodes are still prefixed with the namespace name. For example:
+    To skip prefixing your inputs, outputs, or parameters with `namespace_name.` while using a namespace, set the `prefix_datasets_with_namespace` parameter to `False`. This keeps the original names of your inputs, outputs, and parameters. The nodes are still prefixed with the namespace name. For example:
 
 ```python
 Pipeline(
@@ -237,7 +237,7 @@ def create_pipeline(**kwargs) -> Pipeline:
 
 You can further nest namespaces by assigning namespaces at the node level with the `namespace` argument of the `Node` class. Namespacing at node level should be done to enhance visualisation by creating collapsible pipeline parts on Kedro-Viz. In this case, the node name is prefixed with `namespace_name`, while inputs, outputs, and parameters remain unchanged. This behaviour differs from [namespacing at the pipeline level](#what-is-a-namespace).
 
-For example, if you want to group the first two nodes of the `data_processing` pipeline from [Spaceflights tutorial](../tutorials/add_another_pipeline.md#data-science-pipeline) into the same collapsible namespace for visualisation, you can update your pipeline like this:
+For example, suppose you want to group the first two nodes of the `data_processing` pipeline from [Spaceflights tutorial](../tutorials/add_another_pipeline.md#data-science-pipeline) into the same collapsible namespace for visualisation. You can update your pipeline like this:
 
 ```python
 #src/project_name/pipelines/data_science/pipeline.py

--- a/docs/build/nodes.md
+++ b/docs/build/nodes.md
@@ -91,9 +91,11 @@ Any combinations of the above are possible, except nodes of the form `Node(f, No
 ## `*args` node functions
 It is common to have functions that take an arbitrary number of inputs, like a function that combines multiple dataframes. You can use the `*args` argument in the node function, while declaring the names of the datasets in the node's inputs.
 
+<!-- vale Kedro.weaselwords = NO -->
 ## `**kwargs`-only node functions
+<!-- vale Kedro.weaselwords = YES -->
 
-Sometimes, when creating reporting nodes for instance, you need to know the names of the datasets that your node receives, but you might not have this information in advance. This can be solved by defining a `**kwargs`-only function:
+Sometimes, when creating reporting nodes for instance, you need to know the names of the datasets that your node receives, but you might not have this information in advance. This can be solved by defining a function that takes `**kwargs`:
 
 ```python
 def reporting(**kwargs):
@@ -168,7 +170,7 @@ kedro run --tags=pipeline_tag
 This runs the nodes found within the pipeline tagged with `pipeline_tag`.
 
 !!! note
-    Node or tag names must ONLY contain letters, digits, hyphens, underscores, and periods. Other symbols are not permitted.
+    Node or tag names must contain letters, digits, hyphens, underscores, and periods. Other symbols are not permitted.
 
 
 ## How to run a node
@@ -221,7 +223,9 @@ You need to add a new dataset in your `catalog.yml` as follows:
 With `pandas` built-in support, you can use the `chunksize` argument to read data using generator.
 
 ### Saving data with generators
-To use generators to save data lazily, you need do three things:
+<!-- vale Kedro.weaselwords = NO -->
+To use generators to save data lazily, you need to do three things:
+<!-- vale Kedro.weaselwords = YES -->
 - Update the `make_prediction` function definition to use `yield` instead of `return`.
 - Create a [custom dataset](../extend/how_to_create_a_custom_dataset.md) called `ChunkWiseCSVDataset`
 - Update `catalog.yml` to use a newly created `ChunkWiseCSVDataset`.
@@ -331,7 +335,7 @@ After that, you need to update the `catalog.yml` to use this new dataset.
 +  filepath: data/07_model_output/y_pred.csv
 ```
 
-With these changes, when you run `kedro run` in your terminal, you should see `y_pred` being saved multiple times in the logs as the generator lazily processes and saves the data in smaller chunks.
+With these changes, when you run `kedro run` in your terminal, you should see `y_pred` being saved multiple times in the logs as the generator processes and saves the data in smaller chunks.
 
 ```
 ...

--- a/docs/build/pipeline_introduction.md
+++ b/docs/build/pipeline_introduction.md
@@ -217,7 +217,7 @@ Format should be: Node(function, inputs, outputs)
 
 ### Pipeline with circular dependencies
 
-For every two variables where the first depends on the second, there must not be a way in which the second also depends on the first, otherwise, a circular dependency will prevent us from compiling the pipeline.
+For every two variables where the first depends on the second, the second must not also depend on the first. Otherwise, a circular dependency will prevent us from compiling the pipeline.
 
 The first node captures the relationship of how to calculate `y` from `x` and the second captures the relationship of how to calculate `x` knowing `y`. The pair of nodes cannot co-exist in the same pipeline:
 

--- a/docs/build/pipeline_registry.md
+++ b/docs/build/pipeline_registry.md
@@ -2,7 +2,7 @@
 
 Projects generated using Kedro 0.17.2 or later define their pipelines in `src/<package_name>/pipeline_registry.py`. This populates the `pipelines` variable in [`kedro.framework.project`][kedro.framework.project] that the Kedro CLI and plugins use to access project pipelines. The `pipeline_registry` module must contain a top-level `register_pipelines()` function that returns a mapping from pipeline names to [`Pipeline`][kedro.pipeline.pipeline.Pipeline] objects.
 
-For example, the [pipeline registry in the Kedro starter for the completed spaceflights tutorial](https://github.com/kedro-org/kedro-starters/blob/main/spaceflights-pandas/{{ cookiecutter.repo_name }}/src/{{ cookiecutter.python_package }}/pipeline_registry.py) defines the following `register_pipelines()` function. It exposes the data processing pipeline, the data science pipeline, and a default pipeline that combines both:
+For example, the [pipeline registry in the Kedro starter for the completed spaceflights tutorial](https://github.com/kedro-org/kedro-starters/blob/main/spaceflights-pandas/%7B%7B%20cookiecutter.repo_name%20%7D%7D/src/%7B%7B%20cookiecutter.python_package%20%7D%7D/pipeline_registry.py) defines the following `register_pipelines()` function. It exposes the data processing pipeline, the data science pipeline, and a default pipeline that combines both:
 
 ```python
 import spaceflights.pipelines.data_processing as dp
@@ -28,7 +28,7 @@ def register_pipelines() -> Dict[str, Pipeline]:
 As a reminder, [running `kedro run` without the `--pipelines` option runs the default pipeline](./run_a_pipeline.md#run-a-pipeline-by-name).
 
 !!! note
-    The order in which you add the pipelines together is not significant (`data_science_pipeline + data_processing_pipeline` would produce the same result), since Kedro automatically detects the data-centric execution order for all the nodes in the resulting pipeline.
+    The order in which you add the pipelines together is not significant (`data_science_pipeline + data_processing_pipeline` would produce the same result). Kedro automatically detects the data-centric execution order for all the nodes in the resulting pipeline.
 
 ## Pipeline autodiscovery
 

--- a/docs/build/pipeline_registry.md
+++ b/docs/build/pipeline_registry.md
@@ -73,7 +73,7 @@ def register_pipelines() -> Dict[str, Pipeline]:
     return pipelines
 ```
 !!! note
-    In the case above, `kedro run --tags data_engineering` will not run the data engineering pipeline, as it is not part of the default pipeline. To run the data engineering pipeline, you need to specify `kedro run --pipeline data_engineering --tags data_engineering`.
+    In the case above, `kedro run --tags data_engineering` will not run the data engineering pipeline, as it is not part of the default pipeline. To run the data engineering pipeline, you need to specify `kedro run --pipelines data_engineering --tags data_engineering`.
 
 You can also change pipelines *before* assigning `pipelines["__default__"] = sum(pipelines.values())`, which includes them in the default pipeline. For example, you can update the `data_processing` pipeline with the `data_engineering` tag in `pipeline_registry.py` and also include this change in the default pipeline:
 

--- a/docs/build/run_a_pipeline.md
+++ b/docs/build/run_a_pipeline.md
@@ -202,6 +202,25 @@ kedro run --pipelines=data_processing,data_science
 
 Further information about `kedro run` can be found in the [Kedro CLI documentation](../getting-started/commands_reference.md#kedro-run).
 
+## Selective pipeline loading
+
+When you run `kedro run --pipelines <name>`, Kedro imports the pipeline modules required for that run and skips unrelated modules. This speeds up startup time in large projects.
+
+```bash
+kedro run --pipelines data_science
+```
+
+You can also run multiple named pipelines in a single command:
+
+```bash
+kedro run --pipelines data_engineering,data_science
+```
+
+Passing `__default__` (or omitting `--pipelines` entirely) loads all registered pipelines as normal.
+
+!!! note "Limitation"
+    Selective loading requires that `register_pipelines()` uses [`find_pipelines()`](../api/framework/kedro.framework.project.md) for discovery. Top-level imports in `pipeline_registry.py` (outside the function body) fire before any filter is applied. Similarly, direct access to the `pipelines` dictionary outside of `session.run()` (for example, during bootstrapping) bypasses the filter.
+
 ## Run pipelines with IO
 
 The above definition of pipelines applies to non-stateful or "pure" pipelines that do not interact with the outside world. In practice, we would like to interact with APIs, databases, files, and other sources of data. By combining IO and pipelines, we can tackle these more complex use cases.

--- a/docs/catalog-data/advanced_data_catalog_usage.md
+++ b/docs/catalog-data/advanced_data_catalog_usage.md
@@ -1,6 +1,6 @@
 # Advanced: Access the Data Catalog in code
 
-You can define a Data Catalog in two ways. Most projects rely on a YAML configuration file as [illustrated earlier](./data_catalog.md). You can also access the Data Catalog programmatically through [kedro.io.DataCatalog][] using an API that allows you to configure data sources in code and use the IO module within notebooks.
+You can define a Data Catalog in two ways. Most projects rely on a YAML configuration file as [illustrated earlier](./data_catalog.md). You can also access the Data Catalog programmatically through [kedro.io.DataCatalog][]. The API lets you configure data sources in code and use the IO module within notebooks.
 
 !!! Warning
     Datasets are not included in the core Kedro package from Kedro version **`0.19.0`**. Import them from the [`kedro-datasets`](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-datasets) package instead.
@@ -166,7 +166,7 @@ The following steps happened behind the scenes when `load` was called:
 ## How to save data programmatically
 
 !!! warning "Memory Dataset Warning"
-    This pattern is not recommended unless you are using a hosted notebook environment such as SageMaker or Databricks, or writing unit or integration tests for your Kedro pipeline. Use the YAML approach in preference.
+    This pattern is not recommended unless you are using a hosted notebook environment such as SageMaker or Databricks. The pattern is also acceptable when writing unit or integration tests for your Kedro pipeline. Use the YAML approach in preference.
 
 ### How to save data to memory
 

--- a/docs/catalog-data/data_catalog.md
+++ b/docs/catalog-data/data_catalog.md
@@ -224,7 +224,7 @@ Versions are returned in reverse chronological order (newest first).
 
 #### How versioning works
 
-A dataset offers versioning support if it extends the [kedro.io.AbstractVersionedDataset][] class to accept a version keyword argument as part of the constructor and adapt the `_save` and `_load` method to use the versioned data path obtained from `_get_save_path` and `_get_load_path` respectively.
+A dataset offers versioning support if it extends the [kedro.io.AbstractVersionedDataset][] class to accept a version keyword argument as part of the constructor. It must also adapt the `_save` and `_load` methods to use the versioned data path obtained from `_get_save_path` and `_get_load_path` respectively.
 
 To verify whether a dataset can undergo versioning, you should examine the dataset class code to inspect its inheritance [(you can find contributed datasets within the `kedro-datasets` repository)](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-datasets/kedro_datasets). Check if the dataset class inherits from the `AbstractVersionedDataset`. For instance, if you encounter a class like `CSVDataset(AbstractVersionedDataset[pd.DataFrame, pd.DataFrame])`, this indicates that the dataset is set up to support versioning.
 
@@ -235,9 +235,9 @@ To verify whether a dataset can undergo versioning, you should examine the datas
 
 Kedro configuration enables you to organise your project for different stages of your data pipeline. For example, you might need different Data Catalog settings for development, testing, and production environments.
 
-By default, Kedro has a `base` and a `local` folder for configuration. The Data Catalog configuration is loaded using a configuration loader class which recursively scans for configuration files inside the `conf` folder, firstly in `conf/base` and then in `conf/local` (which is the designated overriding environment). Kedro merges the configuration information and returns a configuration dictionary according to rules set out in the [configuration documentation](../configure/configuration_basics.md).
+By default, Kedro has a `base` and a `local` folder for configuration. A configuration loader class scans for configuration files inside the `conf` folder, starting in `conf/base` and then in `conf/local` (the designated overriding environment). Kedro merges the configuration information and returns a configuration dictionary, following the rules set out in the [configuration documentation](../configure/configuration_basics.md).
 
-In summary, if you need to configure your datasets for different environments, you can create both `conf/base/catalog.yml` and `conf/local/catalog.yml`. For instance, you can use the `catalog.yml` file in `conf/base/` to register the locations of datasets that would run in production, while adding a second version of `catalog.yml` in `conf/local/` to register the locations of sample datasets while you are using them for prototyping data pipeline(s).
+In summary, if you need to configure your datasets for different environments, you can create both `conf/base/catalog.yml` and `conf/local/catalog.yml`. For instance, you can use the `catalog.yml` file in `conf/base/` to register the locations of datasets that would run in production. You can then add a second version of `catalog.yml` in `conf/local/` to register the locations of sample datasets for prototyping your data pipelines.
 
 To illustrate this, consider the following catalog entry for a dataset named `cars` in `conf/base/catalog.yml`, which points to a CSV file stored in a bucket on AWS S3:
 
@@ -255,4 +255,4 @@ cars:
   type: pandas.CSVDataset
 ```
 
-In your pipeline code, when the `cars` dataset is used, it will use the overwritten catalog entry from `conf/local/catalog.yml` and rely on Kedro to detect which definition of `cars` dataset to use in your pipeline.
+In your pipeline code, when the `cars` dataset is used, it will use the overwritten catalog entry from `conf/local/catalog.yml`.

--- a/docs/catalog-data/data_catalog_yaml_examples.md
+++ b/docs/catalog-data/data_catalog_yaml_examples.md
@@ -306,7 +306,7 @@ The list of all available parameters is given in the [Paramiko documentation](ht
 
 ## Load multiple datasets with similar configuration using YAML anchors
 
-Different datasets might use the same file format, share the same load and save arguments, and be stored in the same folder. [YAML has a built-in syntax](https://yaml.org/spec/1.2.1/#Syntax) for factorising parts of a YAML file, which means that you can decide what is generalisable across your datasets, so that you need not spend time copying and pasting dataset configurations in the `catalog.yml` file.
+Different datasets might use the same file format, share the same load and save arguments, and be stored in the same folder. [YAML has a built-in syntax](https://yaml.org/spec/1.2.1/#Syntax) for factorising parts of a YAML file. This means you can decide what is generalisable across your datasets, so that you need not spend time copying and pasting dataset configurations in the `catalog.yml` file.
 
 You can see this in the following example:
 

--- a/docs/catalog-data/kedro_dataset_factories.md
+++ b/docs/catalog-data/kedro_dataset_factories.md
@@ -6,7 +6,7 @@ You can load multiple datasets with similar configuration using dataset factorie
     From version **`2.0.0`** of `kedro-datasets`, all dataset names have changed to replace the capital letter "S" in "DataSet" with a lower case "s". For example, `CSVDataSet` is now `CSVDataset`.
 
 
-The dataset factories introduce a syntax that allows you to generalise your configuration and reduce the number of similar catalog entries by matching datasets used in your project's pipelines to dataset factory patterns.
+Dataset factories introduce a syntax that lets you generalise your configuration and reduce the number of similar catalog entries. They match datasets used in your project's pipelines to dataset factory patterns.
 
 For example:
 ```yaml
@@ -109,7 +109,7 @@ Internal fallback behaviour provided by Kedro. These patterns are built into the
 
 By default, runtime patterns are not used when calling `catalog.get()` unless explicitly enabled using the `fallback_to_runtime_pattern=True` flag.
 
-**Case 1: Dataset pattern only**
+**Case 1: User-specified dataset pattern**
 
 ```yaml
 "{dataset_name}#csv":

--- a/docs/catalog-data/lazy_loading.md
+++ b/docs/catalog-data/lazy_loading.md
@@ -48,4 +48,4 @@ This lazy loading mechanism is useful before runtime, during the warm-up phase o
 - Validate external dependencies
 - Ensure all datasets can be created before execution begins
 
-Although `_LazyDataset` is not exposed to end users and doesn't affect your usual catalog usage, it is a useful concept to understand when debugging catalog behaviour or troubleshooting dataset instantiation issues.
+Although `_LazyDataset` is not exposed to end users and doesn't affect your usual catalog usage, it is a useful concept to understand. It helps when debugging catalog behaviour or troubleshooting dataset instantiation issues.

--- a/docs/catalog-data/partitioned_and_incremental_datasets.md
+++ b/docs/catalog-data/partitioned_and_incremental_datasets.md
@@ -87,7 +87,7 @@ The dataset definition should be passed into the `dataset` argument of the `Part
 
 #### Shorthand notation
 
-Specify the underlying dataset class either as a string (for example, `pandas.CSVDataset` or a fully qualified class path like `kedro_datasets.pandas.CSVDataset`) or as a class object that is a subclass of the [kedro.io.AbstractDataset][].
+Specify the underlying dataset class either as a string or as a class object. As a string, you can use a short name (for example, `pandas.CSVDataset`) or a fully qualified class path (such as `kedro_datasets.pandas.CSVDataset`). A class object must be a subclass of [kedro.io.AbstractDataset][].
 
 #### Full notation
 
@@ -102,7 +102,7 @@ Full notation allows you to specify a dictionary with the full underlying datase
 !!! note
     Support for `dataset_credentials` key in the credentials for `PartitionedDataset` is now deprecated. The dataset credentials should be specified explicitly inside the dataset config.
 
-Credentials management for `PartitionedDataset` is somewhat special, because it might contain credentials for both `PartitionedDataset` itself _and_ the underlying dataset that is used for partition load and save. Top-level credentials are passed to the underlying dataset config (unless such config already has credentials configured), but not the other way around - dataset credentials are never propagated to the filesystem.
+Credentials management for `PartitionedDataset` is somewhat special, because it might contain credentials for both `PartitionedDataset` itself _and_ the underlying dataset that is used for partition load and save. Top-level credentials are passed to the underlying dataset config, unless that config already has credentials configured. The reverse does not happen — dataset credentials are never propagated to the filesystem.
 
 Here is the full list of possible scenarios:
 
@@ -152,14 +152,14 @@ def concat_partitions(partitioned_input: Dict[str, Callable[[], Any]]) -> pd.Dat
 
 As you can see from the above example, on load `PartitionedDataset` _does not_ automatically load the data from the located partitions. Instead, `PartitionedDataset` returns a dictionary with partition IDs as keys and the corresponding load functions as values. This design lets the consuming node decide which partitions to load and how to process the data.
 
-Partition ID _does not_ represent the whole partition path, but only a part of it that is unique for a given partition _and_ filename suffix:
+Partition ID represents the part of the partition path that is unique for a given partition _and_ filename suffix, not the whole path:
 
 * Example 1: if `path=s3://my-bucket-name/folder` and partition is stored in `s3://my-bucket-name/folder/2019-12-04/data.csv`, then its Partition ID is `2019-12-04/data.csv`.
 
 
 * Example 2: if `path=s3://my-bucket-name/folder` and `filename_suffix=".csv"` and partition is stored in `s3://my-bucket-name/folder/2019-12-04/data.csv`, then its Partition ID is `2019-12-04/data`.
 
-`PartitionedDataset` caches the load operation, which means that if multiple nodes consume the same `PartitionedDataset`, they will all receive the same partition dictionary even if some new partitions were added to the folder after the first load has been completed. This behaviour guarantees consistent load operations between nodes and avoids race conditions. To reset the cache, call the `release()` method of the partitioned dataset object.
+`PartitionedDataset` caches the load operation. If multiple nodes consume the same `PartitionedDataset`, they will all receive the same partition dictionary, even when new partitions were added to the folder after the first load completed. This behaviour guarantees consistent load operations between nodes and avoids race conditions. To reset the cache, call the `release()` method of the partitioned dataset object.
 
 ### Partitioned dataset save
 
@@ -238,7 +238,7 @@ def create_partitions() -> Dict[str, Callable[[], Any]]:
 !!! note
     Lazy saving is enabled by default. When a `Callable` type is provided, the dataset is written _after_ the `after_node_run` hook finishes.
 
-In certain cases, it might be useful to disable lazy saving, such as when your object is already a `Callable` (for example, a TensorFlow model) and you prefer to write the data straight away.
+In certain cases, it might be useful to disable lazy saving. For example, when your object is already a `Callable` (such as a TensorFlow model) and you prefer to write the data straight away.
 To disable lazy saving, set the `save_lazily` parameter to `False`:
 
 ```yaml
@@ -276,7 +276,7 @@ The `IncrementalDataset` save operation is identical to the [save operation of t
 ### Incremental dataset confirm
 
 !!! note
-    The checkpoint value *is not* automatically updated when a new set of partitions is successfully loaded or saved.
+    The checkpoint value *is not* automatically updated when a new set of partitions is loaded or saved.
 
 Partitioned dataset checkpoint update is triggered by an explicit `confirms` instruction in one of the nodes downstream. It can be the same node, which processes the partitioned dataset:
 

--- a/docs/configure/advanced_configuration.md
+++ b/docs/configure/advanced_configuration.md
@@ -98,7 +98,7 @@ conf_loader["catalog"] = {"catalog_config": "something_new"}
 
 ### How to do templating with the `OmegaConfigLoader`
 #### Parameters
-Templating or [variable interpolation](https://omegaconf.readthedocs.io/en/2.3_branch/usage.html#variable-interpolation), as it's called in `OmegaConf`, for parameters works out of the box if the template values are within the parameter files or the name of the file that contains the template values follows the same config pattern specified for parameters.
+Templating, or [variable interpolation](https://omegaconf.readthedocs.io/en/2.3_branch/usage.html#variable-interpolation) as `OmegaConf` calls it, works out of the box for parameters. The template values must be within the parameter files, or the name of the file that contains them must follow the same config pattern specified for parameters.
 By default, the config pattern for parameters is: `["parameters*", "parameters*/**", "**/parameters*"]`.
 Suppose you have one parameters file called `parameters.yml` containing parameters with `omegaconf` placeholders like this:
 
@@ -117,7 +117,7 @@ data:
 Since both of the file names (`parameters.yml` and `parameters_variables.yml`) match the config pattern for parameters, the `OmegaConfigLoader` will load the files and resolve the placeholders as expected.
 
 #### Catalog
-From Kedro `0.18.10` templating also works for catalog files. To enable templating in the catalog you need to ensure that the template values are within the catalog files or the name of the file that contains the template values follows the same config pattern specified for catalogs.
+From Kedro `0.18.10` templating also works for catalog files. To enable it, ensure that the template values are within the catalog files. Or, the name of the file that contains them must follow the same config pattern specified for catalogs.
 By default, the config pattern for catalogs is: `["catalog*", "catalog*/**", "**/catalog*"]`.
 
 Any template values in the catalog need to start with an underscore `_`. This is because of how catalog entries are validated. Templated values will neither trigger a key duplication error nor appear in the resulting configuration dictionary.

--- a/docs/configure/configuration_basics.md
+++ b/docs/configure/configuration_basics.md
@@ -35,9 +35,9 @@ from omegaconf import OmegaConf
 parameters = OmegaConf.load("/path/to/parameters.yml")
 ```
 
-When your configuration files are complex and contain credentials or templating, Kedro's `OmegaConfigLoader` is more suitable, as described in more detail in [How to load a data catalog with credentials in code?](#how-to-load-a-data-catalog-with-credentials-in-code) and [How to load a data catalog with templating in code?](advanced_configuration.md#how-to-load-a-data-catalog-with-templating-in-code).
+When your configuration files are complex and contain credentials or templating, Kedro's `OmegaConfigLoader` is more suitable. For details, see [How to load a data catalog with credentials in code?](#how-to-load-a-data-catalog-with-credentials-in-code) and [How to load a data catalog with templating in code?](advanced_configuration.md#how-to-load-a-data-catalog-with-templating-in-code).
 
-In summary, while both `OmegaConf` and Kedro's `OmegaConfigLoader` provide ways to manage configurations, your choice depends on the complexity of your configuration and whether you are working within the context of the Kedro framework.
+In summary, both `OmegaConf` and Kedro's `OmegaConfigLoader` provide ways to manage configurations. Your choice depends on the complexity of your configuration and whether you are working within the context of the Kedro framework.
 
 ## Configuration source
 The configuration source folder is [`conf`](../getting-started/kedro_concepts.md#conf) by default. We recommend that you keep all configuration files in the default `conf` folder of a Kedro project.
@@ -144,7 +144,7 @@ How to reference a `zip` file:
 kedro run --conf-source=<path-to-compressed-file>.zip
 ```
 
-To compress your configuration you can use Kedro's `kedro package` command which builds the package into the `dist/` folder of your project, and creates a `.whl` file, as well as a `tar.gz` file containing the project configuration. The compressed version of the config files excludes any files inside your `local` folder.
+To compress your configuration you can use Kedro's `kedro package` command. This builds the package into the `dist/` folder of your project, and creates a `.whl` file, as well as a `tar.gz` file containing the project configuration. The compressed version of the config files excludes any files inside your `local` folder.
 
 You can also run the command below to create a `tar.gz` file:
 
@@ -228,7 +228,7 @@ s3://my-bucket/configs/
 ```
 
 !!! note
-    While Kedro supports reading configuration from compressed files (.tar.gz, .zip) and from cloud storage separately, it does not support reading compressed files directly from cloud storage (for example, s3://my-bucket/configs.tar.gz).
+    Kedro supports reading configuration from compressed files (.tar.gz, .zip) and from cloud storage separately. It does not support reading compressed files directly from cloud storage (for example, s3://my-bucket/configs.tar.gz).
 
 ### How to access configuration in code
 To directly access configuration in code, for example to debug, you can do so as follows:
@@ -249,7 +249,7 @@ conf_catalog = conf_loader["catalog"]
 !!! note
     We do not recommend that you load and manipulate a data catalog directly in a Kedro node. Nodes are designed to be pure functions and thus should remain agnostic of I/O.
 
-Assuming your project contains a catalog and credentials file, each located in `base` and `local` environments respectively, you can use the `OmegaConfigLoader` to load these configurations, and pass them to a `DataCatalog` object to access the catalog entries with resolved credentials.
+Assuming your project contains a catalog and credentials file, each located in `base` and `local` environments respectively, you can use the `OmegaConfigLoader` to load these configurations. Pass them to a `DataCatalog` object to access the catalog entries with resolved credentials.
 ```python
 from kedro.config import OmegaConfigLoader
 from kedro.framework.project import settings

--- a/docs/create/starters.md
+++ b/docs/create/starters.md
@@ -44,7 +44,7 @@ The Kedro team maintains the following starters for a range of Kedro projects:
 * [`databricks-iris`](https://github.com/kedro-org/kedro-starters/tree/main/databricks-iris): An example project using the [Iris dataset](https://www.kaggle.com/uciml/iris) with a setup for [Databricks](https://docs.kedro.org/en/stable/deploy/supported-platforms/databricks/) deployment.
 * [`spaceflights-pandas`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas): The [spaceflights tutorial](../tutorials/spaceflights_tutorial.md) example code with `pandas` datasets.
 * [`spaceflights-pyspark`](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pyspark): The [spaceflights tutorial](../tutorials/spaceflights_tutorial.md) example code with `pyspark` datasets.
-* [`support-agent-langgraph`](https://github.com/kedro-org/kedro-starters/tree/main/support-agent-langgraph): An example project demonstrating pipelines that leverage LangGraph for agentic workflows and Langfuse or Opik for prompt management and tracing.
+* [`support-agent-langgraph`](https://github.com/kedro-org/kedro-starters/tree/main/support-agent-langgraph): An example project demonstrating pipelines that use LangGraph for agentic workflows and Langfuse or Opik for prompt management and tracing.
 
 ### Archived starters
 

--- a/docs/deploy/distributed.md
+++ b/docs/deploy/distributed.md
@@ -1,7 +1,7 @@
 # Distributed deployment
 This topic explains how to deploy Kedro in a distributed system.
 
-Distributed applications refer to software that runs on multiple computers within a network at the same time and can be stored on servers or with cloud computing. Unlike traditional applications that run on a single machine, distributed applications run on multiple systems simultaneously for a single task or job.
+A distributed application is software that runs on multiple computers within a network at the same time. The software can be stored on servers or with cloud computing. Unlike traditional applications that run on a single machine, distributed applications run on multiple systems simultaneously for a single task or job.
 
 You may select a distributed system if your Kedro pipelines require significant compute so you can take advantage of the cloud's elasticity and scalability.
 
@@ -24,7 +24,7 @@ After you build the Docker image for your project locally, transfer the image to
 
 ## 2. Convert your Kedro pipeline into targeted platform primitives
 
-A Kedro pipeline benefits from a structure that is straightforward to translate (at least semantically) into the language that different platforms understand. A DAG of `nodes` can be converted into a series of tasks where each node maps to an individual task, whether it is a Kubeflow operator, an AWS Batch job, or another platform-specific primitive, and the dependencies match those mapped in `Pipeline.node_dependencies`.
+A Kedro pipeline benefits from a structure that is straightforward to translate (at least semantically) into the language that different platforms understand. A DAG of `nodes` can be converted into a series of tasks where each node maps to an individual task. The task could be a Kubeflow operator, an AWS Batch job, or another platform-specific primitive. The dependencies match those mapped in `Pipeline.node_dependencies`.
 
 To perform the conversion programmatically, you will need to develop a script. Make sure you save all your catalog entries to a remote location and that you make best use of node `names` as `tags` in your pipeline to simplify the process. For example, you should name all nodes, and use a programmer-friendly naming convention.
 

--- a/docs/deploy/nodes_grouping.md
+++ b/docs/deploy/nodes_grouping.md
@@ -105,6 +105,8 @@ This reduces the number of Airflow tasks and keeps logically related nodes toget
 
 **AWS Step Functions**: The [AWS Step Functions deployment guide](./supported-platforms/aws_step_functions.md) uses `Pipeline.group_nodes_by("namespace")` so each pipeline-level namespace maps to one Lambda function and one Step Functions task.
 
+**AWS Batch**: The [AWS Batch deployment guide](./supported-platforms/aws_batch.md) uses `Pipeline.group_nodes_by("namespace")` so each pipeline-level namespace maps to one Batch job.
+
 ---
 
 **Summary table**
@@ -114,4 +116,4 @@ This reduces the number of Airflow tasks and keeps logically related nodes toget
 | **What Works** | If you're happy with how the nodes are structured in your existing pipeline, or your pipeline is low complexity and a new grouping view is not required then you don't have to use any alternatives | Tagging individual nodes or the entire pipeline allows flexible execution of specific sections without altering the pipeline structure, and Kedro-Viz offers clear visualisation of these tagged nodes for better understanding. | Namespaces group nodes to ensure clear dependencies and separation within a pipeline, allow selective execution, and can be visualised using Kedro-Viz. |
 | **What Doesn't Work** | If you want to group nodes differently from the current pipeline structure, instead of creating a new pipeline, you can use alternative grouping methods such as tags or namespaces. | Lack of hierarchical structure, using tags makes debugging and maintaining the codebase more challenging | Defining namespaces at the node level behaves like tags without ensuring execution consistency, while defining them at the pipeline level helps create a modular structure by renaming inputs, outputs, and parameters but can introduce naming conflicts if the pipeline is connected elsewhere or parameters are referenced outside the pipeline. |
 | **Syntax** | `kedro run --pipelines=<your_pipeline_names>` | `kedro run --tags=<your_tag_name>` | `kedro run --namespaces=< namespace1,namespace2 >` |
-| **Deployment Plugin Support** | N/A | N/A | `kedro airflow create --group-by namespace`; [AWS Step Functions](./supported-platforms/aws_step_functions.md) |
+| **Deployment Plugin Support** | N/A | N/A | `kedro airflow create --group-by namespace`; [AWS Step Functions](./supported-platforms/aws_step_functions.md); [AWS Batch](./supported-platforms/aws_batch.md) |

--- a/docs/deploy/supported-platforms/airflow.md
+++ b/docs/deploy/supported-platforms/airflow.md
@@ -4,7 +4,7 @@ Apache Airflow is a popular open-source workflow management platform. It is a su
 
 ## Introduction and strategy
 
-The general strategy to deploy a Kedro pipeline on Apache Airflow is to run every Kedro node as an [Airflow task](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html) while the whole pipeline is converted to an [Airflow DAG](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html). This approach mirrors the principles of [running Kedro in a distributed environment](../distributed.md).
+The general strategy to deploy a Kedro pipeline on Apache Airflow is to run every Kedro node as an [Airflow task](https://airflow.apache.org/docs/apache-airflow/stable/concepts/tasks.html). The whole pipeline is converted to an [Airflow DAG](https://airflow.apache.org/docs/apache-airflow/stable/concepts/dags.html). This approach mirrors the principles of [running Kedro in a distributed environment](../distributed.md).
 
 Each node will be executed within a new Kedro session, which implies that `MemoryDatasets` cannot serve as storage for the intermediate results of nodes. Instead, all datasets must be registered in the [`DataCatalog`](https://docs.kedro.org/en/stable/catalog-data/data_catalog/) and stored in persistent storage. This approach enables nodes to access the results from preceding nodes.
 

--- a/docs/deploy/supported-platforms/amazon_emr_serverless.md
+++ b/docs/deploy/supported-platforms/amazon_emr_serverless.md
@@ -178,6 +178,9 @@ kedro run
 
 The PySpark starter does not include a local Spark runtime by default. Install `kedro-datasets[spark-local]` so `kedro run` works on your machine before you submit to EMR. For more detail, read [Get started with the PySpark starter](../../integrations-and-plugins/pyspark_integration.md#get-started-with-the-pyspark-starter).
 
+!!! note "Java required for local Spark"
+    Local runs with `kedro-datasets[spark-local]` need a **JDK** installed and **`JAVA_HOME` set** to that JDK. Check with `java -version` and `echo $JAVA_HOME`. If `kedro run` fails with `[JAVA_GATEWAY_EXITED]`, PySpark could not start the JVM — fix `JAVA_HOME`, ensure Java is on your `PATH`, and retry before you package for EMR.
+
 Keep `conf/base/catalog.yml` on **local file paths** for local development. You add S3 paths in a separate environment in [Step 3](#step-3-configure-kedro-for-emr). For release choice, pipeline grouping, and storage planning, see [Strategy](#strategy).
 
 ---

--- a/docs/deploy/supported-platforms/argo.md
+++ b/docs/deploy/supported-platforms/argo.md
@@ -1,7 +1,7 @@
 # Argo Workflows (outdated documentation that needs review)
 
 !!! warning
-    This page contains outdated documentation that has not been tested against recent Kedro releases. If you successfully use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
+    This page contains outdated documentation that has not been tested against recent Kedro releases. If you use Argo Workflows with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 
 This page explains how to convert your Kedro pipeline to use [Argo Workflows](https://github.com/argoproj/argo-workflows), an open-source container-native workflow engine for orchestrating parallel jobs on [Kubernetes](https://kubernetes.io/).
 

--- a/docs/deploy/supported-platforms/aws_batch.md
+++ b/docs/deploy/supported-platforms/aws_batch.md
@@ -4,7 +4,7 @@
     This page contains outdated documentation that has not been tested against recent Kedro releases. If you manage to use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
 
 ## Why use AWS Batch
-[AWS Batch](https://aws.amazon.com/batch/) is optimised for batch computing and applications that scale with the number of jobs running in parallel. It manages job execution and compute resources, and dynamically provisions the optimal quantity and type. AWS Batch can assist with planning, scheduling, and executing your batch computing workloads, using [Amazon EC2](https://aws.amazon.com/ec2/) On-Demand and [Spot Instances](https://aws.amazon.com/ec2/spot/), and it has native integration with [CloudWatch](https://aws.amazon.com/cloudwatch/) for log collection.
+[AWS Batch](https://aws.amazon.com/batch/) is optimised for batch computing and applications that scale with the number of jobs running in parallel. It manages job execution and compute resources, and dynamically provisions the optimal quantity and type. AWS Batch can assist with planning, scheduling, and executing your batch computing workloads. It uses [Amazon EC2](https://aws.amazon.com/ec2/) On-Demand and [Spot Instances](https://aws.amazon.com/ec2/spot/), and integrates natively with [CloudWatch](https://aws.amazon.com/cloudwatch/) for log collection.
 
 AWS Batch helps you run massively parallel Kedro pipelines in a cost-effective way. It also allows you to parallelise the pipeline execution across multiple compute instances. Each Batch job is run in an isolated Docker container environment.
 
@@ -86,7 +86,7 @@ If you store datasets in S3, create an IAM role so Batch can read and write to t
 
 #### Create AWS Batch job definition
 
-Job definitions specify the resources needed to run a job. Create a job definition named `kedro_run`, assign it the `batchJobRole` IAM role, select the container image you built earlier, set the execution timeout to 300 seconds, and allocate 2000 MB of memory. Leave `Command` blank and keep the defaults.
+Job definitions specify the resources needed to run a job. Create a job definition named `kedro_run`, assign it the `batchJobRole` IAM role, select the container image you built earlier, set the execution timeout to 300 seconds, and reserve 2000 MB of memory. Leave `Command` blank and keep the defaults.
 
 #### Create AWS Batch compute environment
 
@@ -216,7 +216,7 @@ class AWSBatchRunner(ThreadRunner):
 
 Next you will want to add the implementation of the `_submit_job()` method referenced in `_run()`. This method will create and submit jobs to AWS Batch with the following:
 
-* Correctly specified upstream dependencies
+* Accurate upstream dependencies
 * A unique job name
 * The corresponding command to run, namely `kedro run --nodes=<node_name>`.
 
@@ -284,7 +284,7 @@ def _track_batch_job(job_id: str, client: Any) -> None:
             return
 ```
 
-#### Set up Batch-related configuration
+#### Configure AWS Batch settings
 
 You'll need to set the Batch-related configuration that the runner will use. Add a `parameters.yml` file inside the `conf/aws_batch/` directory created as part of the prerequisites with the following keys:
 
@@ -347,4 +347,4 @@ kedro run --env=aws_batch --runner=kedro_tutorial.runner.AWSBatchRunner
 
 You should start seeing jobs appearing on your Jobs dashboard, under the `Runnable` tab - meaning they're ready to start as soon as the resources are provisioned in the compute environment.
 
-AWS Batch has native integration with CloudWatch, where you can check the logs for a particular job. You can either click on [the Batch job in the Jobs tab](https://console.aws.amazon.com/batch/home/jobs) and click `View logs` in the pop-up panel, or go to [CloudWatch dashboard](https://console.aws.amazon.com/cloudwatch), click `Log groups` in the side bar and find `/aws/batch/job`.
+AWS Batch has native integration with CloudWatch, where you can check the logs for a particular job. To find logs, click on [the Batch job in the Jobs tab](https://console.aws.amazon.com/batch/home/jobs) and choose `View logs` in the pop-up panel. Or, go to the [CloudWatch dashboard](https://console.aws.amazon.com/cloudwatch), click `Log groups` in the side bar, and find `/aws/batch/job`.

--- a/docs/deploy/supported-platforms/aws_batch.md
+++ b/docs/deploy/supported-platforms/aws_batch.md
@@ -1,120 +1,551 @@
-# AWS Batch (outdated documentation that needs review)
+# AWS Batch
 
-!!! warning
-    This page contains outdated documentation that has not been tested against recent Kedro releases. If you manage to use AWS Batch with a recent version of Kedro, consider telling us the steps you took on [Slack](https://slack.kedro.org) or [GitHub](https://github.com/kedro-org/kedro/issues).
+[AWS Batch](https://aws.amazon.com/batch/) runs containerised batch jobs at scale. Each job runs in an isolated Docker container. The sections below show how to deploy a Kedro project so each **pipeline-level namespace** runs as one Batch job, with datasets stored on Amazon S3.
 
-## Why use AWS Batch
-[AWS Batch](https://aws.amazon.com/batch/) is optimised for batch computing and applications that scale with the number of jobs running in parallel. It manages job execution and compute resources, and dynamically provisions the optimal quantity and type. AWS Batch can assist with planning, scheduling, and executing your batch computing workloads. It uses [Amazon EC2](https://aws.amazon.com/ec2/) On-Demand and [Spot Instances](https://aws.amazon.com/ec2/spot/), and integrates natively with [CloudWatch](https://aws.amazon.com/cloudwatch/) for log collection.
+AWS Batch fits Kedro pipelines that need **more time or memory than [AWS Lambda](https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html) allows**, but do not require **PySpark** or distributed Spark. For lightweight stages with managed orchestration, use [AWS Step Functions](aws_step_functions.md). For Spark workloads, use [Amazon EMR Serverless](amazon_emr_serverless.md).
 
-AWS Batch helps you run massively parallel Kedro pipelines in a cost-effective way. It also allows you to parallelise the pipeline execution across multiple compute instances. Each Batch job is run in an isolated Docker container environment.
+This guide targets Kedro 1.x (`kedro>=1.0`) and uses the [Spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas/) as a worked example. Read [the deployment strategy](#strategy) first if you are deploying your own Kedro project and need guidance on namespace grouping, S3 storage, the custom Batch runner, and job definition settings.
 
-The following sections are a guide on how to deploy a Kedro project to AWS Batch, and uses the [spaceflights tutorial](../../tutorials/spaceflights_tutorial.md) as primary example. The guide assumes that you have already completed the tutorial, and that the project was created with the project name **Kedro Tutorial**.
+## Strategy
 
-## Prerequisites
+Read this section before you deploy your own project. It starts with an overview of the approach, then gives practical advice for adapting it to your pipelines.
 
-To use AWS Batch, ensure you have the following prerequisites in place:
+#### Overview
 
-- An [AWS account set up](https://aws.amazon.com/premiumsupport/knowledge-center/create-and-activate-aws-account/).
-- A `name` attribute is set for each Kedro [Node][kedro.pipeline.node]. Each node will run in its own Batch job, so having sensible node names will make it easier to `kedro run --nodes=<node_name>`.
-- [All node input/output datasets must be configured in `catalog.yml`](../../catalog-data/data_catalog_yaml_examples.md) and point to an external location (for example, AWS S3). A clean way to do this is to create a new configuration environment `conf/aws_batch` containing a `catalog.yml` file with the appropriate configuration, as illustrated below.
+This guide deploys a Kedro pipeline on AWS Batch using a custom **`AWSBatchRunner`** on your local machine (or CI agent) and a shared container image on Amazon S3-backed storage.
 
-??? example "View code"
+The approach in brief:
+
+1. **Group nodes by pipeline-level namespace**. Each group becomes one Batch job. Inside the container, the job runs every node in that namespace with your packaged project CLI.
+2. **Store shared datasets on S3**. Batch containers are isolated, so datasets that cross namespace boundaries cannot use `MemoryDataset`.
+3. **Package the project into a container image** (wheel plus `conf/`). Every namespace group uses the same image.
+4. **Submit jobs from a custom runner**. `AWSBatchRunner` groups the pipeline with `Pipeline.group_nodes_by("namespace")`, submits one Batch job per group with `dependsOn` links, and polls until each job finishes.
+
+#### Why use a container image?
+
+A container image lets you package Kedro, project dependencies, and configuration into one artefact. You can build and test that artefact locally before pushing it to [Amazon Elastic Container Registry](https://docs.aws.amazon.com/AmazonECR/latest/userguide/what-is-ecr.html). Each Batch job overrides the container command to run one namespace group.
+
+<!-- vale off -->
+
+```mermaid
+flowchart LR
+  subgraph driver [Your machine]
+    Runner[AWSBatchRunner]
+  end
+  subgraph aws [AWS]
+    Q[Batch job queue]
+    J1[Job data_processing]
+    J2[Job data_science]
+    J3[Job reporting]
+    S3[(S3 bucket)]
+  end
+  Runner --> Q
+  Q --> J1
+  J1 --> S3
+  J1 --> J2
+  J1 --> J3
+  J2 --> S3
+  J3 --> S3
+```
+
+<!-- vale on -->
+
+For the Spaceflights starter, this pattern creates **three** Batch jobs (`data_processing`, `data_science`, and `reporting`) instead of one per node.
+
+Use **pipeline-level namespaces** (defined on the `Pipeline` object), not node-level namespaces. Node-level namespaces are for Kedro-Viz layout and do not group execution. See the section on [grouping nodes with namespaces in Kedro](../../build/namespaces.md#group-nodes-with-namespaces) for further explanation.
+
+#### Choose how to group nodes
+
+Namespace grouping suits most production pipelines where related nodes share dependencies and finish within Batch job timeout and memory limits.
+
+| Grouping | Pros | Cons | When to use |
+| --- | --- | --- | --- |
+| One Batch job per **namespace** (recommended) | Fewer jobs. Related nodes run together | Whole namespace must fit job timeout and memory | Most production Spaceflights-style pipelines |
+| One Batch job per **node** | Full isolation. Easy to debug a single node | More jobs, longer total runtime, more ECR pulls | Small pipelines or prototyping |
+| **Offload Spark stages** to EMR Serverless | Distributed Spark fits better | Extra infrastructure to set up and operate | PySpark pipelines or nodes that need Spark |
+
+!!! note "When a namespace exceeds Batch limits"
+    If a namespace outgrows your job definition timeout or memory, split it further or increase job definition resources.
+    Run Spark stages on [Amazon EMR Serverless](amazon_emr_serverless.md) instead of Batch.
+
+#### Plan execution order and storage
+
+`AWSBatchRunner` submits namespace groups when their upstream dependencies have finished. Groups with no upstream dependencies can run in parallel, up to `max_workers` in `conf/aws_batch/parameters.yml`. The runner uses the `dependencies` list on each `GroupedNodes` object from `Pipeline.group_nodes_by("namespace")`.
+
+For Spaceflights, `data_processing` runs first to produce intermediate datasets on S3. `data_science` and `reporting` can run in parallel at the next level because both depend on `data_processing` outputs (`model_input_table` and `preprocessed_shuttles`) but not on each other. The same dependency rules apply in [distributed Kedro runs](../distributed.md) and in [grouping nodes for deployment](../nodes_grouping.md).
+
+List **every dataset shared across namespace groups** in `conf/aws_batch/catalog.yml` on S3. Omitting a dataset causes `MemoryDataset` errors when Batch moves between jobs.
+
+#### Configure before you deploy
+
+- Assign **pipeline-level namespaces** with explicit `inputs` / `outputs` and `prefix_datasets_with_namespace=False`
+- Run each namespace locally (`kedro run --namespaces=<name>`) to estimate duration and memory, then set job definition **timeout** and **memory** for the heaviest namespace
+- Add **`s3fs`** and **`boto3`** when using S3-backed datasets and the Batch API from your driver machine
+- Trim **image dependencies** if the container grows too large for your compute environment
+
+!!! note "Deploying without pipeline-level namespaces"
+    If your project has no pipeline-level namespaces, `AWSBatchRunner` still works. `Pipeline.group_nodes_by("namespace")` treats each node without a namespace as its own group, so you get **one Batch job per node**. The runner passes `--nodes <node_name>` for those groups instead of `--namespaces <name>`.
+
+## Working example
+
+### Prerequisites
+
+These apply to the **step-by-step guide** below. This guide builds and deploys from your machine with Kedro, Docker, and the AWS CLI. You use the [AWS Management Console](https://aws.amazon.com/console/) to inspect the job queue and job runs after submission, but you cannot complete the guide with the console alone.
+
+| You need | Used for |
+| --- | --- |
+| A **Kedro project** (`requires-python = ">=3.10"` in `pyproject.toml`) and Python **>=3.10** locally | Packaging the project, local test runs, and running `AWSBatchRunner` on your driver machine |
+| [Docker](https://docs.docker.com/get-docker/) (Podman also works if you have a `docker`-compatible CLI) | Building the Batch container image |
+| [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) configured for your target region | Creating S3 and Batch resources, uploading data, pushing the image to ECR, and submitting jobs |
+| An AWS account with permissions for Batch, S3, ECR, IAM, and EC2 (for the Batch compute environment) | Creating and running the deployed resources |
+
+The steps that follow deploy the [Spaceflights starter](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas/) end to end. Create the project with:
+
+```bash
+kedro new -s spaceflights-pandas -n spaceflights_batch
+```
+
+If you are new to the project layout, [complete the Spaceflights tutorial](../../tutorials/spaceflights_tutorial.md). If you use your own Kedro project, replace the placeholders below and follow the same steps.
+
+### Placeholders used in this guide
+
+Replace these before building and submitting jobs:
+
+| Placeholder | Example |
+| --- | --- |
+| `<your-bucket>` | `kedro-batch-test-123456789012` |
+| `<your-aws-account-id>` | `123456789012` |
+| `<your-aws-region>` | `us-east-1` |
+| `<PACKAGE_NAME>` | `spaceflights_batch` |
+| `<PACKAGE_CLI>` | `spaceflights-batch` |
+| `<ecr-image-uri>` | `123456789012.dkr.ecr.us-east-1.amazonaws.com/spaceflights-batch:latest` |
+| `<batch-job-role-arn>` | IAM role ARN for Batch jobs (S3 access) |
+| `<batch-job-queue>` | `spaceflights_queue` |
+| `<batch-job-definition>` | `kedro_run` |
+
+### What you will do
+
+1. [Prepare your Kedro project](#step-1-prepare-your-kedro-project)
+2. [Set up AWS](#step-2-set-up-aws)
+3. [Configure Kedro for AWS Batch](#step-3-configure-kedro-for-aws-batch)
+4. [Create the custom AWS Batch runner](#step-4-create-the-custom-aws-batch-runner)
+5. [Customise the project CLI](#step-5-customise-the-project-cli)
+6. [Package, build, and push the container image](#step-6-package-build-and-push-the-container-image)
+7. [Submit the pipeline from your machine](#step-7-submit-the-pipeline-from-your-machine)
+8. [Verify the jobs succeeded](#step-8-verify-the-jobs-succeeded)
+
+---
+
+## Step 1: Prepare your Kedro project
+
+From the project root, install dependencies and run the pipeline locally:
+
+```bash
+pip install -e .
+kedro run
+```
+
+Keep `conf/base/catalog.yml` on **local file paths** for local development. You add S3 paths in [Step 3](#step-3-configure-kedro-for-aws-batch) after you create the bucket in [Step 2](#step-2-set-up-aws).
+
+Each node should have a meaningful `name` in its `Node(...)` definition. Batch job names and log streams use namespace or node names.
+
+### Assign pipeline-level namespaces
+
+This step is **recommended** for fewer Batch jobs and lower orchestration overhead. Read [the deployment strategy](#strategy) for grouping trade-offs and namespace requirements. If your pipeline has no pipeline-level namespaces, skip to [Step 2: Set up AWS](#step-2-set-up-aws).
+
+Assign a **pipeline-level namespace** to each sub-pipeline you want to run as one Batch job. In Spaceflights, update `create_pipeline()` in each module under `src/<PACKAGE_NAME>/pipelines/`:
+
+```python
+def create_pipeline(**kwargs) -> Pipeline:
+    return Pipeline(
+        [
+            # ... nodes unchanged ...
+        ],
+        namespace="data_processing",
+        prefix_datasets_with_namespace=False,
+        inputs={"companies", "shuttles", "reviews"},
+        outputs={"model_input_table"},
+    )
+```
+
+Set `prefix_datasets_with_namespace=False` so dataset names in `conf/base/catalog.yml` and `conf/aws_batch/catalog.yml` keep their original names. Declare explicit `inputs` and `outputs` for each namespace.
+
+| Sub-pipeline | `namespace` | `inputs` | `outputs` |
+| --- | --- | --- | --- |
+| `data_science` | `data_science` | `{"model_input_table"}` | `{"regressor", "X_train", "X_test", "y_train", "y_test"}` |
+| `reporting` | `reporting` | `{"preprocessed_shuttles"}` | `{"shuttle_passenger_capacity_plot_exp", "shuttle_passenger_capacity_plot_go", "dummy_confusion_matrix"}` |
+
+See the section on [grouping nodes with namespaces in Kedro using the full Spaceflights example](../../build/namespaces.md#group-nodes-with-namespaces) for further explanation.
+
+!!! note "Update `conf/base/catalog.yml` for reporting"
+    If the starter lists `matplotlib.MatplotlibWriter` for `dummy_confusion_matrix`, change it to `matplotlib.MatplotlibDataset` in **`conf/base/catalog.yml`** before running locally.
+
+Verify locally after adding namespaces:
+
+```bash
+kedro run --namespaces=data_processing
+kedro run
+```
+
+---
+
+## Step 2: Set up AWS
+
+Create the AWS resources your Kedro project will use before you point configuration at them. Complete this setup for each AWS account and region. Follow the linked AWS guides for console and CLI steps. This section lists what you need and Kedro-specific settings.
+
+| Resource | AWS documentation | What you need for Kedro |
+| --- | --- | --- |
+| **S3 bucket** | [Creating a bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/create-bucket-overview.html) | Raw data and pipeline outputs (`s3://<your-bucket>/...`) |
+| **ECR repository** | [Create a private repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/repository-create.html) | One **private** repo for the Batch container image (for example `spaceflights-batch`) |
+| **IAM job role** | [IAM roles for Batch](https://docs.aws.amazon.com/batch/latest/userguide/IAM_policies.html) | S3 read/write for datasets; attach to the job definition as `jobRoleArn` |
+| **Compute environment** | [Compute environments](https://docs.aws.amazon.com/batch/latest/userguide/compute_environments.html) | Managed EC2 environment (for example `spaceflights_env`) |
+| **Job queue** | [Job queues](https://docs.aws.amazon.com/batch/latest/userguide/job_queues.html) | Links jobs to the compute environment (for example `spaceflights_queue`) |
+| **Job definition** | [Job definitions](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html) | Points at `<ecr-image-uri>` after you push in Step 6; leave `command` empty (overridden per job) |
+
+!!! warning "Avoid overly broad IAM policies"
+    For production, scope the policy to your bucket ARN.
+
+### Upload raw data to S3
+
+Upload input data before you configure the catalog. Follow the AWS guide for [uploading objects to S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/upload-objects.html):
+
+```bash
+export AWS_REGION=<your-aws-region>
+export S3_BUCKET=<your-bucket>
+
+aws s3 mb "s3://${S3_BUCKET}" --region "${AWS_REGION}"
+aws s3 sync data/01_raw/ "s3://${S3_BUCKET}/01_raw/"
+```
+
+!!! note "`shuttles.xlsx` may be missing locally"
+    The starter gitignores `data/01_raw/shuttles.xlsx`. Copy it from the [Spaceflights starter repository on GitHub](https://github.com/kedro-org/kedro-starters/tree/main/spaceflights-pandas) if `kedro new` did not place it in your project.
+
+### Create the Amazon ECR repository
+
+Create the repository now. You push the image in [Step 6](#step-6-package-build-and-push-the-container-image):
+
+```bash
+aws ecr create-repository --repository-name spaceflights-batch --region <your-aws-region>
+```
+
+### Job definition settings (Kedro-specific)
+
+When creating the job definition (for example `kedro_run`), set:
+
+| Setting | Recommended value |
+| --- | --- |
+| **Image** | `<ecr-image-uri>` (after Step 6 push) |
+| **vCPUs** | `2` |
+| **Memory** | `4096` MiB (increase for heavy modelling nodes) |
+| **Job role** | `<batch-job-role-arn>` with S3 access |
+| **Timeout** | `3600` seconds or higher |
+| **Command** | leave empty (the runner overrides per job) |
+
+The compute environment does not launch instances until jobs are submitted, so creating it does not incur immediate cost.
+
+---
+
+## Step 3: Configure Kedro for AWS Batch
+
+### Create an `aws_batch` config environment
+
+Add `conf/aws_batch/` with `globals.yml`, `catalog.yml`, and `parameters.yml`. Set `s3_bucket` in `conf/aws_batch/globals.yml` to the same value as `S3_BUCKET` from Step 2. [Learn how to use catalog globals in Kedro configuration](../../configure/advanced_configuration.md#how-to-use-global-variables-with-the-omegaconfigloader).
+
+`conf/aws_batch/globals.yml`:
+
+```yaml
+s3_bucket: <your-bucket>
+```
+
+`conf/aws_batch/parameters.yml` (used by the custom runner in Step 5):
+
+```yaml
+aws_batch:
+  job_queue: <batch-job-queue>
+  job_definition: <batch-job-definition>
+  max_workers: 4
+  package_cli: <PACKAGE_CLI>
+  conf_source: /app/conf
+```
+
+!!! warning "Catalog environment merge is destructive"
+    By default, Kedro merges configuration environments at the **top level**. If `conf/aws_batch/catalog.yml` overrides a dataset using `filepath` alone, it **replaces** the entire dataset entry from `conf/base/` and drops keys such as `type`. Either include the full dataset definition (including `type`) in `conf/aws_batch/catalog.yml`, or set `merge_strategy: {catalog: soft}` in `settings.py` so environment files can override individual fields.
+
+!!! warning "Every shared dataset needs S3 storage"
+    The `aws_batch` catalog must list **every** dataset used by the deployed pipeline, including intermediate outputs such as `X_train` and reporting artefacts. Omitting a dataset causes `MemoryDataset` errors when Batch moves between jobs.
+
+### Add dependencies
+
+Add `s3fs` and `boto3` to `pyproject.toml`:
+
+```toml
+"s3fs>=2024.6.0",
+"boto3>=1.34.0",
+```
+
+The Spaceflights starter uses Parquet for intermediate tables. Use `matplotlib.MatplotlibDataset` (not the legacy `MatplotlibWriter` type).
+
+??? example "View `conf/aws_batch/catalog.yml`"
     ```yaml
     companies:
-    type: pandas.CSVDataset
-    filepath: s3://<your-bucket>/companies.csv
+      type: pandas.CSVDataset
+      filepath: s3://${globals:s3_bucket}/01_raw/companies.csv
 
     reviews:
-    type: pandas.CSVDataset
-    filepath: s3://<your-bucket>/reviews.csv
+      type: pandas.CSVDataset
+      filepath: s3://${globals:s3_bucket}/01_raw/reviews.csv
 
     shuttles:
-    type: pandas.ExcelDataset
-    filepath: s3://<your-bucket>/shuttles.xlsx
+      type: pandas.ExcelDataset
+      filepath: s3://${globals:s3_bucket}/01_raw/shuttles.xlsx
+      load_args:
+        engine: openpyxl
 
     preprocessed_companies:
-    type: pandas.CSVDataset
-    filepath: s3://<your-bucket>/preprocessed_companies.csv
+      type: pandas.ParquetDataset
+      filepath: s3://${globals:s3_bucket}/02_intermediate/preprocessed_companies.parquet
 
     preprocessed_shuttles:
-    type: pandas.CSVDataset
-    filepath: s3://<your-bucket>/preprocessed_shuttles.csv
+      type: pandas.ParquetDataset
+      filepath: s3://${globals:s3_bucket}/02_intermediate/preprocessed_shuttles.parquet
 
     model_input_table:
-    type: pandas.CSVDataset
-    filepath: s3://<your-bucket>/model_input_table.csv
-
-    regressor:
-    type: pickle.PickleDataset
-    filepath: s3://<your-bucket>/regressor.pickle
-    versioned: true
+      type: pandas.ParquetDataset
+      filepath: s3://${globals:s3_bucket}/03_primary/model_input_table.parquet
 
     X_train:
-    type: pickle.PickleDataset
-    filepath: s3://<your-bucket>/X_train.pickle
+      type: pickle.PickleDataset
+      filepath: s3://${globals:s3_bucket}/04_feature/X_train.pickle
 
     X_test:
-    type: pickle.PickleDataset
-    filepath: s3://<your-bucket>/X_test.pickle
+      type: pickle.PickleDataset
+      filepath: s3://${globals:s3_bucket}/04_feature/X_test.pickle
 
     y_train:
-    type: pickle.PickleDataset
-    filepath: s3://<your-bucket>/y_train.pickle
+      type: pickle.PickleDataset
+      filepath: s3://${globals:s3_bucket}/04_feature/y_train.pickle
 
     y_test:
-    type: pickle.PickleDataset
-    filepath: s3://<your-bucket>/y_test.pickle
+      type: pickle.PickleDataset
+      filepath: s3://${globals:s3_bucket}/04_feature/y_test.pickle
+
+    regressor:
+      type: pickle.PickleDataset
+      filepath: s3://${globals:s3_bucket}/06_models/regressor.pickle
+      versioned: true
+
+    shuttle_passenger_capacity_plot_exp:
+      type: plotly.PlotlyDataset
+      filepath: s3://${globals:s3_bucket}/08_reporting/shuttle_passenger_capacity_plot_exp.json
+      versioned: true
+      plotly_args:
+        type: bar
+        fig:
+          x: shuttle_type
+          y: passenger_capacity
+          orientation: h
+        layout:
+          xaxis_title: Shuttles
+          yaxis_title: Average passenger capacity
+          title: Shuttle Passenger capacity
+
+    shuttle_passenger_capacity_plot_go:
+      type: plotly.JSONDataset
+      filepath: s3://${globals:s3_bucket}/08_reporting/shuttle_passenger_capacity_plot_go.json
+      versioned: true
+
+    dummy_confusion_matrix:
+      type: matplotlib.MatplotlibDataset
+      filepath: s3://${globals:s3_bucket}/08_reporting/dummy_confusion_matrix.png
+      versioned: true
     ```
 
-## Run a Kedro pipeline with  AWS Batch
+### Verify the AWS Batch environment locally
 
-### Containerise your Kedro project
+```bash
+kedro run --env aws_batch
+```
 
-Containerise your Kedro project with a preferred container solution (for example, [Docker](https://www.docker.com/)) to build an image for AWS Batch.
+Confirm outputs appear under your S3 bucket paths.
 
-This walk-through assumes a Docker workflow. Use the [Kedro-Docker plugin](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-docker) to streamline the build. [Instructions are in the plugin README](https://github.com/kedro-org/kedro-plugins/blob/main/README.md).
+---
 
-After you build the Docker image locally, [transfer the image to a container registry](../single_machine.md#how-to-use-container-registry), such as [AWS ECR](https://aws.amazon.com/ecr/). You can follow Amazon's [ECR documentation](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html) or open the repository in the [ECR dashboard](https://console.aws.amazon.com/ecr) and click `View push commands` for tailored steps.
+## Step 4: Create the custom AWS Batch runner
 
-### Provision resources
+Create `src/<PACKAGE_NAME>/runner/batch_runner.py` with an `AWSBatchRunner` class that extends `AbstractRunner` and submits Batch jobs for each namespace group (or each node when no namespace is defined).
 
-Provision the following resources before deploying your pipeline to AWS Batch:
+??? example "View `batch_runner.py`"
+    ```python
+    """``AWSBatchRunner`` submits Kedro namespace groups as AWS Batch jobs."""
 
-#### Create the IAM role
+    from __future__ import annotations
 
-If you store datasets in S3, create an IAM role so Batch can read and write to the relevant locations. Follow the AWS tutorial on [creating a fetch and run job](https://aws.amazon.com/blogs/compute/creating-a-simple-fetch-and-run-aws-batch-job/) and set the policy in step 3 to `AmazonS3FullAccess`. Name the role `batchJobRole`.
+    from concurrent.futures import ThreadPoolExecutor
+    from time import sleep
+    from typing import Any
 
-#### Create AWS Batch job definition
+    import boto3
+    from pluggy import PluginManager
 
-Job definitions specify the resources needed to run a job. Create a job definition named `kedro_run`, assign it the `batchJobRole` IAM role, select the container image you built earlier, set the execution timeout to 300 seconds, and reserve 2000 MB of memory. Leave `Command` blank and keep the defaults.
+    from kedro.io import CatalogProtocol
+    from kedro.pipeline import Pipeline
+    from kedro.pipeline.node import GroupedNodes
+    from kedro.runner import AbstractRunner
 
-#### Create AWS Batch compute environment
 
-Create a managed, on-demand compute environment named `spaceflights_env`. Let AWS create service and instance roles if none exist. A managed environment lets AWS scale instances automatically.
+    def _track_batch_job(job_id: str, client: Any) -> None:
+        """Poll Batch until the job succeeds or raises on failure."""
+        while True:
+            sleep(1.0)
+            jobs = client.describe_jobs(jobs=[job_id])["jobs"]
+            if not jobs:
+                raise ValueError(f"Job ID {job_id} not found.")
 
-!!! note
-    The compute environment does not contain instances until you trigger the pipeline run, so creating it does not incur immediate cost.
+            job = jobs[0]
+            status = job["status"]
 
-#### Create AWS Batch job queue
+            if status == "FAILED":
+                reason = job.get("statusReason", "unknown")
+                raise RuntimeError(f"Job {job_id} failed: {reason}")
 
-A job queue is the bridge between the submitted jobs and the compute environment they should run on. Create a queue named `spaceflights_queue`, connected to your newly created compute environment `spaceflights_env`, and give it `Priority` 1.
+            if status == "SUCCEEDED":
+                return
 
-### Configure the credentials
 
-Ensure you have AWS credentials configured so the pipeline can access the relevant services. See the [AWS CLI documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html) for setup instructions.
+    class AWSBatchRunner(AbstractRunner):
+        """Submit Kedro namespace groups to AWS Batch with dependency ordering."""
 
-!!! note
-    Configure the default region to match the region where you created the Batch resources.
+        def __init__(
+            self,
+            job_queue: str,
+            job_definition: str,
+            max_workers: int | None = None,
+            package_cli: str | None = None,
+            conf_source: str | None = None,
+            is_async: bool = False,
+        ):
+            super().__init__(is_async=is_async)
+            self._job_queue = job_queue
+            self._job_definition = job_definition
+            self._max_workers = max_workers
+            self._package_cli = package_cli or "kedro"
+            self._conf_source = conf_source
+            self._client = boto3.client("batch")
 
-### Submit AWS Batch jobs
+        def _get_required_workers_count(self, groups: list[GroupedNodes]) -> int:
+            required = len(groups)
+            if self._max_workers is not None:
+                return min(required, self._max_workers)
+            return required
 
-With the resources in place, submit jobs to Batch programmatically by using the job definition and queue. Each job runs one node. To keep the correct execution order, specify the dependencies (job IDs) of each submitted job. You can use a custom runner for this step.
+        def _get_executor(self, max_workers: int):
+            return ThreadPoolExecutor(max_workers=max_workers)
 
-#### Create a custom runner
+        def _run(
+            self,
+            pipeline: Pipeline,
+            catalog: CatalogProtocol,
+            hook_manager: PluginManager | None = None,
+            run_id: str | None = None,
+        ) -> None:
+            groups = pipeline.group_nodes_by("namespace")
+            group_map = {group.name: group for group in groups}
+            group_deps = {group.name: set(group.dependencies) for group in groups}
 
-Create a new Python package `runner` in your `src` folder (for example, `kedro_tutorial/src/kedro_tutorial/runner/`). Make sure there is an `__init__.py` file at this location, and add another file named `batch_runner.py`, which will contain the implementation of your custom runner, `AWSBatchRunner`. The `AWSBatchRunner` will submit and track jobs asynchronously, surfacing any errors that occur on Batch.
+            todo_groups = set(group_map.keys())
+            group_to_job: dict[str, str] = {}
+            done_groups: set[str] = set()
+            futures: set = set()
+            max_workers = self._get_required_workers_count(groups)
 
-Make sure the `__init__.py` file in the `runner` folder includes the following import and declaration:
+            self._logger.info("Max workers: %d", max_workers)
+            with ThreadPoolExecutor(max_workers=max_workers) as pool:
+                while True:
+                    done = {fut for fut in futures if fut.done()}
+                    futures -= done
+                    for future in done:
+                        try:
+                            group_name = future.result()
+                        except Exception:
+                            self._suggest_resume_scenario(
+                                pipeline, set(), catalog
+                            )
+                            raise
+                        done_groups.add(group_name)
+                        self._logger.info(
+                            "Completed %d out of %d jobs",
+                            len(done_groups),
+                            len(groups),
+                        )
+
+                    ready = {
+                        name
+                        for name in todo_groups
+                        if group_deps[name] <= done_groups
+                    }
+                    todo_groups -= ready
+                    for name in ready:
+                        future = pool.submit(
+                            self._submit_job,
+                            group_map[name],
+                            group_to_job,
+                            group_deps[name],
+                            run_id,
+                        )
+                        futures.add(future)
+
+                    if not futures:
+                        if todo_groups:
+                            raise RuntimeError(
+                                f"Unresolved groups: {sorted(todo_groups)}"
+                            )
+                        break
+
+        def _submit_job(
+            self,
+            group: GroupedNodes,
+            group_to_job: dict[str, str],
+            group_dependencies: set[str],
+            run_id: str | None,
+        ) -> str:
+            self._logger.info("Submitting the job for group: %s", group.name)
+
+            run_suffix = run_id or "local"
+            job_name = f"kedro-{run_suffix}-{group.name}".replace(".", "-")[:128]
+            depends_on = [
+                {"jobId": group_to_job[dep]}
+                for dep in group_dependencies
+                if dep in group_to_job
+            ]
+
+            command = [
+                self._package_cli,
+                "run",
+                "--env",
+                "aws_batch",
+            ]
+            if group.type == "namespace":
+                command.extend(["--namespaces", group.name])
+            else:
+                command.extend(["--nodes", group.nodes[0]])
+            if self._conf_source:
+                command.extend(["--conf-source", self._conf_source])
+
+            response = self._client.submit_job(
+                jobName=job_name,
+                jobQueue=self._job_queue,
+                jobDefinition=self._job_definition,
+                dependsOn=depends_on,
+                containerOverrides={"command": command},
+            )
+
+            job_id = response["jobId"]
+            group_to_job[group.name] = job_id
+            _track_batch_job(job_id, self._client)
+            return group.name
+    ```
+
+Export the runner from `src/<PACKAGE_NAME>/runner/__init__.py`:
 
 ```python
 from .batch_runner import AWSBatchRunner
@@ -122,229 +553,199 @@ from .batch_runner import AWSBatchRunner
 __all__ = ["AWSBatchRunner"]
 ```
 
-Copy the contents of the script below into `batch_runner.py`:
+---
+
+## Step 5: Customise the project CLI
+
+Add the custom runner and CLI on your driver machine before you build the container image. Push the image in Step 6 and update the job definition **Image** field before you submit jobs in Step 7.
+
+Kedro's built-in `kedro run` passes `is_async` to the runner constructor and nothing else. `AWSBatchRunner` needs `job_queue`, `job_definition`, and other settings from `conf/aws_batch/parameters.yml`.
+
+Add `src/<PACKAGE_NAME>/cli.py` using [the project CLI template](../../getting-started/commands_reference.md#customise-or-override-project-specific-kedro-commands). Override the `run` command so the runner is constructed with Batch parameters from the active Kedro session:
 
 ```python
-from concurrent.futures import ThreadPoolExecutor
-from time import sleep
-from typing import Any, Dict, Set
-
-import boto3
-
-from kedro.io import DataCatalog
-from kedro.pipeline.pipeline import Pipeline, Node
-from kedro.runner import ThreadRunner
-
-
-class AWSBatchRunner(ThreadRunner):
-    def __init__(
-        self,
-        max_workers: int = None,
-        job_queue: str = None,
-        job_definition: str = None,
-        is_async: bool = False,
-    ):
-        super().__init__(max_workers, is_async=is_async)
-        self._job_queue = job_queue
-        self._job_definition = job_definition
-        self._client = boto3.client("batch")
-
-    def create_default_dataset(self, ds_name: str):
-        raise NotImplementedError("All datasets must be defined in the catalog")
-
-    def _get_required_workers_count(self, pipeline: Pipeline):
-        if self._max_workers is not None:
-            return self._max_workers
-
-        return super()._get_required_workers_count(pipeline)
-
-    def _run(
-        self,
-        pipeline: Pipeline,
-        catalog: DataCatalog,
-        hook_manager: PluginManager,
-        run_id: str = None,
-    ) -> None:
-        nodes = pipeline.nodes
-        node_dependencies = pipeline.node_dependencies
-        todo_nodes = set(node_dependencies.keys())
-        node_to_job = dict()
-        done_nodes = set()  # type: Set[Node]
-        futures = set()
-        max_workers = self._get_required_workers_count(pipeline)
-
-        self._logger.info("Max workers: %d", max_workers)
-        with ThreadPoolExecutor(max_workers=max_workers) as pool:
-            while True:
-                # Process the nodes that have completed, meaning jobs that reached
-                # FAILED or SUCCEEDED state
-                done = {fut for fut in futures if fut.done()}
-                futures -= done
-                for future in done:
-                    try:
-                        node = future.result()
-                    except Exception:
-                        self._suggest_resume_scenario(pipeline, done_nodes)
-                        raise
-                    done_nodes.add(node)
-                    self._logger.info(
-                        "Completed %d out of %d jobs", len(done_nodes), len(nodes)
-                    )
-
-                # A node is ready to be run if all its upstream dependencies have been
-                # submitted to Batch, meaning all node dependencies were assigned a job ID
-                ready = {
-                    n for n in todo_nodes if node_dependencies[n] <= node_to_job.keys()
-                }
-                todo_nodes -= ready
-                # Asynchronously submit Batch jobs
-                for node in ready:
-                    future = pool.submit(
-                        self._submit_job,
-                        node,
-                        node_to_job,
-                        node_dependencies[node],
-                        run_id,
-                    )
-                    futures.add(future)
-
-                # If no more nodes left to run, ensure the entire pipeline was run
-                if not futures:
-                    assert not todo_nodes, (todo_nodes, done_nodes, ready, done)
-                    break
-```
-
-Next you will want to add the implementation of the `_submit_job()` method referenced in `_run()`. This method will create and submit jobs to AWS Batch with the following:
-
-* Accurate upstream dependencies
-* A unique job name
-* The corresponding command to run, namely `kedro run --nodes=<node_name>`.
-
-Once submitted, the method tracks progress and surfaces any errors if the jobs end in `FAILED` state.
-
-Make sure the contents below are placed inside the `AWSBatchRunner` class:
-
-```python
-def _submit_job(
-    self,
-    node: Node,
-    node_to_job: Dict[Node, str],
-    node_dependencies: Set[Node],
-    run_id: str,
-) -> Node:
-    self._logger.info("Submitting the job for node: %s", str(node))
-
-    job_name = f"kedro_{run_id}_{node.name}".replace(".", "-")
-    depends_on = [{"jobId": node_to_job[dep]} for dep in node_dependencies]
-    command = ["kedro", "run", "--nodes", node.name]
-
-    response = self._client.submit_job(
-        jobName=job_name,
-        jobQueue=self._job_queue,
-        jobDefinition=self._job_definition,
-        dependsOn=depends_on,
-        containerOverrides={"command": command},
-    )
-
-    job_id = response["jobId"]
-    node_to_job[node] = job_id
-
-    _track_batch_job(job_id, self._client)  # make sure the job finishes
-
-    return node
-```
-
-The last part of the implementation is the helper function `_track_batch_job()`, called from `_submit_job()`, which looks like this:
-
-```python
-def _track_batch_job(job_id: str, client: Any) -> None:
-    """Continuously poll the Batch client for a job's status,
-    given the job ID. If it ends in FAILED state, raise an exception
-    and log the reason. Return if successful.
-    """
-    while True:
-        # we don't want to bombard AWS with the requests
-        # to not get throttled
-        sleep(1.0)
-
-        jobs = client.describe_jobs(jobs=[job_id])["jobs"]
-        if not jobs:
-            raise ValueError(f"Job ID {job_id} not found.")
-
-        job = jobs[0]
-        status = job["status"]
-
-        if status == "FAILED":
-            reason = job["statusReason"]
-            raise Exception(
-                f"Job {job_id} has failed with the following reason: {reason}"
-            )
-
-        if status == "SUCCEEDED":
-            return
-```
-
-#### Configure AWS Batch settings
-
-You'll need to set the Batch-related configuration that the runner will use. Add a `parameters.yml` file inside the `conf/aws_batch/` directory created as part of the prerequisites with the following keys:
-
-```yaml
-aws_batch:
-  job_queue: "spaceflights_queue"
-  job_definition: "kedro_run"
-  max_workers: 2
-```
-
-#### Update CLI implementation
-
-You're nearly there! Before you can use the new runner, add a `cli.py` file at the same level as `settings.py`, using [the template we provide](../../getting-started/commands_reference.md#customise-or-override-project-specific-kedro-commands). Update the `run()` function in the new `cli.py` file so that the runner class is instantiated with the right configuration:
-
-```python
-def run(tag, env, ...):
-    """Run the pipeline."""
-    runner = runner or "SequentialRunner"
-
-    tag = _get_values_as_tuple(tag) if tag else tag
-    node_names = _get_values_as_tuple(node_names) if node_names else node_names
-
-    with KedroSession.create(env=env, extra_params=params) as session:
-        context = session.load_context()
-        runner_instance = _instantiate_runner(runner, is_async, context)
-        session.run(
-            tags=tag,
-            runner=runner_instance,
-            node_names=node_names,
-            from_nodes=from_nodes,
-            to_nodes=to_nodes,
-            from_inputs=from_inputs,
-            to_outputs=to_outputs,
-            load_versions=load_version,
-            pipeline_name=pipeline,
-        )
-```
-
-where the helper function `_instantiate_runner()` looks like this:
-
-```python
-def _instantiate_runner(runner, is_async, project_context):
-    runner_class = load_obj(runner, "kedro.runner")
-    runner_kwargs = dict(is_async=is_async)
-
-    if runner.endswith("AWSBatchRunner"):
-        batch_kwargs = project_context.params.get("aws_batch") or {}
+def _instantiate_runner(runner: str | None, is_async: bool, params: dict[str, Any]):
+    runner_class = load_obj(runner or "SequentialRunner", "kedro.runner")
+    runner_kwargs: dict[str, Any] = {"is_async": is_async}
+    if runner and runner.endswith("AWSBatchRunner"):
+        batch_kwargs = params.get("aws_batch") or {}
         runner_kwargs.update(batch_kwargs)
-
     return runner_class(**runner_kwargs)
 ```
 
-### Deploy
+Inside `run()`, create the session, load the context, build the runner from `context.params`, and pass it to `session.run()`. When `runner` is omitted (for example inside a Batch container job), Kedro defaults to `SequentialRunner` and does not pass Batch driver settings to the constructor:
 
-You're now ready to trigger the run. Execute the following command:
-
-```bash
-kedro run --env=aws_batch --runner=kedro_tutorial.runner.AWSBatchRunner
+```python
+with KedroSession.create(
+    env=env, conf_source=conf_source, runtime_params=params
+) as session:
+    context = session.load_context()
+    runner_instance = _instantiate_runner(runner, is_async, dict(context.params))
+    return session.run(
+        runner=runner_instance,
+        # ... other run arguments ...
+    )
 ```
 
-You should start seeing jobs appearing on your Jobs dashboard, under the `Runnable` tab - meaning they're ready to start as soon as the resources are provisioned in the compute environment.
+[Learn how to customise Kedro commands in common use cases](../../extend/common_use_cases.md).
 
-AWS Batch has native integration with CloudWatch, where you can check the logs for a particular job. To find logs, click on [the Batch job in the Jobs tab](https://console.aws.amazon.com/batch/home/jobs) and choose `View logs` in the pop-up panel. Or, go to the [CloudWatch dashboard](https://console.aws.amazon.com/cloudwatch), click `Log groups` in the side bar, and find `/aws/batch/job`.
+---
+
+## Step 6: Package, build, and push the container image
+
+Package the project, then build and push the Batch image. Repeat this step when you change pipeline code, dependencies, or `conf/aws_batch/`.
+
+Run this in your project root:
+
+```bash
+kedro package
+```
+
+This creates a `.whl` in `dist/`. [Learn how to package a Kedro project](../package_a_project.md#package-a-kedro-project).
+
+Create a `Dockerfile` in your project root:
+
+```dockerfile
+FROM python:3.12-slim
+
+WORKDIR /app
+
+COPY dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/*.whl && rm -f /tmp/*.whl
+
+COPY conf/ /app/conf/
+```
+
+!!! tip "Apple Silicon (ARM) builders"
+    Batch on EC2 compute environments uses **`x86_64`** instances. Build with `--platform linux/amd64` (Docker or Podman).
+
+Build the image. Tag it with your ECR URI at build time:
+
+```bash
+export ECR_IMAGE=<ecr-image-uri>
+
+docker build --platform linux/amd64 -t ${ECR_IMAGE} .
+```
+
+If you build with a local tag first, run `docker tag spaceflights-batch:latest <ecr-image-uri>` right before pushing.
+
+### How config reaches the job
+
+Now that you have built the image, here is how your Step 3 configuration reaches each Batch container at runtime:
+
+1. **The wheel carries pipeline code.** `kedro package` bundles your pipeline code and dependencies into a `.whl` file. It does not include `conf/`.
+2. **The Dockerfile carries `conf/`.** `COPY conf/` places your `conf/aws_batch/` settings at `/app/conf` inside the container.
+3. **The Batch job command selects the environment.** [AWSBatchRunner](#step-4-create-the-custom-aws-batch-runner) passes `--env aws_batch --conf-source /app/conf --namespaces <name>` (or `--nodes <name>` for nodes without a namespace) through `containerOverrides`.
+
+### Push the image to Amazon ECR
+
+Follow the AWS guide for [pushing a Docker image to an Amazon ECR repository](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html):
+
+```bash
+aws ecr get-login-password --region <your-aws-region> | \
+  docker login --username AWS --password-stdin <your-aws-account-id>.dkr.ecr.<your-aws-region>.amazonaws.com
+docker push ${ECR_IMAGE}
+```
+
+!!! note "Trim dependencies for production images"
+    The Spaceflights starter includes Jupyter and Kedro-Viz, which increase image size. For production Batch images, consider a slimmer `requirements` subset or a multi-stage Dockerfile that omits development dependencies.
+
+!!! note "Re-push after catalog or pipeline changes"
+    When you change `conf/aws_batch/` or rebuild the wheel, repeat Step 6 and push a new image tag. Update the job definition **Image** field to `<ecr-image-uri>` if you created the definition before pushing.
+
+---
+
+## Step 7: Submit the pipeline from your machine
+
+Complete Step 6 first so your job definition points at the image in ECR.
+
+From your project root (with AWS credentials configured), use your packaged project CLI and the custom runner:
+
+```bash
+spaceflights-batch run \
+  --env aws_batch \
+  --runner spaceflights_batch.runner.AWSBatchRunner
+```
+
+The `AWSBatchRunner` on your machine submits Batch jobs. Each job runs inside the container image and executes one namespace group (or a single node when no namespace is defined). For Spaceflights `__default__`, expect **three** jobs.
+
+Track jobs in the [AWS Batch console](https://console.aws.amazon.com/batch/) or with:
+
+```bash
+aws batch list-jobs --job-queue <batch-job-queue> --job-status RUNNING
+```
+
+Logs are available in [CloudWatch Logs](https://docs.aws.amazon.com/batch/latest/userguide/monitoring.html) under `/aws/batch/job`.
+
+---
+
+## Step 8: Verify the jobs succeeded
+
+1. **Check Batch job states.** All jobs should reach **SUCCEEDED**. [Learn how to check AWS Batch job status](https://docs.aws.amazon.com/batch/latest/userguide/monitoring.html):
+
+```bash
+aws batch list-jobs --job-queue <batch-job-queue> --job-status SUCCEEDED
+```
+
+2. **Check S3 outputs.** List paths from your `conf/aws_batch/catalog.yml`. [Learn how to list objects in Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingObjects.html):
+
+```bash
+aws s3 ls "s3://<your-bucket>/" --recursive
+```
+
+You should see objects under `02_intermediate/`, `03_primary/`, `04_feature/`, `06_models/`, and `08_reporting/`.
+
+If jobs failed, see [Troubleshooting](#troubleshooting).
+
+---
+
+## Troubleshooting
+
+<!-- vale off -->
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| `Cannot install ... s3fs` dependency conflict | `kedro-viz` pins an older `s3fs` range | Use `s3fs>=2021.4` locally; omit Kedro-Viz from the Batch image for production |
+| `AccessDenied` on S3 inside Batch jobs | Job role lacks bucket permissions | Attach an IAM policy scoped to `<your-bucket>` on the job role |
+| `MemoryDataset` errors between jobs | Dataset missing from `conf/aws_batch/catalog.yml` | Add S3-backed entries for all shared datasets |
+| Batch job times out mid-namespace | Namespace contains too much work for one job timeout | Split namespaces further, or increase job definition timeout/memory, or run heavy stages on [Amazon EMR Serverless](amazon_emr_serverless.md) |
+| `Dataset 'MatplotlibWriter' not found` | Outdated dataset type in `conf/base/catalog.yml` | Use `matplotlib.MatplotlibDataset` in base and aws_batch catalogs |
+| S3 errors during `kedro run --env aws_batch` locally | Missing AWS CRT support in `botocore` | Run `pip install 'botocore[crt]'` and retry |
+| Jobs stuck in `RUNNABLE` | Compute environment not scaled or no capacity | Check compute environment status; increase `maxvCpus` or instance types |
+| `Essential container exited` immediately | Wrong `--conf-source` or missing `conf/` in image | Verify `COPY conf/ /app/conf/` in the Dockerfile and `conf_source: /app/conf` in parameters |
+| `ModuleNotFoundError` for runner kwargs | Built-in `kedro run` used instead of custom `cli.py` | Use `<PACKAGE_CLI> run` after adding the customised `cli.py` from Step 5 |
+| Job fails with out-of-memory | Default memory too low for sklearn/matplotlib nodes | Increase memory in the job definition (for example `4096` or `8192` MiB) |
+
+<!-- vale on -->
+
+---
+
+## Limitations
+
+- Each Batch job runs **one namespace group** (or one node when no namespace is defined). A namespace must finish within the job definition timeout and memory limits.
+- **Not for Spark:** This pattern is for non-distributed Python stages. Run PySpark workloads on [Amazon EMR Serverless](amazon_emr_serverless.md) instead.
+- **Driver machine:** The machine where you run `AWSBatchRunner` must stay online until all jobs complete. For managed orchestration of lightweight stages, consider [AWS Step Functions](aws_step_functions.md).
+- **Image lifecycle:** When you change pipeline code, dependencies, or `conf/aws_batch/`, repeat [Step 6](#step-6-package-build-and-push-the-container-image), push to ECR, and update the job definition image URI before the next run.
+- Pipelines with dozens of nodes without namespaces increase Batch job count and ECR pulls. Add pipeline-level namespaces for coarser grouping.
+- Batch job dependencies use AWS Batch `dependsOn`. This matches Kedro's DAG but does not replace Kedro's own `ThreadRunner` parallelism on a single machine.
+
+---
+
+## Further reading
+
+### Kedro
+
+- [Learn how to run Kedro in a distributed environment](../distributed.md)
+- [Learn how to group nodes for deployment](../nodes_grouping.md)
+- [Learn how to group nodes with namespaces in Kedro](../../build/namespaces.md#group-nodes-with-namespaces)
+- [Learn how to package a Kedro project](../package_a_project.md)
+- [Learn how to customise project-specific Kedro commands](../../getting-started/commands_reference.md#customise-or-override-project-specific-kedro-commands)
+- [Learn how to use catalog globals in Kedro configuration](../../configure/advanced_configuration.md#how-to-use-global-variables-with-the-omegaconfigloader)
+
+### AWS
+
+- [Read the AWS Batch user guide](https://docs.aws.amazon.com/batch/latest/userguide/what-is-aws-batch.html)
+- [Learn how to create an AWS Batch job definition](https://docs.aws.amazon.com/batch/latest/userguide/job_definitions.html)
+- [Learn how to configure IAM policies for AWS Batch](https://docs.aws.amazon.com/batch/latest/userguide/IAM_policies.html)
+- [Learn how to push a Docker image to Amazon ECR](https://docs.aws.amazon.com/AmazonECR/latest/userguide/docker-push-ecr-image.html)
+- [Learn how to check AWS Batch job status](https://docs.aws.amazon.com/batch/latest/userguide/monitoring.html)

--- a/docs/deploy/supported-platforms/aws_step_functions.md
+++ b/docs/deploy/supported-platforms/aws_step_functions.md
@@ -237,7 +237,7 @@ Set `s3_bucket` in `conf/aws/globals.yml` to the same value as `S3_BUCKET` from 
 
 ### Create an `aws` config environment
 
-Add `conf/aws/` with a `globals.yml` file and a `catalog.yml` that points every dataset to S3. [Use catalog globals to define the S3 bucket name in one place](https://docs.kedro.org/en/stable/configure/advanced_configuration.html#how-to-use-globals-and-runtime-params).
+Add `conf/aws/` with a `globals.yml` file and a `catalog.yml` that points every dataset to S3. [Use catalog globals to define the S3 bucket name in one place](../../configure/advanced_configuration.md#how-to-use-global-variables-with-the-omegaconfigloader).
 
 `conf/aws/globals.yml`:
 
@@ -753,7 +753,7 @@ If the execution failed, see [Troubleshooting](#troubleshooting).
 - [Learn how to group nodes with namespaces in Kedro](../../build/namespaces.md#group-nodes-with-namespaces)
 - [Learn how to package a Kedro project](../package_a_project.md)
 - [Learn how to run a packaged Kedro project](../package_a_project.md#run-a-packaged-project)
-- [Learn how to use catalog globals in Kedro configuration](https://docs.kedro.org/en/stable/configure/advanced_configuration.html#how-to-use-globals-and-runtime-params)
+- [Learn how to use catalog globals in Kedro configuration](../../configure/advanced_configuration.md#how-to-use-global-variables-with-the-omegaconfigloader)
 - [Learn how to manage Kedro sessions and lifecycle](../../extend/session.md)
 
 ### AWS

--- a/docs/deploy/supported-platforms/azure.md
+++ b/docs/deploy/supported-platforms/azure.md
@@ -2,6 +2,6 @@
 
 ## `kedro-azureml` plugin
 
-For deployment to Azure ML pipelines, you should [consult the documentation](https://kedro-azureml.readthedocs.io/en/stable/source/03_quickstart.html) for the [`kedro-azureml` plugin](https://github.com/getindata/kedro-azureml) from GetInData | Part of Xebia that enables you to run your code on Azure ML Pipelines in a fully managed fashion.
+For deployment to Azure ML pipelines, see the [`kedro-azureml` plugin](https://github.com/getindata/kedro-azureml) from GetInData | Part of Xebia. This plugin enables you to run your code on Azure ML Pipelines in a fully managed fashion. For setup steps, [consult the documentation](https://kedro-azureml.readthedocs.io/en/stable/source/03_quickstart.html).
 
 The plugin supports both Docker-based workflows and code-upload workflows. It also supports distributed training in PyTorch, TensorFlow, and MPI, and works well with the Azure ML native MLflow integration.

--- a/docs/deploy/supported-platforms/dagster.md
+++ b/docs/deploy/supported-platforms/dagster.md
@@ -2,7 +2,7 @@
 
 
 ## Why would you use Dagster?
-Dagster is a modern Python data orchestration platform. For Kedro users, Dagster provides a powerful bridge between local development and production-grade data and machine learning pipelines. Dagster complements Kedro’s effective modular pipeline authoring, configuration management, and data catalog by enabling teams to build, schedule, and monitor workflows with enhanced observability and scalability. Key benefits of using Dagster with Kedro include:
+Dagster is a modern Python data orchestration platform. For Kedro users, Dagster provides a powerful bridge between local development and production-grade data and machine learning pipelines. Dagster complements Kedro’s effective modular pipeline authoring, configuration management, and data catalog by enabling teams to build, schedule, and track workflows with enhanced observability and scalability. Key benefits of using Dagster with Kedro include:
 
 - **Asset-first philosophy**: Dagster adopts an asset-first approach, treating datasets and models as first-class citizens. This aligns naturally with Kedro’s data catalog and node-based pipeline architecture. By mapping Kedro nodes and datasets to Dagster assets, you gain a clearer view of data lineage, dependencies, and the flow of transformations across your project.
 - **Enhanced orchestration, scheduling, and observability**: Dagster offers rich orchestration capabilities with fine-grained control over scheduling, retries, and execution monitoring. From a Kedro perspective, this means turning your pipelines into fully observable assets with built-in dashboards for runs, logs, and asset materialisation thus providing transparency across your data lifecycle.

--- a/docs/deploy/supported-platforms/prefect.md
+++ b/docs/deploy/supported-platforms/prefect.md
@@ -2,7 +2,7 @@
 
 This page explains how to run your Kedro pipeline using [Prefect 2.0](https://www.prefect.io/opensource), an open-source workflow management system.
 
-The scope of this documentation is the deployment to a self hosted [Prefect Server](https://docs-2.prefect.io/latest/guides/host/). Prefect Server is an open-source backend that helps you track and execute your Prefect flows and automatically extends Prefect 2.0. We will use an [Agent that pulls submitted flow runs from a Work Queue](https://docs-2.prefect.io/latest/concepts/deployments/#workers-and-work-pools).
+The scope of this documentation is the deployment to a self-hosted [Prefect Server](https://docs-2.prefect.io/latest/guides/host/). Prefect Server is an open-source backend that helps you track and execute your Prefect flows. It automatically extends Prefect 2.0. We will use an Agent that pulls submitted flow runs from a [Work Queue](https://docs-2.prefect.io/latest/concepts/deployments/#workers-and-work-pools).
 
 !!! note
     This deployment has been tested using Kedro 0.18.10 with Prefect version 2.10.17. If you want to deploy with Prefect 1.0, we recommend you review [earlier versions of Kedro's Prefect deployment documentation](https://docs.kedro.org/en/stable/deploy/supported-platforms/prefect/).
@@ -24,7 +24,7 @@ prefect config set PREFECT_API_URL="http://127.0.0.1:4200/api"
 For each new Kedro project you create, you need to decide whether to opt into [usage analytics](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry). Your decision is recorded in the `.telemetry` file stored in the project root.
 
 !!! warning
-    When you run a Kedro project locally, you are asked on the first `kedro` command for the project, but in this use case, the project will hang unless you follow these instructions.
+    When you run a Kedro project locally, you are asked on the first `kedro` command for the project. In this use case, the project will hang unless you follow these instructions.
 
 Create a `.telemetry` file manually and put it in the **root of your Kedro project** and add your preference to give or decline consent. To do this, specify either `true` (to give consent) or `false`. The example given below accepts Kedro's usage analytics.
 
@@ -55,7 +55,7 @@ prefect agent start --pool <work_pool_name> --work-queue <work_queue_name>
 
 ### Convert your Kedro pipeline to Prefect 2.0 flow
 
-To build a [Prefect flow](https://docs-2.prefect.io/latest/concepts/flows/) for your Kedro pipeline programmatically and register it with the Prefect API, use the following Python script, which should be stored in your project’s **root directory**:
+To build a [Prefect flow](https://docs-2.prefect.io/latest/concepts/flows/) for your Kedro pipeline programmatically and register it with the Prefect API, use the following Python script. Store the script in your project’s **root directory**:
 
 ```python
 # <project_root>/register_prefect_flow.py

--- a/docs/develop/automated_testing.md
+++ b/docs/develop/automated_testing.md
@@ -7,9 +7,9 @@ Software testing is the process of checking that the code you have written fulfi
 - **Manual testing** is when you run part or the entire project and check that the results are what you expect.
 - **Automated testing** is writing new code (using libraries called _testing frameworks_) that runs part or the entire project and automatically checks the results against what you expect.
 
-As a project grows larger, new code will increasingly rely on existing code. As these interdependencies grow, making changes in one part of the code base can unexpectedly break the intended functionality in another part.
+As a project grows larger, new code will increasingly rely on existing code. As these interdependencies grow, making changes in one part of the code base can break the intended functionality in another part.
 
-The major disadvantage of manual testing is that it is time-consuming. Manual tests are usually run once, directly after new functionality has been added. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes.
+The major disadvantage of manual testing is that it is time-consuming. Teams typically run manual tests one time, after they add new functionality. It is impractical to repeat manual tests for the entire code base each time a change is made, which means this strategy often misses breaking changes.
 
 The solution to this problem is automated testing. Automated testing runs comprehensive test suites across the whole code base in seconds, every time a new feature is added or an old one is changed. In this way, breaking changes can be discovered during development rather than in production.
 
@@ -108,7 +108,7 @@ This test is redundant, but it introduces several of `pytest`'s core features an
 
 Although this specific example does not use fixtures, they are an essential part of pytest for defining reusable resources across tests. See [Fixtures](https://docs.pytest.org/en/7.1.x/explanation/fixtures.html#about-fixtures)
 
-Tests should be named as descriptively as possible, especially if you are working with other people. For example, it is easier to understand the purpose of a test with the name `test_node_passes_with_valid_input` than a test with the name `test_passes`.
+Tests should be named as descriptively as possible. This is critical when you are working with other people. For example, it is easier to understand the purpose of a test with the name `test_node_passes_with_valid_input` than a test with the name `test_passes`.
 
 You can read more about the [basics of using `pytest` on the getting started page](https://docs.pytest.org/en/7.1.x/getting-started.html). For help writing your own tests and using the full feature set of `pytest`, see the [project documentation](https://docs.pytest.org/).
 

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -166,7 +166,7 @@ A comprehensive list of available options can be found in the [RichHandler docum
 
 ## How to enable file-based logging
 
-File-based logging in Python projects aids troubleshooting and debugging. It offers better visibility into the application's behaviour and keeps the logs searchable. It does not work well with read-only systems such as [Databricks Repos](https://docs.databricks.com/repos/index.html).
+File-based logging in Python projects aids troubleshooting and debugging. It offers better visibility into the application's behaviour and keeps the logs searchable. It does not work well with `read-only` systems such as [Databricks Repos](https://docs.databricks.com/repos/index.html).
 
 To enable file-based logging, add `info_file_handler` in your `root` logger in your `conf/logging.yml` as follows:
 
@@ -199,7 +199,7 @@ export COLUMNS=120 LINES=25
 ```
 
 !!! note
-    You must provide a value for both `COLUMNS` and `LINES` even if you only wish to change the width of the log message. Rich's default values for these variables are `COLUMNS=80` and `LINE=25`.
+    You must provide a value for both `COLUMNS` and `LINES` even when you want to change the width of the log message. Rich's default values for these variables are `COLUMNS=80` and `LINES=25`.
 
 ## How to enable rich logging in Jupyter
 

--- a/docs/extend/common_use_cases.md
+++ b/docs/extend/common_use_cases.md
@@ -4,7 +4,7 @@ Kedro provides several built-in mechanisms that let you extend its behaviour. Th
 
 ## Use Case 1: How to add extra behaviour to Kedro's execution timeline
 
-The execution timeline of a Kedro pipeline is a sequence of actions performed by various Kedro library components. Examples include the [kedro-datasets documentation](https://docs.kedro.org/projects/kedro-datasets/en/stable/), [kedro.io.DataCatalog][], [kedro.pipeline.pipeline.Pipeline][], [kedro.pipeline.node.Node][], and [kedro.framework.context.KedroContext][].
+The execution timeline of a Kedro pipeline is a sequence of actions performed by various Kedro library components. Examples include the [kedro-datasets documentation](https://docs.kedro.org/projects/kedro-datasets/en/stable/), [kedro.io.DataCatalog][], the [`Pipeline`][kedro.pipeline.pipeline.Pipeline] class, [kedro.pipeline.node.Node][], and [kedro.framework.context.KedroContext][].
 
 At different points in the lifecycle of these components, you might want to add extra behaviour. For example, you could add extra computation for profiling purposes _before_ and _after_ a node runs. You might also insert behaviour around the I/O actions of a dataset, namely the `load` and `save` actions.
 

--- a/docs/extend/hooks/common_use_cases.md
+++ b/docs/extend/hooks/common_use_cases.md
@@ -202,7 +202,7 @@ HOOKS = (AzureSecretsHook(),)
 
 ## Use stateful Hooks to share context between Hook methods
 
-Hooks are instantiated once per Kedro session, so instance attributes persist across hook calls.
+Each Hook has a single instance per Kedro session, so instance attributes persist across hook calls.
 This lets you capture data from `after_context_created` and reuse it in hooks that do not receive the context (such as `before_pipeline_run` or `before_node_run`).
 
 ```python
@@ -230,7 +230,7 @@ class RuntimeConfigHook:
 This pattern is useful when migrating older projects that passed `context` through custom integrations, or when coordinating configuration and runtime behaviour across multiple Hook points.
 
 !!! note
-    Keep stored data small and treat it as read-only to avoid surprising side effects across hooks.
+    Keep stored data small and treat it as `read-only` to avoid surprising side effects across hooks.
 
 ## Use Hooks to read `metadata` from `DataCatalog`
 Use the `after_catalog_created` Hook to access `metadata` to extend Kedro.

--- a/docs/extend/hooks/introduction.md
+++ b/docs/extend/hooks/introduction.md
@@ -67,7 +67,7 @@ Kedro defines a small set of CLI hooks that inject additional behaviour around e
 * `before_command_run`
 * `after_command_run`
 
-This is what the [`kedro-telemetry` plugin](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry) relies on under the hood in order to be able to collect CLI usage statistics.
+This is what the [`kedro-telemetry` plugin](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-telemetry) relies on to collect CLI usage statistics.
 
 ## Hook implementation
 

--- a/docs/extend/how_to_create_a_custom_dataset.md
+++ b/docs/extend/how_to_create_a_custom_dataset.md
@@ -1,6 +1,6 @@
 # Advanced: Tutorial to create a custom dataset
 
-[Kedro supports several datasets](https://docs.kedro.org/projects/kedro-datasets/en/stable/) out of the box, but you may find that you need to create a custom dataset. For example, you may need to handle a proprietary data format or filesystem in your pipeline, or perhaps you have found a particular use case for a dataset that Kedro does not support. This tutorial explains how to create a custom dataset to read and save image data.
+[Kedro supports several datasets](https://docs.kedro.org/projects/kedro-datasets/en/stable/) out of the box, but you may find that you need to create a custom dataset. For example, you may need to handle a proprietary data format or filesystem in your pipeline. Or perhaps you have found a particular use case for a dataset that Kedro does not support. This tutorial explains how to create a custom dataset to read and save image data.
 
 ## Understand `AbstractDataset`
 
@@ -98,7 +98,7 @@ src/kedro_pokemon/datasets
 └── image_dataset.py
 ```
 
-## Implement the `load` method with `fsspec`
+## Write the `load` method with `fsspec`
 
 Several built-in Kedro datasets rely on [fsspec](https://filesystem-spec.readthedocs.io/en/latest/) as a consistent interface to different data sources, as described earlier in the section about the [Data Catalog](../catalog-data/data_catalog.md#dataset-filepath). In this example, using `fsspec` with `Pillow` keeps the dataset flexible across different image locations and formats.
 
@@ -171,7 +171,7 @@ In [2]: from PIL import Image
 In [3]: Image.fromarray(image).show()
 ```
 
-## Implement the `save` method with `fsspec`
+## Write the `save` method with `fsspec`
 
 Similarly, define the `_save` method as follows:
 
@@ -196,7 +196,7 @@ In [2]: context.catalog.save('pikachu', data=image)
 
 You can open the file to verify that the data was written back as expected.
 
-## Implement the `_describe` method
+## Write the `_describe` method
 
 The `_describe` method is used for printing purposes. The convention in Kedro is for the method to return a dictionary describing the attributes of the dataset.
 
@@ -510,7 +510,7 @@ Inspect the content of the data directory to find a new version of the data, wri
 
 ## Thread-safety
 
-Kedro datasets should work with the [kedro.runner.SequentialRunner][] and the [kedro.runner.ParallelRunner][], so they must be fully serialisable by the [Python multiprocessing package](https://docs.python.org/3/library/multiprocessing.html). This means that your datasets should not make use of lambda functions, nested functions, closures etc. If you are using custom decorators, you need to ensure that they are using [`functools.wraps()`](https://docs.python.org/3/library/functools.html#functools.wraps).
+Kedro datasets should work with the [kedro.runner.SequentialRunner][] and the [kedro.runner.ParallelRunner][], so they must be fully serialisable by the [Python multiprocessing package](https://docs.python.org/3/library/multiprocessing.html). This means that your datasets should not make use of lambda functions, nested functions, or closures. If you are using custom decorators, you need to ensure that they are using [`functools.wraps()`](https://docs.python.org/3/library/functools.html#functools.wraps).
 
 [SparkDataset](https://docs.kedro.org/projects/kedro-datasets/en/feature-8.0/api/kedro_datasets/spark.SparkDataset/) is one exception.
 [Apache Spark](https://spark.apache.org/) uses its own parallelism, so it doesn't work with Kedro [kedro.runner.ParallelRunner][].

--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -167,7 +167,7 @@ On success the response contains `run_id`, `status`, and `duration_ms`:
 }
 ```
 
-On failure the response additionally contains an `error` object with the exception type and message:
+On failure the response also contains an `error` object with the exception type and message:
 
 ```json
 {

--- a/docs/extend/session.md
+++ b/docs/extend/session.md
@@ -17,7 +17,7 @@ Kedro provides two session classes, based on the abstract base class `AbstractSe
 
 
 !!! note
-    `KedroServiceSession` is currently in active development and might be subject to occasional breaking changes. We encourage you to try it out and share your feedback with us.
+    `KedroServiceSession` is in active development and might be subject to occasional breaking changes. We encourage you to try it out and share your feedback with us.
 
 
 The main methods and properties of both `KedroSession` and `KedroServiceSession` are:
@@ -58,7 +58,7 @@ You can provide the following optional arguments in `KedroSession.create()`:
 - `conf_source`: Optional argument to specify the configuration source for the `KedroContext`
 
 ## Create a `KedroServiceSession`
-The following code creates a `KedroServiceSession` object as a context manager and runs a pipeline inside the context, with session data provided. Similar to the above example, this script can be called from anywhere in your Kedro project as the root folder will automatically be located. The session automatically closes after exit:
+The following code creates a `KedroServiceSession` object as a context manager and runs a pipeline inside the context, with session data provided. Like the above example, this script can be called from anywhere in your Kedro project as the root folder will automatically be located. The session automatically closes after exit:
 
 ```python
 from pathlib import Path

--- a/docs/getting-started/architecture_overview.md
+++ b/docs/getting-started/architecture_overview.md
@@ -20,7 +20,7 @@ As a data pipeline developer, you will interact with a Kedro project, which cons
 * The **`src`** directory, which contains the source code for the project, including:
     * The **`pipelines`**  directory, which contains the source code for your pipelines.
     * **`settings.py`** file contains the settings for the project, such as library component registration and custom hook registration. All the available settings are listed and explained in the [project settings chapter](../tutorials/settings.md).
-    * **`pipeline_registry.py`** file defines the project pipelines that can be run using `kedro run --pipeline`.
+    * **`pipeline_registry.py`** file defines the project pipelines that can be run using `kedro run --pipelines`.
     * **`__main__.py`** file serves as the main entry point of the project in [package mode](../deploy/package_a_project.md#package-a-kedro-project).
 
 * **`pyproject.toml`** identifies the project root by providing project metadata, including:

--- a/docs/getting-started/faq.md
+++ b/docs/getting-started/faq.md
@@ -76,7 +76,7 @@ brains behind a layered data-engineering convention as a model of managing data.
 Refer to the following table below for a high level guide to each layer's purpose
 
 !!! note
-    The data layers don’t have to exist locally in the `data` folder within your project, but we recommend that you structure your S3 buckets or other data stores in a similar way.
+    The data layers don’t have to exist locally in the `data` folder within your project. We recommend that you structure your S3 buckets or other data stores in a similar way.
 
 ![Data Engineering Convention](../meta/images/data_layers.png)
 

--- a/docs/ide/set_up_pycharm.md
+++ b/docs/ide/set_up_pycharm.md
@@ -56,14 +56,14 @@ Specify the **Run / Debug Configuration** name in the **Name** field, and edit t
 - Enter ``kedro`` in the **Module Name** field
 - Enter ``run`` in the **Parameters** field
 - Enter the path of your project directory into the **Working directory** field
-- Pick ``Emulate terminal in output console`` from the **Modify options** dropdown, and then click **OK**
+- Pick ``Emulate terminal in output console`` from the `Modify options` dropdown, and then click **OK**
 
 ![](../meta/images/pycharm_edit_py_run_config.png)
 
 !!! note
     **Emulate terminal in output console** enables PyCharm to show [rich terminal output](../develop/logging.md).
 
-To execute the Run configuration, select it from the **Run / Debug Configurations** dropdown in the toolbar (if that toolbar is not visible, you can enable it by going to **View > Toolbar**). Click the green triangle:
+To execute the Run configuration, select it from the **Run / Debug Configurations** dropdown in the toolbar. If that toolbar is not visible, enable it by going to **View > Toolbar**. Click the green triangle:
 
 ![](../meta/images/pycharm_conf_run_button.png)
 
@@ -156,7 +156,7 @@ With this configuration, when you create a Python Console you should be able to 
 
 ## Configuring the Kedro catalog validation schema
 
-You can enable the Kedro catalog validation schema in your PyCharm IDE to enable real-time validation, autocompletion, and see documentation about the different fields in your `catalog` as you write it. To enable this, open a `catalog.yml` file and you should see "No JSON Schema" in the bottom right corner of your window. Click it and select "Edit Schema Mapping".
+You can enable the Kedro catalog validation schema in your PyCharm IDE for real-time validation, autocompletion, and documentation about the different fields in your `catalog` as you write it. To enable this, open a `catalog.yml` file and you should see "No JSON Schema" in the bottom right corner of your window. Click it and select "Edit Schema Mapping".
 
 ![](../meta/images/pycharm_edit_schema_mapping.png)
 

--- a/docs/ide/set_up_vscode.md
+++ b/docs/ide/set_up_vscode.md
@@ -26,7 +26,7 @@ To ensure your virtual environments appear in the Python interpreter list, open 
 "python.venvPath": "/path/containing/your/venvs/"
 ```
 
-If you create a `venv` / `virtualenv` in your project directory named `venv`, VS Code (much like PyCharm) automatically loads it as the Python interpreter unless you manually define a different interpreter as described above.
+If you create a `venv` or `virtualenv` in your project directory named `venv`, VS Code automatically loads it as the Python interpreter (much like PyCharm). This is the default unless you manually define a different interpreter as described above.
 
 
 ## Set up tasks

--- a/docs/inspect/inspect-project.md
+++ b/docs/inspect/inspect-project.md
@@ -179,6 +179,6 @@ snapshot = get_project_snapshot("/path/to/my_project", conf_source="conf/custom"
 
 ## How to access the snapshot through the HTTP server
 
-The Kedro HTTP server exposes the same snapshot data at `GET /snapshot`. On success, the response contains the same `metadata`, `pipelines`, `datasets`, and `parameters` fields as `ProjectSnapshot`, serialised as JSON. On failure, only `status` and `error` are returned — the data fields are absent.
+The Kedro HTTP server exposes the same snapshot data at `GET /snapshot`. On success, the response contains the same `metadata`, `pipelines`, `datasets`, and `parameters` fields as `ProjectSnapshot`, serialised as JSON. On failure, the response returns `status` and `error` with no data fields.
 
 See [Serving Kedro pipelines over HTTP](../extend/serving.md#get-snapshot) for the full endpoint reference, example responses, and failure behaviour.

--- a/docs/integrations-and-plugins/dvc.md
+++ b/docs/integrations-and-plugins/dvc.md
@@ -211,7 +211,7 @@ Here is an example configuration for dvc.yaml:
 ```yaml
 stages:
   data_processing:
-    cmd: kedro run --pipeline data_processing
+    cmd: kedro run --pipelines data_processing
     deps:
       - data/01_raw/companies.csv
       - data/01_raw/reviews.csv
@@ -222,7 +222,7 @@ stages:
       - data/03_primary/model_input_table.parquet
 
   data_science:
-    cmd: kedro run --pipeline data_science
+    cmd: kedro run --pipelines data_science
     deps:
       - data/03_primary/model_input_table.parquet
     outs:
@@ -248,7 +248,7 @@ You can track changes to your code by adding the relevant files to the `deps` se
 ```yaml
 stages:
   data_processing:
-    cmd: kedro run --pipeline data_processing
+    cmd: kedro run --pipelines data_processing
     deps:
       - data/01_raw/companies.csv
       - data/01_raw/reviews.csv
@@ -277,7 +277,7 @@ To track parameters, you can include them under the `params` section in `dvc.yam
 ```yaml
 stages:
   data_science:
-    cmd: kedro run --pipeline data_science
+    cmd: kedro run --pipelines data_science
     deps:
       - data/03_primary/model_input_table.parquet
       - src/space_dvc/pipelines/data_science/nodes.py

--- a/docs/integrations-and-plugins/great_expectations.md
+++ b/docs/integrations-and-plugins/great_expectations.md
@@ -90,7 +90,7 @@ When you validate data, Great Expectations:
 2. Runs each expectation against it
 3. Returns detailed results showing what passed and what failed
 
-- During quick interactive work you may use an ephemeral GX Data Context (no files persisted between runs). This is fine for exploration and iterative expectation creation.
+- During interactive work you may use an ephemeral GX Data Context (no files persisted between runs). This is fine for exploration and iterative expectation creation.
 - For production runs, persist expectation suites and use a file-based Data Context so suites, validation results and histories are reproducible and shareable.
 
 ## Integration options

--- a/docs/integrations-and-plugins/mlflow.md
+++ b/docs/integrations-and-plugins/mlflow.md
@@ -44,8 +44,8 @@ to a local directory called `mlflow_runs`.
 
 ## Simple use cases
 
-Although MLflow works best when working with machine learning (ML) and AI pipelines,
-you can track your regular Kedro runs as experiments in MLflow even if they do not use ML.
+MLflow works best with machine learning (ML) and AI pipelines.
+You can still track regular Kedro runs as experiments in MLflow, even when they do not use ML.
 
 This section explains how you can use the [`kedro-mlflow`](https://kedro-mlflow.readthedocs.io/) plugin
 to track your Kedro pipelines in MLflow in a straightforward way.
@@ -94,8 +94,8 @@ for more detailed steps.
 ### Artifact tracking in MLflow using `kedro-mlflow`
 
 `kedro-mlflow` provides some out-of-the-box artifact tracking capabilities
-that connect your Kedro project with your MLflow deployment, such as `MlflowArtifactDataset`,
-which can be used to wrap any of your existing Kedro datasets.
+that connect your Kedro project with your MLflow deployment.
+An example is `MlflowArtifactDataset`, which can be used to wrap any of your existing Kedro datasets.
 
 Use of this dataset has the advantage that the preview capabilities of the MLflow UI can be used.
 

--- a/features/run.feature
+++ b/features/run.feature
@@ -77,6 +77,23 @@ Feature: Run Project
     Then I should get a successful exit code
     And the logs should show that 4 nodes were run
 
+  Scenario: Run kedro run with selective pipeline loading
+    Given I have prepared a config file
+    And I have run a non-interactive kedro new with starter "default"
+    When I execute the kedro command "run --pipelines data_engineering"
+    Then I should get a successful exit code
+    And the logs should show that 1 nodes were run
+    And the logs should show that "split_data_node" was run
+
+  Scenario: Run kedro run with selective pipeline loading skips unrelated pipeline modules
+    Given I have prepared a config file
+    And I have run a non-interactive kedro new with starter "default"
+    And I have broken the "data_science" pipeline with an unimportable dependency
+    When I execute the kedro command "run --pipelines data_engineering"
+    Then I should get a successful exit code
+    And the logs should show that 1 nodes were run
+    And the logs should show that "split_data_node" was run
+
   Scenario: Run with --only-missing-outputs flag after deleting an intermediate output
     Given I have prepared a config file
     And I have run a non-interactive kedro new with starter "default"

--- a/features/steps/cli_steps.py
+++ b/features/steps/cli_steps.py
@@ -768,6 +768,24 @@ def step_uninstall_rich(context):
     ), f"Failed to uninstall rich:\n{result.stdout}\n{result.stderr}"
 
 
+@given('I have broken the "{pipeline_name}" pipeline with an unimportable dependency')
+def step_break_pipeline_import(context, pipeline_name):
+    """Prepend a bad import to a pipeline's nodes.py to simulate a missing dependency."""
+    nodes_file = (
+        context.root_project_dir
+        / "src"
+        / context.package_name
+        / "pipelines"
+        / pipeline_name
+        / "nodes.py"
+    )
+    content = nodes_file.read_text(encoding="utf-8")
+    nodes_file.write_text(
+        "import _this_package_does_not_exist_kedro_selective_loading_test\n" + content,
+        encoding="utf-8",
+    )
+
+
 @when('I delete the file "{filepath}" from the project')
 def delete_project_file(context, filepath):
     """Deletes a specified file within the root_project_dir."""

--- a/kedro/__init__.py
+++ b/kedro/__init__.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 import sys
 import warnings
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 
 class KedroDeprecationWarning(DeprecationWarning):

--- a/kedro/framework/cli/catalog.py
+++ b/kedro/framework/cli/catalog.py
@@ -9,7 +9,7 @@ import yaml
 from click import secho
 
 from kedro.framework.cli.utils import env_option, split_string
-from kedro.framework.project import settings
+from kedro.framework.project import pipelines, settings
 
 if TYPE_CHECKING:
     from kedro.framework.startup import ProjectMetadata
@@ -42,7 +42,7 @@ def catalog() -> None:
     callback=split_string,
 )
 @click.pass_obj
-def describe_datasets(metadata: ProjectMetadata, pipeline: str, env: str) -> None:
+def describe_datasets(metadata: ProjectMetadata, pipeline: list[str], env: str) -> None:
     """
     Describe datasets used in the specified pipelines, grouped by type.\n
 
@@ -52,11 +52,12 @@ def describe_datasets(metadata: ProjectMetadata, pipeline: str, env: str) -> Non
     - `factories`: Datasets resolved from dataset factory patterns.\n
     - `defaults`: Datasets that do not match any pattern or explicit definition.\n
     """
+    if pipeline:
+        pipelines.set_requested(pipeline)
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 
-    p = pipeline or None
-    datasets_dict = context.catalog.describe_datasets(p)  # type: ignore
+    datasets_dict = context.catalog.describe_datasets(pipeline)  # type: ignore
 
     secho(yaml.dump(datasets_dict))
 
@@ -89,7 +90,7 @@ def list_patterns(metadata: ProjectMetadata, env: str) -> None:
     callback=split_string,
 )
 @click.pass_obj
-def resolve_patterns(metadata: ProjectMetadata, pipeline: str, env: str) -> None:
+def resolve_patterns(metadata: ProjectMetadata, pipeline: list[str], env: str) -> None:
     """
     Resolve dataset factory patterns against pipeline datasets.
 
@@ -97,10 +98,11 @@ def resolve_patterns(metadata: ProjectMetadata, pipeline: str, env: str) -> None
     It includes datasets explicitly defined in the catalog as well as those resolved
     from dataset factory patterns.
     """
+    if pipeline:
+        pipelines.set_requested(pipeline)
     session = _create_session(metadata.package_name, env=env)
     context = session.load_context()
 
-    p = pipeline or None
-    datasets_dict = context.catalog.resolve_patterns(p)  # type: ignore
+    datasets_dict = context.catalog.resolve_patterns(pipeline)  # type: ignore
 
     secho(yaml.dump(datasets_dict))

--- a/kedro/framework/cli/registry.py
+++ b/kedro/framework/cli/registry.py
@@ -35,8 +35,12 @@ def describe_registered_pipeline(
     """Describe a registered pipeline by providing a pipeline name.
     Defaults to the `__default__` pipeline.
     """
+    # Must be called before pipelines.get(), which triggers the first pipelines dict access.
+    pipelines.set_requested([name])
     pipeline_obj = pipelines.get(name)
     if not pipeline_obj:
+        # Reset to None so keys() loads all pipelines for the error message.
+        pipelines.set_requested(None)
         all_pipeline_names = pipelines.keys()
         existing_pipelines = ", ".join(sorted(all_pipeline_names))
         raise KedroCliError(

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -203,6 +203,7 @@ class _ProjectPipelines(MutableMapping):
         self._pipelines_module: str | None = None
         self._is_data_loaded = False
         self._content: dict[str, Pipeline] = {}
+        self._requested_pipelines: list[str] | None = None
 
     @staticmethod
     def _get_pipelines_registry_callable(pipelines_module: str) -> Any:
@@ -226,6 +227,23 @@ class _ProjectPipelines(MutableMapping):
         self._content = project_pipelines
         self._is_data_loaded = True
 
+    def set_requested(self, pipeline_names: list[str] | None) -> None:
+        """Store which pipelines should be loaded on the next dict access.
+
+        Invalidates the cache when the filter changes so that a subsequent
+        access with a different (or absent) filter re-runs ``_load_data``.
+
+        Args:
+            pipeline_names: Names of the pipelines to load selectively, or
+                ``None`` to load all registered pipelines.
+        """
+        if set(self._requested_pipelines or []) != set(pipeline_names or []):
+            self._is_data_loaded = False
+            self._content = {}
+        self._requested_pipelines = (
+            list(pipeline_names) if pipeline_names is not None else None
+        )
+
     def configure(self, pipelines_module: str | None = None) -> None:
         """Configure the pipelines_module to load the pipelines dictionary.
         Reset the data loading state so that after every ``configure`` call,
@@ -234,6 +252,7 @@ class _ProjectPipelines(MutableMapping):
         self._pipelines_module = pipelines_module
         self._is_data_loaded = False
         self._content = {}
+        self._requested_pipelines = None
 
     # Dict-like interface
     __getitem__ = _load_data_wrapper(operator.getitem)
@@ -501,9 +520,14 @@ def find_pipelines(  # noqa: PLR0912, PLR0915
             "Call 'configure_project' first."
         )
 
-    # Determine if specific pipelines were requested
-    load_all = pipelines_to_find is None or "__default__" in pipelines_to_find
-    requested_pipelines: set[str] | None = None if load_all else set(pipelines_to_find)  # type: ignore[arg-type]
+    # CLI-set filter takes precedence; falls back to the explicit kwarg.
+    pipeline_filter = (
+        pipelines._requested_pipelines
+        if pipelines._requested_pipelines is not None
+        else pipelines_to_find
+    )
+    load_all = pipeline_filter is None or "__default__" in pipeline_filter
+    requested_pipelines: set[str] | None = None if load_all else set(pipeline_filter)  # type: ignore[arg-type]
 
     pipelines_dict: dict[str, Pipeline] = {}
 

--- a/kedro/framework/session/service_session.py
+++ b/kedro/framework/session/service_session.py
@@ -159,6 +159,8 @@ class KedroServiceSession(AbstractSession):
         self._logger.info("Run ID: %s", run_id)
         save_version = run_id
 
+        # Must be called before load_context(), which triggers the first pipelines dict access.
+        pipelines.set_requested(pipeline_names or None)
         context = self.load_context(runtime_params)
         pipeline_names = pipeline_names or ["__default__"]
         combined_pipeline = Pipeline([])
@@ -166,6 +168,8 @@ class KedroServiceSession(AbstractSession):
             try:
                 combined_pipeline += pipelines[name]
             except KeyError as exc:
+                # Reset to None so keys() loads all pipelines for suggestions.
+                pipelines.set_requested(None)
                 matches = get_close_matches(name, pipelines.keys())
                 if matches:
                     suggestion = (

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -342,6 +342,8 @@ class KedroSession(AbstractSession):
         session_id = self.store["session_id"]
         save_version = session_id
         runtime_params = self.store.get("runtime_params") or {}
+        # Must be called before load_context(), which triggers the first pipelines dict access.
+        pipelines.set_requested(pipeline_names or None)
         context = self.load_context()
 
         names = pipeline_names or ["__default__"]
@@ -350,6 +352,8 @@ class KedroSession(AbstractSession):
             try:
                 combined_pipelines += pipelines[name]
             except KeyError as exc:
+                # Reset to None so keys() loads all pipelines for suggestions.
+                pipelines.set_requested(None)
                 matches = get_close_matches(name, pipelines.keys())
                 if matches:
                     suggestion = (

--- a/tests/framework/cli/test_registry.py
+++ b/tests/framework/cli/test_registry.py
@@ -48,7 +48,22 @@ class TestRegistryDescribeCommand:
         yaml_dump_mock,
         pipeline_name,
         pipelines_dict,
+        mocker,
     ):
+        mock_nodes = []
+        for node_str in pipelines_dict[pipeline_name]:
+            node_name, func_part = node_str.split(" (", 1)
+            mock_node = mocker.Mock()
+            mock_node.name = node_name
+            mock_node._func_name = func_part.rstrip(")")
+            mock_nodes.append(mock_node)
+
+        mock_pipeline = mocker.Mock()
+        mock_pipeline.nodes = mock_nodes
+
+        mock_pipes = mocker.patch("kedro.framework.cli.registry.pipelines")
+        mock_pipes.get.return_value = mock_pipeline
+
         result = CliRunner().invoke(
             fake_project_cli,
             ["registry", "describe", pipeline_name],
@@ -56,15 +71,31 @@ class TestRegistryDescribeCommand:
         )
 
         assert not result.exit_code
+        mock_pipes.set_requested.assert_called_once_with([pipeline_name])
         expected_dict = {"Nodes": pipelines_dict[pipeline_name]}
         yaml_dump_mock.assert_called_once_with(expected_dict)
 
-    def test_registered_pipeline_not_found(self, fake_project_cli, fake_metadata):
+    def test_registered_pipeline_not_found(
+        self, fake_project_cli, fake_metadata, mocker
+    ):
+        mock_pipes = mocker.patch("kedro.framework.cli.registry.pipelines")
+        mock_pipes.get.return_value = None
+        mock_pipes.keys.return_value = [
+            "__default__",
+            "data_engineering",
+            "data_processing",
+            "data_science",
+        ]
+
         result = CliRunner().invoke(
             fake_project_cli, ["registry", "describe", "missing"], obj=fake_metadata
         )
 
         assert result.exit_code
+        assert mock_pipes.set_requested.call_args_list == [
+            mocker.call(["missing"]),
+            mocker.call(None),
+        ]
         expected_output = (
             "Error: 'missing' pipeline not found. Existing pipelines: "
             "[__default__, data_engineering, data_processing, data_science]\n"
@@ -77,7 +108,22 @@ class TestRegistryDescribeCommand:
         fake_metadata,
         yaml_dump_mock,
         pipelines_dict,
+        mocker,
     ):
+        mock_nodes = []
+        for node_str in pipelines_dict["__default__"]:
+            node_name, func_part = node_str.split(" (", 1)
+            mock_node = mocker.Mock()
+            mock_node.name = node_name
+            mock_node._func_name = func_part.rstrip(")")
+            mock_nodes.append(mock_node)
+
+        mock_pipeline = mocker.Mock()
+        mock_pipeline.nodes = mock_nodes
+
+        mock_pipes = mocker.patch("kedro.framework.cli.registry.pipelines")
+        mock_pipes.get.return_value = mock_pipeline
+
         result = CliRunner().invoke(
             fake_project_cli,
             ["registry", "describe"],
@@ -85,5 +131,6 @@ class TestRegistryDescribeCommand:
         )
 
         assert not result.exit_code
+        mock_pipes.set_requested.assert_called_once_with(["__default__"])
         expected_dict = {"Nodes": pipelines_dict["__default__"]}
         yaml_dump_mock.assert_called_once_with(expected_dict)

--- a/tests/framework/project/test_pipeline_discovery.py
+++ b/tests/framework/project/test_pipeline_discovery.py
@@ -6,7 +6,14 @@ from pathlib import Path
 
 import pytest
 
-from kedro.framework.project import configure_project, find_pipelines
+from kedro.framework.project import (
+    _ProjectPipelines,
+    configure_project,
+    find_pipelines,
+)
+from kedro.framework.project import (
+    pipelines as _pipelines_global,
+)
 
 
 @pytest.fixture
@@ -435,3 +442,192 @@ def test_find_pipelines_package_name_none_selective_raises(monkeypatch):
     monkeypatch.setattr(project_module, "PACKAGE_NAME", None)
     with pytest.raises(RuntimeError, match="find_pipelines.*cannot be called before"):
         find_pipelines(pipelines_to_find=["some_pipeline"])
+
+
+def test_set_requested_invalidates_cache_on_filter_change():
+    p = _ProjectPipelines()
+    p._is_data_loaded = True
+    p._content = {"__default__": object()}
+
+    p.set_requested(["pipe_a"])
+
+    assert not p._is_data_loaded
+    assert p._content == {}
+    assert p._requested_pipelines == ["pipe_a"]
+
+
+def test_set_requested_same_filter_preserves_cache():
+    p = _ProjectPipelines()
+    p._requested_pipelines = ["pipe_a"]
+    p._is_data_loaded = True
+    sentinel = object()
+    p._content = {"pipe_a": sentinel}
+
+    p.set_requested(["pipe_a"])
+
+    assert p._is_data_loaded
+    assert p._content == {"pipe_a": sentinel}
+
+
+def test_set_requested_order_independent():
+    p = _ProjectPipelines()
+    p._requested_pipelines = ["pipe_a", "pipe_b"]
+    p._is_data_loaded = True
+    sentinel = object()
+    p._content = {"pipe_a": sentinel}
+
+    p.set_requested(["pipe_b", "pipe_a"])
+
+    assert p._is_data_loaded
+    assert p._content == {"pipe_a": sentinel}
+
+
+def test_configure_resets_requested_pipelines():
+    p = _ProjectPipelines()
+    p.set_requested(["pipe_a"])
+    assert p._requested_pipelines == ["pipe_a"]
+
+    p.configure()
+
+    assert p._requested_pipelines is None
+
+
+@pytest.fixture()
+def _reset_global_pipelines_request():
+    """Reset _requested_pipelines on the global singleton after each test."""
+    yield
+    _pipelines_global.set_requested(None)
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines",
+    [{"pipe_x", "pipe_y", "pipe_z"}],
+    indirect=True,
+)
+def test_find_pipelines_uses_global_requested_pipelines(
+    mock_package_name_with_pipelines, _reset_global_pipelines_request
+):
+    configure_project(mock_package_name_with_pipelines)
+    _pipelines_global.set_requested(["pipe_x"])
+
+    result = find_pipelines()
+
+    assert set(result) == {"pipe_x"}
+    assert "__default__" not in result
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines",
+    [{"pipe_x", "pipe_y"}],
+    indirect=True,
+)
+def test_find_pipelines_global_requested_overrides_kwarg(
+    mock_package_name_with_pipelines, _reset_global_pipelines_request
+):
+    configure_project(mock_package_name_with_pipelines)
+    _pipelines_global.set_requested(["pipe_x"])
+
+    result = find_pipelines(pipelines_to_find=["pipe_y"])
+
+    assert set(result) == {"pipe_x"}
+    assert "pipe_y" not in result
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines",
+    [{"pipe_x", "pipe_y"}],
+    indirect=True,
+)
+def test_find_pipelines_none_global_requested_falls_back_to_kwarg(
+    mock_package_name_with_pipelines,
+):
+    configure_project(mock_package_name_with_pipelines)
+    assert _pipelines_global._requested_pipelines is None  # sanity check
+
+    result = find_pipelines(pipelines_to_find=["pipe_x"])
+
+    assert set(result) == {"pipe_x"}
+    assert "pipe_y" not in result
+
+
+@pytest.mark.parametrize(
+    "mock_package_name_with_pipelines",
+    [{"pipe_x", "pipe_y", "pipe_z"}],
+    indirect=True,
+)
+def test_find_pipelines_global_requested_default_loads_all(
+    mock_package_name_with_pipelines, _reset_global_pipelines_request
+):
+    """``"__default__"`` in the filter is special: it means load everything."""
+    configure_project(mock_package_name_with_pipelines)
+    _pipelines_global.set_requested(["__default__"])
+
+    result = find_pipelines()
+
+    assert set(result) == {"pipe_x", "pipe_y", "pipe_z", "__default__"}
+
+
+@pytest.fixture
+def mock_package_with_registry(tmp_path):
+    """A complete package with pipeline_registry.py so the global pipelines object
+    can be accessed via dict operations (which trigger _load_data / register_pipelines)."""
+    package_name = "test_pkg_registry"
+    pkg_dir = tmp_path / package_name
+    pkg_dir.mkdir()
+    (pkg_dir / "__init__.py").touch()
+
+    pipelines_dir = pkg_dir / "pipelines"
+    pipelines_dir.mkdir()
+    (pipelines_dir / "__init__.py").touch()
+
+    for name in ("pipe_x", "pipe_y"):
+        p = pipelines_dir / name
+        p.mkdir()
+        (p / "__init__.py").write_text(
+            textwrap.dedent(
+                f"""
+                from kedro.pipeline import Pipeline, node, pipeline
+
+                def create_pipeline(**kwargs) -> Pipeline:
+                    return pipeline([node(lambda: 1, None, "{name}")])
+                """
+            )
+        )
+
+    (pkg_dir / "pipeline_registry.py").write_text(
+        textwrap.dedent(
+            """
+            from kedro.framework.project import find_pipelines
+
+            def register_pipelines():
+                return find_pipelines()
+            """
+        )
+    )
+
+    sys.path.insert(0, str(tmp_path))
+    yield package_name
+    sys.path.pop(0)
+    for mod in list(sys.modules):
+        if mod.startswith(package_name):
+            del sys.modules[mod]
+
+
+def test_set_requested_none_after_filter_reloads_all_pipelines(
+    mock_package_with_registry, _reset_global_pipelines_request
+):
+    """Resetting to None after a filtered load reloads all pipelines.
+
+    This mirrors the ``kedro registry describe`` error path: a filter is set
+    for the requested name, the load finds nothing, then ``set_requested(None)``
+    is called so that ``keys()`` can list every registered pipeline in the
+    error message.
+    """
+    configure_project(mock_package_with_registry)
+
+    _pipelines_global.set_requested(["nonexistent"])
+    assert _pipelines_global.get("nonexistent") is None
+
+    _pipelines_global.set_requested(None)
+
+    assert set(_pipelines_global.keys()) == {"pipe_x", "pipe_y", "__default__"}

--- a/tests/framework/session/test_service_session.py
+++ b/tests/framework/session/test_service_session.py
@@ -206,6 +206,44 @@ class TestKedroServiceSession:
         assert mock_context._pipelines_to_validate == expected_scope
 
     @pytest.mark.usefixtures("mock_settings_context_class")
+    @pytest.mark.parametrize(
+        "pipeline_names, expected_requested",
+        [
+            (None, None),
+            ([], None),
+            ([_FAKE_PIPELINE_NAME], [_FAKE_PIPELINE_NAME]),
+            (
+                [_FAKE_PIPELINE_NAME, "other_pipeline"],
+                [_FAKE_PIPELINE_NAME, "other_pipeline"],
+            ),
+        ],
+    )
+    def test_run_calls_set_requested(
+        self,
+        fake_project,
+        mock_context_class,
+        mock_runner,
+        mocker,
+        pipeline_names,
+        expected_requested,
+    ):
+        """``KedroServiceSession.run`` calls ``pipelines.set_requested`` with the
+        pipeline filter before the first dict access, so ``find_pipelines`` only
+        imports the requested modules."""
+        mocker.patch("kedro.framework.session.service_session._create_hook_manager")
+        mock_pipelines = mocker.patch(
+            "kedro.framework.session.service_session.pipelines"
+        )
+        mock_runner.__name__ = "SequentialRunner"
+
+        with KedroServiceSession.create(
+            project_path=fake_project, session_id="fake_id"
+        ) as session:
+            session.run(runner=mock_runner, pipeline_names=pipeline_names)
+
+        mock_pipelines.set_requested.assert_called_once_with(expected_requested)
+
+    @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, [_FAKE_PIPELINE_NAME]])
     def test_run(
         self,
@@ -356,12 +394,15 @@ class TestKedroServiceSession:
 
         filter_mock.filter.return_value = ds_mock
 
+        class _PipelinesDict(dict):
+            def set_requested(self, _):
+                pass
+
         mocker.patch(
             "kedro.framework.session.service_session.pipelines",
-            {
-                _FAKE_PIPELINE_NAME: filter_mock,
-                "__default__": filter_mock,
-            },
+            _PipelinesDict(
+                {_FAKE_PIPELINE_NAME: filter_mock, "__default__": filter_mock}
+            ),
         )
         mocker.patch(
             "kedro.io.data_catalog.CatalogConfigResolver.match_dataset_pattern",
@@ -448,6 +489,30 @@ class TestKedroServiceSession:
         assert "Failed to find the pipeline named '__defult__'" in msg
         assert "Did you mean one of these instead?" in msg
         assert "__default__" in msg
+
+    @pytest.mark.usefixtures("mock_settings_context_class")
+    def test_run_nonexistent_pipeline_resets_filter_for_suggestions(
+        self, fake_project, mock_context_class, mock_runner, mocker
+    ):
+        """set_requested(None) is called before keys() in the error path so that
+        suggestions are drawn from all registered pipelines, not just the active filter."""
+        mocker.patch("kedro.framework.session.service_session._create_hook_manager")
+        mock_pipelines = mocker.patch(
+            "kedro.framework.session.service_session.pipelines"
+        )
+        mock_pipelines.__getitem__.side_effect = KeyError("nonexistent")
+        mock_pipelines.keys.return_value = ["__default__", "data_engineering"]
+        mock_runner.__name__ = "SequentialRunner"
+
+        with pytest.raises(ValueError):
+            with KedroServiceSession.create(project_path=fake_project) as session:
+                session.run(runner=mock_runner, pipeline_names=["nonexistent"])
+
+        assert mock_pipelines.set_requested.call_args_list == [
+            mocker.call(["nonexistent"]),
+            mocker.call(None),
+        ]
+        mock_pipelines.keys.assert_called_once()
 
     @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, [_FAKE_PIPELINE_NAME]])

--- a/tests/framework/session/test_session.py
+++ b/tests/framework/session/test_session.py
@@ -629,6 +629,40 @@ class TestKedroSession:
 
         assert mock_context._pipelines_to_validate == expected_scope
 
+    @pytest.mark.usefixtures("mock_settings_context_class")
+    @pytest.mark.parametrize(
+        "pipeline_names, expected_requested",
+        [
+            (None, None),
+            ([], None),
+            ([_FAKE_PIPELINE_NAME], [_FAKE_PIPELINE_NAME]),
+            (
+                [_FAKE_PIPELINE_NAME, "other_pipeline"],
+                [_FAKE_PIPELINE_NAME, "other_pipeline"],
+            ),
+        ],
+    )
+    def test_run_calls_set_requested(
+        self,
+        fake_project,
+        mock_context_class,
+        mock_runner,
+        mocker,
+        pipeline_names,
+        expected_requested,
+    ):
+        """``KedroSession.run`` calls ``pipelines.set_requested`` with the pipeline
+        filter before the first dict access, so ``find_pipelines`` only imports
+        the requested modules."""
+        mocker.patch("kedro.framework.session.session._create_hook_manager")
+        mock_pipelines = mocker.patch("kedro.framework.session.session.pipelines")
+        mock_runner.__name__ = "SequentialRunner"
+
+        with KedroSession.create(fake_project) as session:
+            session.run(runner=mock_runner, pipeline_names=pipeline_names)
+
+        mock_pipelines.set_requested.assert_called_once_with(expected_requested)
+
     def test_run_logs_package_name_when_outside_project(
         self, tmp_path, mock_package_name, caplog, monkeypatch
     ):
@@ -695,10 +729,13 @@ class TestKedroSession:
 
         filter_mock.filter.return_value = ds_mock
 
-        pipelines_ret = {
-            _FAKE_PIPELINE_NAME: filter_mock,
-            "__default__": filter_mock,
-        }
+        class _PipelinesDict(dict):
+            def set_requested(self, _):
+                pass
+
+        pipelines_ret = _PipelinesDict(
+            {_FAKE_PIPELINE_NAME: filter_mock, "__default__": filter_mock}
+        )
         mocker.patch("kedro.framework.session.session.pipelines", pipelines_ret)
         mocker.patch(
             "kedro.io.data_catalog.CatalogConfigResolver.match_dataset_pattern",
@@ -859,6 +896,28 @@ class TestKedroSession:
         assert "Failed to find the pipeline named '__defult__'" in msg
         assert "Did you mean one of these instead?" in msg
         assert "__default__" in msg
+
+    @pytest.mark.usefixtures("mock_settings_context_class")
+    def test_run_nonexistent_pipeline_resets_filter_for_suggestions(
+        self, fake_project, mock_context_class, mock_runner, mocker
+    ):
+        """set_requested(None) is called before keys() in the error path so that
+        suggestions are drawn from all registered pipelines, not just the active filter."""
+        mocker.patch("kedro.framework.session.session._create_hook_manager")
+        mock_pipelines = mocker.patch("kedro.framework.session.session.pipelines")
+        mock_pipelines.__getitem__.side_effect = KeyError("nonexistent")
+        mock_pipelines.keys.return_value = ["__default__", "data_engineering"]
+        mock_runner.__name__ = "SequentialRunner"
+
+        with pytest.raises(ValueError):
+            with KedroSession.create(fake_project) as session:
+                session.run(runner=mock_runner, pipeline_name="nonexistent")
+
+        assert mock_pipelines.set_requested.call_args_list == [
+            mocker.call(["nonexistent"]),
+            mocker.call(None),
+        ]
+        mock_pipelines.keys.assert_called_once()
 
     @pytest.mark.usefixtures("mock_settings_context_class")
     @pytest.mark.parametrize("fake_pipeline_name", [None, _FAKE_PIPELINE_NAME])


### PR DESCRIPTION
## Summary

- Fix the ASV Benchmark workflow failure introduced when CI picked up [ASV 0.6.6](https://github.com/airspeed-velocity/asv/releases) (see [failed run](https://github.com/kedro-org/kedro/actions/runs/28378628221/job/84180612711)).
- ASV 0.6.6 requires exactly one wheel in the build cache, but the default `pip wheel` command without `--no-deps` saves all dependency wheels alongside `kedro`, causing: `Found multiple wheels ... Cannot decide correct one`.
- Add an explicit `build_command` with `--no-deps` to `asv.conf.json` and pin `asv>=0.6.6` in the benchmark workflow.

## Test plan

- [x] ASV Benchmark workflow passes on this PR
- [x] Verify only a single `kedro-*.whl` is written to the ASV build cache during the build step


Made with [Cursor](https://cursor.com)