### PR TITLE
Add the node's function name to NodeSnapshot

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,5 +1,7 @@
 # Upcoming Release
 ## Major features and improvements
+* Added the node function name to project inspection snapshots as `NodeSnapshot.func_name`.
+
 ## Bug fixes and other changes
 ## Documentation changes
 ## Community contributions

--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -81,6 +81,7 @@ curl http://127.0.0.1:8000/snapshot
       "nodes": [
         {
           "name": "split_data_node",
+          "func_name": "split_data",
           "inputs": ["example_iris_data"],
           "outputs": ["X_train", "X_test"],
           "tags": [],

--- a/docs/inspect/inspect-project.md
+++ b/docs/inspect/inspect-project.md
@@ -90,13 +90,14 @@ default_pipeline = next(p for p in snapshot.pipelines if p.name == "__default__"
 
 for node in default_pipeline.nodes:
     print(node.name)
+    print("  func_name:", node.func_name)
     print("  namespace:", node.namespace)
     print("  inputs:   ", node.inputs)
     print("  outputs:  ", node.outputs)
     print("  tags:     ", node.tags)
 ```
 
-Each node is represented as a [`NodeSnapshot`][kedro.inspection.models.NodeSnapshot] with `name`, `namespace`, `inputs`, `outputs`, and `tags` fields.
+Each node is represented as a [`NodeSnapshot`][kedro.inspection.models.NodeSnapshot] with `name`, `func_name`, `namespace`, `inputs`, `outputs`, and `tags` fields.
 
 ## How to inspect catalog datasets
 

--- a/kedro/inspection/models.py
+++ b/kedro/inspection/models.py
@@ -65,7 +65,7 @@ class NodeSnapshot:
     """
 
     name: str
-    func_name: str
+    func_name: str = field(kw_only=True)
     namespace: str | None = None
     tags: list[str] = field(default_factory=list)
     inputs: list[str] = field(default_factory=list)

--- a/kedro/inspection/models.py
+++ b/kedro/inspection/models.py
@@ -57,6 +57,7 @@ class NodeSnapshot:
 
     Attributes:
         name: Fully-qualified node name (includes namespace prefix if present).
+        func_name: Readable name of the node's underlying function.
         namespace: Node namespace, or ``None`` if the node has no namespace.
         tags: Sorted list of tags assigned to the node.
         inputs: Ordered list of input dataset names.
@@ -64,6 +65,7 @@ class NodeSnapshot:
     """
 
     name: str
+    func_name: str
     namespace: str | None = None
     tags: list[str] = field(default_factory=list)
     inputs: list[str] = field(default_factory=list)

--- a/kedro/inspection/snapshot.py
+++ b/kedro/inspection/snapshot.py
@@ -79,7 +79,7 @@ def _node_to_snapshot(node: Node) -> NodeSnapshot:
     """
     return NodeSnapshot(
         name=node.name,
-        func_name=node._func_name,
+        func_name=node._func_name,  # Matches Node.__str__ and registry describe.
         namespace=node.namespace,
         tags=sorted(node.tags),
         inputs=node.inputs,

--- a/kedro/inspection/snapshot.py
+++ b/kedro/inspection/snapshot.py
@@ -79,6 +79,7 @@ def _node_to_snapshot(node: Node) -> NodeSnapshot:
     """
     return NodeSnapshot(
         name=node.name,
+        func_name=node._func_name,
         namespace=node.namespace,
         tags=sorted(node.tags),
         inputs=node.inputs,

--- a/tests/inspection/test_helper.py
+++ b/tests/inspection/test_helper.py
@@ -12,7 +12,7 @@ from kedro.inspection.models import DatasetSnapshot, NodeSnapshot, PipelineSnaps
 
 
 def _make_node_snapshot(inputs: list[str], outputs: list[str]) -> NodeSnapshot:
-    return NodeSnapshot(name="n", inputs=inputs, outputs=outputs)
+    return NodeSnapshot(name="n", func_name="identity", inputs=inputs, outputs=outputs)
 
 
 def _make_pipeline_snapshot(nodes: list[NodeSnapshot]) -> PipelineSnapshot:

--- a/tests/inspection/test_node_pipeline_snapshot.py
+++ b/tests/inspection/test_node_pipeline_snapshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from functools import partial
+
 import pytest
 
 from kedro.inspection.models import NodeSnapshot, PipelineSnapshot
@@ -50,6 +52,11 @@ class TestNodeSnapshot:
         assert snapshot.inputs == []
         assert snapshot.outputs == []
 
+    def test_func_name_is_keyword_only(self):
+        snapshot = NodeSnapshot("my_node", "my_namespace", func_name="my_func")
+        assert snapshot.func_name == "my_func"
+        assert snapshot.namespace == "my_namespace"
+
 
 class TestNodeToSnapshot:
     def test_populates_all_fields(self, simple_node):
@@ -70,6 +77,20 @@ class TestNodeToSnapshot:
 
     def test_returns_node_snapshot_instance(self, simple_node):
         assert isinstance(_node_to_snapshot(simple_node), NodeSnapshot)
+
+    def test_named_partial_func_name_warns(self):
+        partial_node = node(
+            partial(_identity),
+            inputs="raw",
+            outputs="processed",
+            name="partial_node",
+        )
+
+        with pytest.warns(UserWarning, match="made from a 'partial' function"):
+            snapshot = _node_to_snapshot(partial_node)
+
+        assert snapshot.name == "partial_node"
+        assert snapshot.func_name == "<partial>"
 
 
 class TestPipelineSnapshot:

--- a/tests/inspection/test_node_pipeline_snapshot.py
+++ b/tests/inspection/test_node_pipeline_snapshot.py
@@ -42,8 +42,9 @@ def simple_pipeline(simple_node):
 
 class TestNodeSnapshot:
     def test_instantiation_defaults(self):
-        snapshot = NodeSnapshot(name="my_node")
+        snapshot = NodeSnapshot(name="my_node", func_name="my_func")
         assert snapshot.name == "my_node"
+        assert snapshot.func_name == "my_func"
         assert snapshot.namespace is None
         assert snapshot.tags == []
         assert snapshot.inputs == []
@@ -54,6 +55,7 @@ class TestNodeToSnapshot:
     def test_populates_all_fields(self, simple_node):
         snapshot = _node_to_snapshot(simple_node)
         assert snapshot.name == simple_node.name
+        assert snapshot.func_name == "_identity"
         assert snapshot.namespace == simple_node.namespace
         assert snapshot.inputs == simple_node.inputs
         assert snapshot.outputs == simple_node.outputs
@@ -72,7 +74,9 @@ class TestNodeToSnapshot:
 
 class TestPipelineSnapshot:
     def test_instantiation(self):
-        node_snap = NodeSnapshot(name="n", inputs=["a"], outputs=["b"])
+        node_snap = NodeSnapshot(
+            name="n", func_name="identity", inputs=["a"], outputs=["b"]
+        )
         snapshot = PipelineSnapshot(name="my_pipe", nodes=[node_snap])
         assert snapshot.name == "my_pipe"
         assert snapshot.nodes == [node_snap]

--- a/tests/inspection/test_node_pipeline_snapshot.py
+++ b/tests/inspection/test_node_pipeline_snapshot.py
@@ -57,6 +57,9 @@ class TestNodeSnapshot:
         assert snapshot.func_name == "my_func"
         assert snapshot.namespace == "my_namespace"
 
+        with pytest.raises(TypeError, match="func_name"):
+            NodeSnapshot("my_node", "my_namespace")
+
 
 class TestNodeToSnapshot:
     def test_populates_all_fields(self, simple_node):

--- a/tests/inspection/test_project_snapshot.py
+++ b/tests/inspection/test_project_snapshot.py
@@ -43,6 +43,7 @@ def metadata_snapshot():
 def node_snapshot():
     return NodeSnapshot(
         name="node_a",
+        func_name="process_companies",
         inputs=["companies"],
         outputs=["processed_companies"],
     )

--- a/tests/server/test_snapshot_endpoint.py
+++ b/tests/server/test_snapshot_endpoint.py
@@ -23,6 +23,7 @@ def _make_snapshot() -> ProjectSnapshot:
                 nodes=[
                     NodeSnapshot(
                         name="my_node",
+                        func_name="process_data",
                         namespace="ns",
                         tags=["tag1"],
                         inputs=["raw_data"],
@@ -76,6 +77,7 @@ class TestSnapshotEndpoint:
         assert len(pipelines) == 1
         assert pipelines[0]["name"] == "__default__"
         assert pipelines[0]["nodes"][0]["name"] == "my_node"
+        assert pipelines[0]["nodes"][0]["func_name"] == "process_data"
 
         assert "raw_data" in payload["datasets"]
         assert payload["datasets"]["raw_data"]["type"] == "pandas.CSVDataset"


### PR DESCRIPTION
## Description

Fixes #5653.

`get_project_snapshot` exposes each node's `name`, `namespace`, `tags`, `inputs` and `outputs`, but not the name of the underlying function. Kedro-Viz needs the function name when reading the graph from the snapshot instead of a live `KedroSession` (kedro-org/kedro-viz#2265):

- to reconstruct its existing node IDs, which are a hash of the node's string form (which includes the function name), avoiding a breaking change for anything keyed on those IDs

## Development notes

- Added `func_name: str` to `NodeSnapshot`, populated in `_node_to_snapshot` from `Node._func_name`, the readable function name Kedro already derives internally (the same one `kedro registry describe` prints). The value is available at snapshot-build time, so no extra project loading is needed.
- Updated the inspection docs (`NodeSnapshot` field list and example) and the `GET /snapshot` example response in the serving docs.
- Tests: extended the `NodeSnapshot` instantiation and `_node_to_snapshot` tests, and the snapshot endpoint test now asserts `func_name` appears in the JSON payload.

**Note on the constructor:** `func_name` is added as a required field, second in `NodeSnapshot`, so it sits next to `name` in serialized output. This changes the signature for any code that constructs `NodeSnapshot` positionally, likely rare, since snapshots are produced by Kedro and all internal call sites use keyword arguments. Happy to make it keyword-only (`field(kw_only=True)`) or give it a default if preferred.


## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
