### PR TITLE
Clarify kedro new tools flag hint

### DIFF
--- a/docs/create/new_project.md
+++ b/docs/create/new_project.md
@@ -47,7 +47,9 @@ Which tools would you like to include in your project? [1-6/1,3/all/none]:
 
 The options are described in more detail in the [documentation about the new project tools](./new_project_tools.md).
 
-Select the tools by number, or `all` or follow the default to add `none`.
+Select the tools by number, or `all`, or follow the default to add `none`.
+When using the `--tools` CLI flag instead of the interactive prompt, specify tools by
+name, for example `--tools=lint,test`, or use `--tools=all` or `--tools=none`.
 
 ### Project examples
 

--- a/docs/create/new_project_tools.md
+++ b/docs/create/new_project_tools.md
@@ -42,7 +42,8 @@ You are then asked to select which tools to include. Choose from the list using 
 Project Tools
 =============
 These optional tools can help you apply software engineering best practices.
-To skip this step in future use --tools
+To skip this step in future use --tools with tool names, for example
+--tools=lint,test, or use --tools=all or --tools=none
 To find out more: https://docs.kedro.org/en/stable/create/new_project_tools/
 
 Tools
@@ -98,7 +99,11 @@ To skip this step and select tools directly, add the tools selection to `kedro n
 uvx kedro new --tools=<your tool selection>
 ```
 
-To specify your desired tools you must provide them by name as a comma separated list, for example `--tools=lint,test`. The following tools are available for selection: `lint`, `test`, `log`, `docs`, `data`, and `pyspark`.
+To specify your desired tools you must provide them by name as a comma separated list,
+for example `--tools=lint,test`. The following tools are available for selection:
+`lint`, `test`, `log`, `docs`, `data`, and `pyspark`. You can also use `--tools=all`
+or `--tools=none`. The numeric selections shown in the interactive prompt only apply
+when answering that prompt.
 
 ### Example code
 In the final step you are asked whether you want to populate the project with an example spaceflights starter pipeline. If you select `yes`, the example code included depends upon your previous choice of tools, as follows:

--- a/docs/create/new_project_tools.md
+++ b/docs/create/new_project_tools.md
@@ -102,8 +102,8 @@ uvx kedro new --tools=<your tool selection>
 To specify your desired tools you must provide them by name as a comma separated list,
 for example `--tools=lint,test`. The following tools are available for selection:
 `lint`, `test`, `log`, `docs`, `data`, and `pyspark`. You can also use `--tools=all`
-or `--tools=none`. The numeric selections shown in the interactive prompt only apply
-when answering that prompt.
+or `--tools=none`. The numeric selections shown in the interactive prompt apply
+when answering the prompt.
 
 ### Example code
 In the final step you are asked whether you want to populate the project with an example spaceflights starter pipeline. If you select `yes`, the example code included depends upon your previous choice of tools, as follows:

--- a/kedro/framework/cli/starters.py
+++ b/kedro/framework/cli/starters.py
@@ -275,7 +275,9 @@ def _print_selection_and_prompt_info(
     if interactive:
         click.secho(
             "\nTo skip the interactive flow you can run `kedro new` with"
-            "\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>",
+            "\ntool names for `--tools`, or `all`/`none`:"
+            "\nkedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>",
             fg="green",
         )
 

--- a/kedro/templates/project/prompts.yml
+++ b/kedro/templates/project/prompts.yml
@@ -13,7 +13,8 @@ tools:
   title: "Project Tools"
   text: |
     These optional tools can help you apply software engineering best practices.
-    To skip this step in future use --tools
+    To skip this step in future use --tools with tool names, for example
+    --tools=lint,test, or use --tools=all or --tools=none
     To find out more: https://docs.kedro.org/en/stable/create/new_project_tools/#tools-to-customise-a-new-kedro-project
 
     Tools

--- a/tests/framework/cli/starters/test_new_from_cli_flags.py
+++ b/tests/framework/cli/starters/test_new_from_cli_flags.py
@@ -43,7 +43,10 @@ class TestToolsAndExampleFromCLI:
         else:
             assert "You have selected no project tools" in result.output
         assert (
-            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            "To skip the interactive flow you can run `kedro new` with\n"
+            "tool names for `--tools`, or `all`/`none`:\n"
+            "kedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>"
             in result.output
         )
 
@@ -93,7 +96,10 @@ class TestToolsAndExampleFromCLI:
 
         assert result.exit_code == 0
         assert (
-            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            "To skip the interactive flow you can run `kedro new` with\n"
+            "tool names for `--tools`, or `all`/`none`:\n"
+            "kedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>"
             not in result.output
         )
 

--- a/tests/framework/cli/starters/test_new_from_config_file.py
+++ b/tests/framework/cli/starters/test_new_from_config_file.py
@@ -218,7 +218,10 @@ class TestToolsAndExampleFromConfigFile:
         else:
             assert "You have selected no project tools" in result.output
         assert (
-            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            "To skip the interactive flow you can run `kedro new` with\n"
+            "tool names for `--tools`, or `all`/`none`:\n"
+            "kedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>"
             not in result.output
         )
 

--- a/tests/framework/cli/starters/test_new_from_prompts.py
+++ b/tests/framework/cli/starters/test_new_from_prompts.py
@@ -256,7 +256,10 @@ class TestToolsAndExampleFromUserPrompts:
         else:
             assert "You have selected no project tools" in result.output
         assert (
-            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            "To skip the interactive flow you can run `kedro new` with\n"
+            "tool names for `--tools`, or `all`/`none`:\n"
+            "kedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>"
             in result.output
         )
 

--- a/tests/framework/cli/starters/test_starters_flow.py
+++ b/tests/framework/cli/starters/test_starters_flow.py
@@ -196,7 +196,10 @@ class TestNewWithStarterValid:
             input=_make_cli_prompt_input(),
         )
         assert (
-            "To skip the interactive flow you can run `kedro new` with\nkedro new --name=<your-project-name> --tools=<your-project-tools> --example=<yes/no>"
+            "To skip the interactive flow you can run `kedro new` with\n"
+            "tool names for `--tools`, or `all`/`none`:\n"
+            "kedro new --name=<your-project-name> "
+            "--tools=lint,test,log,docs,data,pyspark --example=<yes/no>"
             not in result.output
         )
         assert "You have selected" not in result.output


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->

Fixes #3735.

Clarifies the `kedro new` hint and documentation for `--tools`. The CLI flag now shows tool-name values such as `lint,test,log,docs,data,pyspark`, plus `all` and `none`, instead of the placeholder `--tools=<your-project-tools>`.

## Development notes
<!-- What have you changed, and how has this been tested? -->

Updated the `kedro new` interactive skip hint, the project prompt text, and the docs for new project tools to explain that numeric selections apply to the interactive prompt, while `--tools` expects tool names or `all`/`none`.

Updated starter CLI tests that asserted the previous hint text.

Tested with:

- Targeted starter CLI tests: `257 passed`
- Ruff format hook
- Ruff hook
- `prompts.yml` YAML parse check
- `git diff --check`

## Developer Certificate of Origin


## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team