### PR TITLE
Security skill: flag suppression comments

### DIFF
--- a/.agents/skills/kedro-security-review/SKILL.md
+++ b/.agents/skills/kedro-security-review/SKILL.md
@@ -406,7 +406,7 @@ None actionable. <count> false positives on pre-existing lines.
 
 ### Manual review checks
 <If all clean, one line:>
-All clean (config-dict consumers, env-var paths, path construction, subprocess/eval/exec/pickle/yaml/dynamic import).
+All clean (config-dict consumers, env-var paths, path construction, security suppression comments, subprocess/eval/exec/pickle/yaml/dynamic import).
 
 <Otherwise, only list the checks that flagged something, with reasoning.>
 

--- a/.agents/skills/kedro-security-review/reference.md
+++ b/.agents/skills/kedro-security-review/reference.md
@@ -104,6 +104,40 @@ outside Kedro's own defaults (CLI arg, env var, catalog config, API param):
 - Check whether `..` or absolute path segments are rejected before use
 - If not: `needs_manual_review` at minimum
 
+### 4. Security suppression comments
+
+Search scanned files for comments that suppress security scanner findings:
+- `# nosec` (Bandit)
+- `# nosemgrep` (Semgrep)
+- `# type: ignore[` used alongside a `nosec` or `nosemgrep` on the same line
+  (occasionally combined to silence both type-checker and security scanner)
+
+A suppression comment makes the flagged code invisible to the scanner. If the
+suppression is unjustified or outdated, it silently masks a real vulnerability.
+
+For every match, classify as `needs_manual_review` and ask the reviewer to
+verify:
+1. The suppression is still necessary — the underlying issue has not been
+   refactored away.
+2. The risk is documented — there is an adjacent comment explaining **why** the
+   suppression is safe.
+3. There is no code-level fix that would remove the need for suppression
+   entirely.
+
+**PR mode — new vs. pre-existing suppressions:**
+
+In PR mode, compare each hit against the PR diff (`gh pr diff <number>`).
+- A suppression whose line appears in the diff (added or modified) is a **new
+  suppression** — flag it with higher priority. New suppressions in a PR are
+  the primary concern: they indicate that a contributor is actively silencing a
+  scanner finding on code that is about to be merged.
+- A suppression on a line not in the diff is **pre-existing** — still flag it
+  as `needs_manual_review`, but note that it predates this PR so it may be
+  tracked separately (e.g. in a follow-up cleanup issue).
+
+In full-codebase mode, all suppressions are treated equally (there is no diff
+to distinguish new from old).
+
 ## General ruleset guidance
 
 ### `p/security-audit`

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 ## Major features and improvements
 ## Bug fixes and other changes
+* Added a security scan check that flags `# nosec` and `# nosemgrep` suppression comments for manual review.
 ## Documentation changes
 ## Community contributions
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,7 +1,6 @@
 # Upcoming Release
 ## Major features and improvements
 ## Bug fixes and other changes
-* Added a security scan check that flags `# nosec` and `# nosemgrep` suppression comments for manual review.
 ## Documentation changes
 ## Community contributions
 


### PR DESCRIPTION
## Description

Closes #5631

A follow-up PR (https://github.com/kedro-org/kedro/pull/5647) on top of this one fixes the findings from running the new check on the full codebase (two undocumented `# nosec` suppressions in the CLI).

## Development notes
- Add manual review check `Security suppression comments` to the `kedro-security-review` skill
- Searches scanned files for `# nosec` (Bandit) and `# nosemgrep` (Semgrep) suppression patterns and classifies each as `needs_manual_review`
- In PR mode, distinguishes new suppressions (in the diff) from pre-existing ones
- Update the report template's "all clean" line to include the new check

## How to test
- [x] Run security scan on full codebase — verify check fires on existing `# nosec` comments
- [x] Run security scan on a PR — verify new vs. pre-existing distinction works

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
