### PR TITLE
Fix mypy lint issue

### DIFF
--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -539,20 +539,15 @@ def _get_available_tags(template_path: str) -> list:
 
     try:
         tags = git.cmd.Git().ls_remote("--tags", template_path.replace("git+", ""))
-
-        if not isinstance(tags, str):
-            return []
-        
-        unique_tags = {
-            tag.split("/")[-1].replace("^{}", "") for tag in tags.split("\n")
-        }
-        # Remove git ref "^{}" and duplicates. For example,
-        # tags: ['/tags/version', '/tags/version^{}']
-        # unique_tags: {'version'}
-
     except git.GitCommandError:  # pragma: no cover
         return []
-    return sorted(unique_tags)
+
+    if not isinstance(tags, str):
+        return []
+    # Remove git ref "^{}" and duplicates. For example,
+    # tags: ['/tags/version', '/tags/version^{}']
+    # unique_tags: {'version'}
+    return sorted({tag.split("/")[-1].replace("^{}", "") for tag in tags.split("\n")})
 
 
 def _get_starters_dict() -> dict[str, KedroStarterSpec]:

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -540,6 +540,9 @@ def _get_available_tags(template_path: str) -> list:
     try:
         tags = git.cmd.Git().ls_remote("--tags", template_path.replace("git+", ""))
 
+        if not isinstance(tags, str):
+            return []
+        
         unique_tags = {
             tag.split("/")[-1].replace("^{}", "") for tag in tags.split("\n")
         }

--- a/kedro/pipeline/node.py
+++ b/kedro/pipeline/node.py
@@ -630,7 +630,7 @@ class Node:
                     f"do not match with the returned output's keys {set(keys)}."
                 )
             if iterator:
-                exploded = map(lambda x: tuple(x[k] for k in keys), iterator)
+                exploded = map(lambda x: tuple(x[k] for k in keys), iterator)  # type: ignore[index]
                 result = unzip(exploded)
             else:
                 # evaluate this eagerly so we can reuse variable name
@@ -659,7 +659,7 @@ class Node:
                 )
 
             if iterator:
-                result = unzip(iterator)
+                result = unzip(iterator)  # type: ignore[arg-type]
             return dict(zip(self._outputs, result))
 
         if self._outputs is None:

--- a/tests/framework/cli/starters/test_starters_flow.py
+++ b/tests/framework/cli/starters/test_starters_flow.py
@@ -223,7 +223,16 @@ class TestNewWithStarterInvalid:
             ),
         ],
     )
-    def test_invalid_checkout(self, starter, repo, fake_kedro_cli):
+    @pytest.mark.parametrize(
+        "ls_remote_return, expected_tags",
+        [
+            ("tag1\ntag2", "tag1, tag2"),
+            (b"tag1\ntag2", ""),
+        ],
+    )
+    def test_invalid_checkout(
+        self, starter, repo, ls_remote_return, expected_tags, fake_kedro_cli
+    ):
         """Test invalid checkout with mocked git interactions."""
         with (
             patch(
@@ -233,7 +242,7 @@ class TestNewWithStarterInvalid:
             patch("git.cmd.Git") as mock_git,
         ):
             mock_ls_remote = mock_git.return_value.ls_remote
-            mock_ls_remote.return_value = "tag1\ntag2"
+            mock_ls_remote.return_value = ls_remote_return
             result = CliRunner().invoke(
                 fake_kedro_cli,
                 ["new", "-v", "--starter", starter, "--checkout", "invalid"],
@@ -241,7 +250,7 @@ class TestNewWithStarterInvalid:
             )
             assert result.exit_code != 0
             assert (
-                "Specified tag invalid. The following tags are available: tag1, tag2"
+                f"Specified tag invalid. The following tags are available: {expected_tags}"
                 in result.output
             )
             mock_ls_remote.assert_called_with("--tags", repo)


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix https://github.com/kedro-org/kedro/issues/5661
Fix https://github.com/kedro-org/kedro/issues/5658

## Development notes
<!-- What have you changed, and how has this been tested? -->
Fixed lint failures because of `mypy` release:
- Add check for `str` type on `tags` in `framework/cli/starters.py`
- Update test for coverage
- Type ignore for `node.py` 

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
