### PR TITLE
fix: deduplicate get_close_matches suggestions and support iterator targets

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 * Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 ## Documentation changes
 ## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
+* [eeshsaxena](https://github.com/eeshsaxena)
 
 # Release 1.5.0
 ## Major features and improvements

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,6 +1,7 @@
 # Upcoming Release
 ## Major features and improvements
 ## Bug fixes and other changes
+* Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 ## Documentation changes
 ## Community contributions
 

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -279,19 +279,21 @@ def get_close_matches(
     Returns:
         List of close matches or empty list if no matches are found.
     """
-    _init_matches = []
-    if isinstance(input, str):
-        matches = difflib.get_close_matches(
-            input, list(targets), n=max_suggestions, cutoff=cutoff
-        )
-        _init_matches.extend(matches)
-    else:
-        for source_str in input:
-            _matches = difflib.get_close_matches(
-                source_str, list(targets), n=max_suggestions, cutoff=cutoff
-            )
-            _init_matches.extend(_matches)
-    return _init_matches[:max_suggestions]
+    # Materialize once: `targets` may be a one-shot iterable, and it is reused
+    # for every input string below.
+    targets = list(targets)
+    inputs = [input] if isinstance(input, str) else input
+
+    matches: list[str] = []
+    for source_str in inputs:
+        for match in difflib.get_close_matches(
+            source_str, targets, n=max_suggestions, cutoff=cutoff
+        ):
+            # Deduplicate while preserving order: different inputs can match the
+            # same target, which would otherwise repeat it in the suggestions.
+            if match not in matches:
+                matches.append(match)
+    return matches[:max_suggestions]
 
 
 def find_config_file(

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -285,13 +285,16 @@ def get_close_matches(
     inputs = [input] if isinstance(input, str) else input
 
     matches: list[str] = []
+    seen: set[str] = set()
     for source_str in inputs:
         for match in difflib.get_close_matches(
             source_str, targets, n=max_suggestions, cutoff=cutoff
         ):
             # Deduplicate while preserving order: different inputs can match the
             # same target, which would otherwise repeat it in the suggestions.
-            if match not in matches:
+            # A `seen` set keeps the membership check O(1).
+            if match not in seen:
+                seen.add(match)
                 matches.append(match)
     return matches[:max_suggestions]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -42,9 +42,9 @@ class TestGetCloseMatches:
         assert result == ["pipeline"]
 
     def test_list_input_accepts_one_shot_iterator_targets(self):
-        # `targets` is typed as an Iterable; a generator must not be exhausted
-        # after matching the first input string.
-        targets = (name for name in ["data_science", "data_engineering"])
+        # `targets` is typed as an Iterable; a one-shot iterator must not be
+        # exhausted after matching the first input string.
+        targets = iter(["data_science", "data_engineering"])
         result = get_close_matches(["data_scnce", "data_enginering"], targets)
         assert result == ["data_science", "data_engineering"]
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -35,6 +35,19 @@ class TestGetCloseMatches:
         print(result)
         assert result == ["data_science", "data_engineering"]
 
+    def test_list_input_deduplicates_shared_matches(self):
+        # Two misspellings that both resolve to the same target should suggest
+        # that target only once, not repeat it.
+        result = get_close_matches(["pipelin", "pipeine"], ["pipeline", "catalog"])
+        assert result == ["pipeline"]
+
+    def test_list_input_accepts_one_shot_iterator_targets(self):
+        # `targets` is typed as an Iterable; a generator must not be exhausted
+        # after matching the first input string.
+        targets = (name for name in ["data_science", "data_engineering"])
+        result = get_close_matches(["data_scnce", "data_enginering"], targets)
+        assert result == ["data_science", "data_engineering"]
+
 
 class TestExtractObject:
     def test_load_obj(self):


### PR DESCRIPTION
## Description

`get_close_matches` (in `kedro/utils.py`) has two issues when it receives a **list** of inputs:

1. **Duplicate suggestions.** Matches are collected per input and concatenated, so a target matched by more than one input is repeated. This surfaces in the user-facing "did you mean one of these instead: ..." text of `PipelineError` (via `_validate_datasets_exist` in `kedro/pipeline/pipeline.py`). For example:

   ```python
   get_close_matches(["pipelin", "pipeine"], ["pipeline", "catalog"])
   # ['pipeline', 'pipeline']   <- 'pipeline' repeated
   ```

2. **`targets` iterable can be exhausted.** `targets` is typed as `Iterable[str]`, but `list(targets)` was called once *per input* inside the loop. A one-shot iterable (e.g. a generator) is consumed on the first input, so later inputs match against an empty list and silently return nothing.

## Development notes

- Materialize `targets = list(targets)` once, before iterating the inputs.
- Deduplicate matches while preserving order (first-seen), so shared matches appear only once.
- Unified the `str` and `list` input handling; single-string behaviour is unchanged (a single `difflib.get_close_matches` call already returns unique, score-ordered results).

Testing:
- Added two regression tests to `TestGetCloseMatches` in `tests/test_utils.py`: one asserting shared matches are deduplicated, one passing a generator as `targets`. Both fail on `main` and pass with this change; the existing string/list tests still pass (`pytest tests/test_utils.py -k GetCloseMatches` -> 4 passed).
- Added a `RELEASE.md` entry under "Bug fixes and other changes".

An AI assistant helped spot and implement this; I reviewed the change and ran the tests locally.

## Checklist

- [x] Read the contributing guidelines
- [x] Signed off each commit with a Developer Certificate of Origin (DCO)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the `RELEASE.md` file
- [x] Added tests to cover my changes
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
