### PR TITLE
fix: exclude kedro_benchmarks from packaging (wheel shipped benchmark tests)

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,8 @@
 * Added the node function name to project inspection snapshots as `NodeSnapshot.func_name`.
 
 ## Bug fixes and other changes
+* Excluded `kedro_benchmarks` from the built wheel so benchmark tests are no longer shipped with the package.
+
 ## Documentation changes
 ## Community contributions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ zip-safe = false
 
 [tool.setuptools.packages.find]
 include = ["kedro*"]
+exclude = ["kedro_benchmarks*"]
 
 [tool.setuptools.package-data]
 kedro = ["py.typed"]


### PR DESCRIPTION
Fixes #5604

## Description
`pip install kedro` currently ships the `kedro_benchmarks` package in the wheel: the `include = ["kedro*"]` glob in `[tool.setuptools.packages.find]` also matches `kedro_benchmarks`. This PR adds an explicit `exclude = ["kedro_benchmarks*"]` so benchmark tests are no longer packaged.

## Development notes
- One-line change in `pyproject.toml`, plus a `RELEASE.md` entry.
- Tested by building the wheel (`python -m build --wheel`) before and after the change:
  - before: the wheel contains 8 `kedro_benchmarks/*` files;
  - after: none.
- No runtime code is touched, so no unit tests were added; the change is exercised by the build itself.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes (not needed: packaging config only)
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes (no runtime code changed; verified by building the wheel before/after)
- [x] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team (no impact)
