### PR TITLE
Add node source to inspection snapshot

### DIFF
--- a/kedro/inspection/models.py
+++ b/kedro/inspection/models.py
@@ -52,6 +52,21 @@ class DatasetSnapshot:
 
 
 @dataclass
+class NodeSourceSnapshot:
+    """Read-only snapshot of a pipeline node's function source location.
+
+    Attributes:
+        filepath: Source file containing the node function definition.
+        line_start: First line of the node function definition.
+        line_end: Last line of the node function definition.
+    """
+
+    filepath: str
+    line_start: int
+    line_end: int
+
+
+@dataclass
 class NodeSnapshot:
     """Read-only snapshot of a single pipeline node.
 
@@ -62,6 +77,7 @@ class NodeSnapshot:
         tags: Sorted list of tags assigned to the node.
         inputs: Ordered list of input dataset names.
         outputs: Ordered list of output dataset names.
+        source: Source location of the node function, or ``None`` when unavailable.
     """
 
     name: str
@@ -70,6 +86,7 @@ class NodeSnapshot:
     tags: list[str] = field(default_factory=list)
     inputs: list[str] = field(default_factory=list)
     outputs: list[str] = field(default_factory=list)
+    source: NodeSourceSnapshot | None = None
 
 
 @dataclass

--- a/kedro/inspection/snapshot.py
+++ b/kedro/inspection/snapshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import functools
+import inspect
 import re
 import warnings
 from pathlib import Path
@@ -18,6 +20,7 @@ from kedro.inspection.helper import (
 from kedro.inspection.models import (
     DatasetSnapshot,
     NodeSnapshot,
+    NodeSourceSnapshot,
     PipelineSnapshot,
     ProjectMetadataSnapshot,
     ProjectSnapshot,
@@ -29,6 +32,47 @@ if TYPE_CHECKING:
 
 
 _ENV_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _get_source_callable(func: Any) -> Any:
+    """Return the callable whose source best represents a node function."""
+    source_func = inspect.unwrap(func)
+    while isinstance(source_func, functools.partial):
+        source_func = inspect.unwrap(source_func.func)
+    return source_func
+
+
+def _format_source_filepath(source_file: str, project_path: Path | None) -> str:
+    source_path = Path(source_file).resolve()
+    if project_path is None:
+        return str(source_path)
+
+    try:
+        return str(source_path.relative_to(project_path.resolve()))
+    except ValueError:
+        return str(source_path)
+
+
+def _get_node_source_snapshot(
+    node: Node, project_path: Path | None = None
+) -> NodeSourceSnapshot | None:
+    """Build a source-location snapshot for a node function when inspectable."""
+    try:
+        source_func = _get_source_callable(node.func)
+        if getattr(source_func, "__name__", None) == "<lambda>":
+            return None
+        source_file = inspect.getsourcefile(source_func)
+        if source_file is None:
+            return None
+        source_lines, line_start = inspect.getsourcelines(source_func)
+    except (OSError, TypeError, ValueError):
+        return None
+
+    return NodeSourceSnapshot(
+        filepath=_format_source_filepath(source_file, project_path),
+        line_start=line_start,
+        line_end=line_start + len(source_lines) - 1,
+    )
 
 
 def _build_project_metadata_snapshot(
@@ -68,11 +112,12 @@ def _build_dataset_snapshots(
     }
 
 
-def _node_to_snapshot(node: Node) -> NodeSnapshot:
+def _node_to_snapshot(node: Node, project_path: Path | None = None) -> NodeSnapshot:
     """Convert a live ``Node`` object to a ``NodeSnapshot``.
 
     Args:
         node: A Kedro pipeline node.
+        project_path: Project root path used to relativise source file paths.
 
     Returns:
         Read-only snapshot of the node's structural metadata.
@@ -84,17 +129,19 @@ def _node_to_snapshot(node: Node) -> NodeSnapshot:
         tags=sorted(node.tags),
         inputs=node.inputs,
         outputs=node.outputs,
+        source=_get_node_source_snapshot(node, project_path),
     )
 
 
 def _build_pipeline_snapshots(
-    pipeline_dict: dict[str, Any],
+    pipeline_dict: dict[str, Any], project_path: Path | None = None
 ) -> list[PipelineSnapshot]:
     """Build a ``PipelineSnapshot`` for every registered pipeline.
 
     Args:
         pipeline_dict: Dictionary of pipeline name to ``Pipeline`` object,
             as returned by ``dict(kedro.framework.project.pipelines)``.
+        project_path: Project root path used to relativise source file paths.
 
     Returns:
         List of pipeline snapshots in registry iteration order.
@@ -106,7 +153,9 @@ def _build_pipeline_snapshots(
         snapshots.append(
             PipelineSnapshot(
                 name=pipeline_id,
-                nodes=[_node_to_snapshot(_node) for _node in pipeline.nodes],
+                nodes=[
+                    _node_to_snapshot(_node, project_path) for _node in pipeline.nodes
+                ],
                 inputs=sorted(pipeline.inputs()),
                 outputs=sorted(pipeline.outputs()),
             )
@@ -177,7 +226,9 @@ def _build_project_snapshot(
         conf_catalog = {}
 
     metadata_snapshot = _build_project_metadata_snapshot(metadata)
-    pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))
+    pipeline_snapshots = _build_pipeline_snapshots(
+        dict(pipelines), effective_project_path
+    )
     dataset_snapshots = _build_dataset_snapshots(conf_catalog)
 
     # resolve factory patterns

--- a/tests/inspection/test_node_pipeline_snapshot.py
+++ b/tests/inspection/test_node_pipeline_snapshot.py
@@ -2,17 +2,41 @@
 
 from __future__ import annotations
 
+import importlib.util
+import inspect
 from functools import partial
+from pathlib import Path
 
 import pytest
 
-from kedro.inspection.models import NodeSnapshot, PipelineSnapshot
+from kedro.inspection.models import NodeSnapshot, NodeSourceSnapshot, PipelineSnapshot
 from kedro.inspection.snapshot import _build_pipeline_snapshots, _node_to_snapshot
 from kedro.pipeline import Pipeline, node
 
 
 def _identity(x):
     return x
+
+
+def _load_external_function(tmp_path):
+    module_path = tmp_path / "external_nodes.py"
+    module_path.write_text(
+        "def external_identity(x):\n    return x\n",
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "external_nodes_for_inspection", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.external_identity, module_path
+
+
+@pytest.fixture
+def project_root():
+    return Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -51,6 +75,7 @@ class TestNodeSnapshot:
         assert snapshot.tags == []
         assert snapshot.inputs == []
         assert snapshot.outputs == []
+        assert snapshot.source is None
 
     def test_func_name_is_keyword_only(self):
         snapshot = NodeSnapshot("my_node", "my_namespace", func_name="my_func")
@@ -59,6 +84,18 @@ class TestNodeSnapshot:
 
         with pytest.raises(TypeError, match="func_name"):
             NodeSnapshot("my_node", "my_namespace")
+
+
+class TestNodeSourceSnapshot:
+    def test_instantiation(self):
+        snapshot = NodeSourceSnapshot(
+            filepath="src/my_package/pipeline.py",
+            line_start=10,
+            line_end=12,
+        )
+        assert snapshot.filepath == "src/my_package/pipeline.py"
+        assert snapshot.line_start == 10
+        assert snapshot.line_end == 12
 
 
 class TestNodeToSnapshot:
@@ -95,6 +132,69 @@ class TestNodeToSnapshot:
         assert snapshot.name == "partial_node"
         assert snapshot.func_name == "<partial>"
 
+    def test_source_populated_for_normal_function(self, simple_node, project_root):
+        snapshot = _node_to_snapshot(simple_node, project_path=project_root)
+        lines, line_start = inspect.getsourcelines(_identity)
+
+        assert snapshot.source == NodeSourceSnapshot(
+            filepath=str(Path(__file__).resolve().relative_to(project_root)),
+            line_start=line_start,
+            line_end=line_start + len(lines) - 1,
+        )
+
+    def test_source_populated_for_partial(self, project_root):
+        partial_node = node(
+            partial(_identity),
+            inputs="raw",
+            outputs="processed",
+            name="partial_node",
+        )
+
+        with pytest.warns(UserWarning, match="made from a 'partial' function"):
+            snapshot = _node_to_snapshot(partial_node, project_path=project_root)
+        lines, line_start = inspect.getsourcelines(_identity)
+
+        assert snapshot.source == NodeSourceSnapshot(
+            filepath=str(Path(__file__).resolve().relative_to(project_root)),
+            line_start=line_start,
+            line_end=line_start + len(lines) - 1,
+        )
+
+    def test_source_is_none_for_uninspectable_callable(self):
+        len_node = node(len, inputs="raw", outputs="processed", name="len_node")
+
+        snapshot = _node_to_snapshot(len_node)
+
+        assert snapshot.source is None
+
+    def test_source_is_none_for_lambda(self):
+        lambda_node = node(
+            lambda raw: raw,
+            inputs="raw",
+            outputs="processed",
+            name="lambda_node",
+        )
+
+        snapshot = _node_to_snapshot(lambda_node)
+
+        assert snapshot.source is None
+
+    def test_source_uses_absolute_filepath_outside_project(
+        self, tmp_path, project_root
+    ):
+        external_func, module_path = _load_external_function(tmp_path)
+        external_node = node(
+            external_func,
+            inputs="raw",
+            outputs="processed",
+            name="external_node",
+        )
+
+        snapshot = _node_to_snapshot(external_node, project_path=project_root)
+
+        assert snapshot.source is not None
+        assert snapshot.source.filepath == str(module_path.resolve())
+
 
 class TestPipelineSnapshot:
     def test_instantiation(self):
@@ -127,6 +227,16 @@ class TestBuildPipelineSnapshots:
         snapshots = _build_pipeline_snapshots({"__default__": simple_pipeline})
         assert snapshots[0].inputs == sorted(simple_pipeline.inputs())
         assert snapshots[0].outputs == sorted(simple_pipeline.outputs())
+
+    def test_nodes_receive_project_relative_source(self, simple_pipeline, project_root):
+        snapshots = _build_pipeline_snapshots(
+            {"__default__": simple_pipeline}, project_path=project_root
+        )
+
+        assert snapshots[0].nodes[0].source is not None
+        assert snapshots[0].nodes[0].source.filepath == str(
+            Path(__file__).resolve().relative_to(project_root)
+        )
 
     def test_empty_registry_returns_empty_list(self):
         assert _build_pipeline_snapshots({}) == []

--- a/tests/inspection/test_project_snapshot.py
+++ b/tests/inspection/test_project_snapshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from kedro.config import MissingConfigException
@@ -138,7 +140,7 @@ class TestBuildProjectSnapshot:
             "kedro.inspection.snapshot.pipelines",
             new={},
         )
-        mocker.patch(
+        self.mock_build_pipeline_snapshots = mocker.patch(
             "kedro.inspection.snapshot._build_pipeline_snapshots",
             return_value=self.pipeline_snapshots,
         )
@@ -171,6 +173,12 @@ class TestBuildProjectSnapshot:
     def test_pipelines_populated(self):
         result = _build_project_snapshot(self.project_path)
         assert result.pipelines is self.pipeline_snapshots
+
+    def test_pipeline_snapshots_built_with_project_path(self):
+        _build_project_snapshot(self.project_path)
+        self.mock_build_pipeline_snapshots.assert_called_once_with(
+            {}, self.project_path
+        )
 
     def test_datasets_populated(self):
         result = _build_project_snapshot(self.project_path)
@@ -298,8 +306,6 @@ class TestBuildProjectSnapshot:
             _build_project_snapshot(different_path, metadata=project_metadata)
 
     def test_no_warning_when_project_path_matches_metadata(self, project_metadata):
-        import warnings
-
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             _build_project_snapshot(


### PR DESCRIPTION
## Description

Adds per-node source-location metadata to the inspection snapshot returned by `kedro.inspection.get_project_snapshot(...)`, addressing #5668.

## Development notes

- Added `NodeSourceSnapshot` with `filepath`, `line_start`, and `line_end`.
- Added `source: NodeSourceSnapshot | None = None` to `NodeSnapshot`.
- Populates source metadata for inspectable node functions.
- Uses project-relative filepaths for sources inside the project root and absolute filepaths for external sources.
- Returns `None` for unresolvable sources, including built-ins and lambdas.
- Handles `functools.partial` by resolving the underlying callable where possible.
- Added tests for normal functions, partials, lambdas, uninspectable callables, project-relative paths, external absolute paths, and project-path handoff.

Tested with:

```bash
python -m ruff format --check kedro/inspection/models.py kedro/inspection/snapshot.py tests/inspection/test_node_pipeline_snapshot.py tests/inspection/test_project_snapshot.py
python -m ruff check kedro/inspection/models.py kedro/inspection/snapshot.py tests/inspection/test_node_pipeline_snapshot.py tests/inspection/test_project_snapshot.py
uv run --no-project --isolated --with-editable "." --with pytest --with pytest-mock --with pandas python -m pytest -o addopts="" tests/inspection
```

`tests/inspection`: 98 passed.

## Developer Certificate of Origin

## Checklist

- [x] Read the [[contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md)](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [[Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`[RELEASE.md](https://github.com/kedro-org/kedro/blob/main/RELEASE.md)`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team