### PR TITLE
Feat/datacatalog thread safety

### DIFF
--- a/kedro/inspection/models.py
+++ b/kedro/inspection/models.py
@@ -52,6 +52,21 @@ class DatasetSnapshot:
 
 
 @dataclass
+class NodeSourceSnapshot:
+    """Read-only snapshot of a pipeline node's function source location.
+
+    Attributes:
+        filepath: Source file containing the node function definition.
+        line_start: First line of the node function definition.
+        line_end: Last line of the node function definition.
+    """
+
+    filepath: str
+    line_start: int
+    line_end: int
+
+
+@dataclass
 class NodeSnapshot:
     """Read-only snapshot of a single pipeline node.
 
@@ -62,6 +77,7 @@ class NodeSnapshot:
         tags: Sorted list of tags assigned to the node.
         inputs: Ordered list of input dataset names.
         outputs: Ordered list of output dataset names.
+        source: Source location of the node function, or ``None`` when unavailable.
     """
 
     name: str
@@ -70,6 +86,7 @@ class NodeSnapshot:
     tags: list[str] = field(default_factory=list)
     inputs: list[str] = field(default_factory=list)
     outputs: list[str] = field(default_factory=list)
+    source: NodeSourceSnapshot | None = None
 
 
 @dataclass

--- a/kedro/inspection/snapshot.py
+++ b/kedro/inspection/snapshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import functools
+import inspect
 import re
 import warnings
 from pathlib import Path
@@ -18,6 +20,7 @@ from kedro.inspection.helper import (
 from kedro.inspection.models import (
     DatasetSnapshot,
     NodeSnapshot,
+    NodeSourceSnapshot,
     PipelineSnapshot,
     ProjectMetadataSnapshot,
     ProjectSnapshot,
@@ -29,6 +32,47 @@ if TYPE_CHECKING:
 
 
 _ENV_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _get_source_callable(func: Any) -> Any:
+    """Return the callable whose source best represents a node function."""
+    source_func = inspect.unwrap(func)
+    while isinstance(source_func, functools.partial):
+        source_func = inspect.unwrap(source_func.func)
+    return source_func
+
+
+def _format_source_filepath(source_file: str, project_path: Path | None) -> str:
+    source_path = Path(source_file).resolve()
+    if project_path is None:
+        return str(source_path)
+
+    try:
+        return str(source_path.relative_to(project_path.resolve()))
+    except ValueError:
+        return str(source_path)
+
+
+def _get_node_source_snapshot(
+    node: Node, project_path: Path | None = None
+) -> NodeSourceSnapshot | None:
+    """Build a source-location snapshot for a node function when inspectable."""
+    try:
+        source_func = _get_source_callable(node.func)
+        if getattr(source_func, "__name__", None) == "<lambda>":
+            return None
+        source_file = inspect.getsourcefile(source_func)
+        if source_file is None:
+            return None
+        source_lines, line_start = inspect.getsourcelines(source_func)
+    except (OSError, TypeError, ValueError):
+        return None
+
+    return NodeSourceSnapshot(
+        filepath=_format_source_filepath(source_file, project_path),
+        line_start=line_start,
+        line_end=line_start + len(source_lines) - 1,
+    )
 
 
 def _build_project_metadata_snapshot(
@@ -68,11 +112,12 @@ def _build_dataset_snapshots(
     }
 
 
-def _node_to_snapshot(node: Node) -> NodeSnapshot:
+def _node_to_snapshot(node: Node, project_path: Path | None = None) -> NodeSnapshot:
     """Convert a live ``Node`` object to a ``NodeSnapshot``.
 
     Args:
         node: A Kedro pipeline node.
+        project_path: Project root path used to relativise source file paths.
 
     Returns:
         Read-only snapshot of the node's structural metadata.
@@ -84,17 +129,19 @@ def _node_to_snapshot(node: Node) -> NodeSnapshot:
         tags=sorted(node.tags),
         inputs=node.inputs,
         outputs=node.outputs,
+        source=_get_node_source_snapshot(node, project_path),
     )
 
 
 def _build_pipeline_snapshots(
-    pipeline_dict: dict[str, Any],
+    pipeline_dict: dict[str, Any], project_path: Path | None = None
 ) -> list[PipelineSnapshot]:
     """Build a ``PipelineSnapshot`` for every registered pipeline.
 
     Args:
         pipeline_dict: Dictionary of pipeline name to ``Pipeline`` object,
             as returned by ``dict(kedro.framework.project.pipelines)``.
+        project_path: Project root path used to relativise source file paths.
 
     Returns:
         List of pipeline snapshots in registry iteration order.
@@ -106,7 +153,9 @@ def _build_pipeline_snapshots(
         snapshots.append(
             PipelineSnapshot(
                 name=pipeline_id,
-                nodes=[_node_to_snapshot(_node) for _node in pipeline.nodes],
+                nodes=[
+                    _node_to_snapshot(_node, project_path) for _node in pipeline.nodes
+                ],
                 inputs=sorted(pipeline.inputs()),
                 outputs=sorted(pipeline.outputs()),
             )
@@ -177,7 +226,9 @@ def _build_project_snapshot(
         conf_catalog = {}
 
     metadata_snapshot = _build_project_metadata_snapshot(metadata)
-    pipeline_snapshots = _build_pipeline_snapshots(dict(pipelines))
+    pipeline_snapshots = _build_pipeline_snapshots(
+        dict(pipelines), effective_project_path
+    )
     dataset_snapshots = _build_dataset_snapshots(conf_catalog)
 
     # resolve factory patterns

--- a/kedro/io/data_catalog.py
+++ b/kedro/io/data_catalog.py
@@ -11,6 +11,7 @@ import logging
 import re
 from multiprocessing.reduction import ForkingPickler
 from pickle import PicklingError
+from threading import RLock
 from typing import TYPE_CHECKING, Any, ClassVar, Iterator, List  # noqa: UP035
 
 from kedro.io.cached_dataset import CachedDataset
@@ -256,6 +257,7 @@ class DataCatalog(CatalogProtocol):
             print(catalog)
         ```
         """
+        self._lock = RLock()
         self._config_resolver = config_resolver or CatalogConfigResolver(
             default_runtime_patterns=self.default_runtime_patterns
         )
@@ -314,11 +316,12 @@ class DataCatalog(CatalogProtocol):
             # "example: kedro.io.memory_dataset.MemoryDataset()"
         ```
         """
-        combined = self._lazy_datasets | self._datasets
-        lines = []
-        for key, dataset in combined.items():
-            lines.append(f"'{key}': {dataset!r}")
-        return "\n".join(lines)
+        with self._lock:
+            combined = self._lazy_datasets | self._datasets
+            lines = []
+            for key, dataset in combined.items():
+                lines.append(f"'{key}': {dataset!r}")
+            return "\n".join(lines)
 
     def __contains__(self, dataset_name: str) -> bool:
         """
@@ -341,13 +344,14 @@ class DataCatalog(CatalogProtocol):
             # False
         ```
         """
-        return (
-            dataset_name in self._datasets
-            or dataset_name in self._lazy_datasets
-            or self._config_resolver.match_dataset_pattern(dataset_name) is not None
-            or self._config_resolver.match_user_catch_all_pattern(dataset_name)
-            is not None
-        )
+        with self._lock:
+            return (
+                dataset_name in self._datasets
+                or dataset_name in self._lazy_datasets
+                or self._config_resolver.match_dataset_pattern(dataset_name) is not None
+                or self._config_resolver.match_user_catch_all_pattern(dataset_name)
+                is not None
+            )
 
     def __eq__(
         self, other: Any
@@ -369,15 +373,16 @@ class DataCatalog(CatalogProtocol):
             # False
         ```
         """
-        return (
-            self._datasets,
-            self._lazy_datasets,
-            self._config_resolver.list_patterns(),
-        ) == (
-            other._datasets,
-            other._lazy_datasets,
-            other.config_resolver.list_patterns(),
-        )
+        with self._lock:
+            return (
+                self._datasets,
+                self._lazy_datasets,
+                self._config_resolver.list_patterns(),
+            ) == (
+                other._datasets,
+                other._lazy_datasets,
+                other.config_resolver.list_patterns(),
+            )
 
     def keys(self) -> List[str]:  # noqa: UP006
         """
@@ -393,7 +398,8 @@ class DataCatalog(CatalogProtocol):
             # ['example']
         ```
         """
-        return list(self._lazy_datasets.keys()) + list(self._datasets.keys())
+        with self._lock:
+            return list(self._lazy_datasets.keys()) + list(self._datasets.keys())
 
     def values(self) -> List[AbstractDataset]:  # noqa: UP006
         """
@@ -518,22 +524,25 @@ class DataCatalog(CatalogProtocol):
             assert catalog.load("data_csv_dataset").equals(df)
         ```
         """
-        if key in self._datasets or key in self._lazy_datasets:
-            self._logger.warning("Replacing dataset '%s'", key)
-            self._datasets.pop(key, None)
-            self._lazy_datasets.pop(key, None)
-            self._config_resolver.config.pop(key, None)
-            self._load_versions.pop(key, None)
-        if isinstance(value, AbstractDataset):
-            self._load_versions, self._save_version = self._validate_versions(
-                {key: value}, self._load_versions, self._save_version
-            )
-            self._datasets[key] = value
-        elif isinstance(value, _LazyDataset):
-            self._lazy_datasets[key] = value
-        else:
-            self._logger.debug(f"Adding input data {key} as a default MemoryDataset")
-            self._datasets[key] = MemoryDataset(data=value)  # type: ignore[abstract]
+        with self._lock:
+            if key in self._datasets or key in self._lazy_datasets:
+                self._logger.warning("Replacing dataset '%s'", key)
+                self._datasets.pop(key, None)
+                self._lazy_datasets.pop(key, None)
+                self._config_resolver.config.pop(key, None)
+                self._load_versions.pop(key, None)
+            if isinstance(value, AbstractDataset):
+                self._load_versions, self._save_version = self._validate_versions(
+                    {key: value}, self._load_versions, self._save_version
+                )
+                self._datasets[key] = value
+            elif isinstance(value, _LazyDataset):
+                self._lazy_datasets[key] = value
+            else:
+                self._logger.debug(
+                    f"Adding input data {key} as a default MemoryDataset"
+                )
+                self._datasets[key] = MemoryDataset(data=value)  # type: ignore[abstract]
 
     def __len__(self) -> int:
         """
@@ -583,26 +592,27 @@ class DataCatalog(CatalogProtocol):
             # None
         ```
         """
-        if key not in self and not fallback_to_runtime_pattern:
-            return None
+        with self._lock:
+            if key not in self and not fallback_to_runtime_pattern:
+                return None
 
-        if not (key in self._datasets or key in self._lazy_datasets):
-            ds_config = self._config_resolver.resolve_pattern(key)
-            if ds_config:
-                self._add_from_config(key, ds_config)
+            if not (key in self._datasets or key in self._lazy_datasets):
+                ds_config = self._config_resolver.resolve_pattern(key)
+                if ds_config:
+                    self._add_from_config(key, ds_config)
 
-        lazy_dataset = self._lazy_datasets.pop(key, None)
-        if lazy_dataset:
-            self[key] = lazy_dataset.materialize()
+            lazy_dataset = self._lazy_datasets.pop(key, None)
+            if lazy_dataset:
+                self[key] = lazy_dataset.materialize()
 
-        dataset = self._datasets[key]
+            dataset = self._datasets[key]
 
-        if version and isinstance(dataset, AbstractVersionedDataset):
-            # we only want to return a similar-looking dataset,
-            # not modify the one stored in the current catalog
-            dataset = dataset._copy(_version=version)
+            if version and isinstance(dataset, AbstractVersionedDataset):
+                # we only want to return a similar-looking dataset,
+                # not modify the one stored in the current catalog
+                dataset = dataset._copy(_version=version)
 
-        return dataset
+            return dataset
 
     def _ipython_key_completions_(self) -> list[str]:
         return self.keys()
@@ -757,26 +767,29 @@ class DataCatalog(CatalogProtocol):
         credentials: dict[str, dict[str, Any]] = {}
         load_versions: dict[str, str | None] = {}
 
-        for ds_name, ds in self._lazy_datasets.items():
-            if _is_memory_dataset(ds.config.get(TYPE_KEY, "")):
-                continue
-            unresolved_config, unresolved_credentials = (
-                self._config_resolver._unresolve_credentials(ds_name, ds.config)
-            )
-            catalog[ds_name] = unresolved_config
-            credentials.update(unresolved_credentials)
-            load_versions[ds_name] = self._load_versions.get(ds_name, None)
+        with self._lock:
+            for ds_name, ds in self._lazy_datasets.items():
+                if _is_memory_dataset(ds.config.get(TYPE_KEY, "")):
+                    continue
+                unresolved_config, unresolved_credentials = (
+                    self._config_resolver._unresolve_credentials(ds_name, ds.config)
+                )
+                catalog[ds_name] = unresolved_config
+                credentials.update(unresolved_credentials)
+                load_versions[ds_name] = self._load_versions.get(ds_name, None)
 
-        for ds_name, ds in self._datasets.items():  # type: ignore[assignment]
-            if _is_memory_dataset(ds):  # type: ignore[arg-type]
-                continue
-            resolved_config = ds._init_config()  # type: ignore[attr-defined]
-            unresolved_config, unresolved_credentials = (
-                self._config_resolver._unresolve_credentials(ds_name, resolved_config)
-            )
-            catalog[ds_name] = unresolved_config
-            credentials.update(unresolved_credentials)
-            load_versions[ds_name] = self._load_versions.get(ds_name, None)
+            for ds_name, ds in self._datasets.items():  # type: ignore[assignment]
+                if _is_memory_dataset(ds):  # type: ignore[arg-type]
+                    continue
+                resolved_config = ds._init_config()  # type: ignore[attr-defined]
+                unresolved_config, unresolved_credentials = (
+                    self._config_resolver._unresolve_credentials(
+                        ds_name, resolved_config
+                    )
+                )
+                catalog[ds_name] = unresolved_config
+                credentials.update(unresolved_credentials)
+                load_versions[ds_name] = self._load_versions.get(ds_name, None)
 
         return catalog, credentials, load_versions, self._save_version
 
@@ -853,15 +866,16 @@ class DataCatalog(CatalogProtocol):
             # True
         ```
         """
-        self._validate_dataset_config(ds_name, ds_config)
-        ds = _LazyDataset(
-            ds_name,
-            ds_config,
-            self._load_versions.get(ds_name),
-            self._save_version,
-        )
+        with self._lock:
+            self._validate_dataset_config(ds_name, ds_config)
+            ds = _LazyDataset(
+                ds_name,
+                ds_config,
+                self._load_versions.get(ds_name),
+                self._save_version,
+            )
 
-        self.__setitem__(ds_name, ds)
+            self.__setitem__(ds_name, ds)
 
     def filter(
         self,
@@ -962,18 +976,28 @@ class DataCatalog(CatalogProtocol):
             # None
         ```
         """
-        if ds_name not in self:
-            return None
+        with self._lock:
+            if ds_name not in self:
+                return None
 
-        if ds_name not in self._datasets and ds_name not in self._lazy_datasets:
-            ds_config = self._config_resolver.resolve_pattern(ds_name)
-            return str(_LazyDataset(ds_name, ds_config))
+            if ds_name not in self._datasets and ds_name not in self._lazy_datasets:
+                ds_config = self._config_resolver.resolve_pattern(ds_name)
+                return str(_LazyDataset(ds_name, ds_config))
 
-        if ds_name in self._lazy_datasets:
-            return str(self._lazy_datasets[ds_name])
+            if ds_name in self._lazy_datasets:
+                return str(self._lazy_datasets[ds_name])
 
-        class_type = type(self._datasets[ds_name])
-        return f"{class_type.__module__}.{class_type.__qualname__}"
+            class_type = type(self._datasets[ds_name])
+            return f"{class_type.__module__}.{class_type.__qualname__}"
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = RLock()
 
     def save(self, ds_name: str, data: Any) -> None:
         """Save data to a registered dataset.
@@ -1231,9 +1255,10 @@ class SharedMemoryDataCatalog(DataCatalog):
             # {'shared_data': kedro.io.memory_dataset.MemoryDataset(data='<list>')}
         ```
         """
-        for _, ds in self._datasets.items():
-            if isinstance(ds, SharedMemoryDataset):
-                ds.set_manager(manager)
+        with self._lock:
+            for _, ds in self._datasets.items():
+                if isinstance(ds, SharedMemoryDataset):
+                    ds.set_manager(manager)
 
     def validate_catalog(self) -> None:
         """
@@ -1261,7 +1286,9 @@ class SharedMemoryDataCatalog(DataCatalog):
         ```
         """
         unserialisable = []
-        for name, dataset in self._datasets.items():
+        with self._lock:
+            datasets = self._datasets.copy()
+        for name, dataset in datasets.items():
             if getattr(dataset, "_SINGLE_PROCESS", False):  # SKIP_IF_NO_SPARK
                 unserialisable.append(name)
                 continue

--- a/kedro/io/memory_dataset.py
+++ b/kedro/io/memory_dataset.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import copy
+from threading import RLock
 from typing import Any
 
 from kedro.io.core import AbstractDataset, DatasetError, TCopyMode
@@ -50,6 +51,7 @@ class MemoryDataset(AbstractDataset):
             metadata: Any arbitrary metadata.
                 This is ignored by Kedro, but may be consumed by users or external plugins.
         """
+        self._lock = RLock()
         self._data = _EMPTY
         self._copy_mode = copy_mode
         self.metadata = metadata
@@ -58,29 +60,43 @@ class MemoryDataset(AbstractDataset):
             self.save.__wrapped__(self, data)  # type: ignore[attr-defined]
 
     def load(self) -> Any:
-        if self._data is _EMPTY:
-            raise DatasetError("Data for MemoryDataset has not been saved yet.")
+        with self._lock:
+            if self._data is _EMPTY:
+                raise DatasetError("Data for MemoryDataset has not been saved yet.")
 
-        copy_mode = self._copy_mode or _infer_copy_mode(self._data)
-        data = _copy_with_mode(self._data, copy_mode=copy_mode)
-        return data
+            copy_mode = self._copy_mode or _infer_copy_mode(self._data)
+            data = _copy_with_mode(self._data, copy_mode=copy_mode)
+            return data
 
     def save(self, data: Any) -> None:
-        copy_mode = self._copy_mode or _infer_copy_mode(data)
-        self._data = _copy_with_mode(data, copy_mode=copy_mode)
+        with self._lock:
+            copy_mode = self._copy_mode or _infer_copy_mode(data)
+            self._data = _copy_with_mode(data, copy_mode=copy_mode)
 
     def _exists(self) -> bool:
-        return self._data is not _EMPTY
+        with self._lock:
+            return self._data is not _EMPTY
 
     def _release(self) -> None:
-        self._data = _EMPTY
+        with self._lock:
+            self._data = _EMPTY
 
     def _describe(self) -> dict[str, Any]:
-        if self._data is not _EMPTY:
-            return {"data": f"<{type(self._data).__name__}>"}
-        # the string representation of datasets leaves out __init__
-        # arguments that are empty/None, equivalent here is _EMPTY
-        return {"data": None}  # pragma: no cover
+        with self._lock:
+            if self._data is not _EMPTY:
+                return {"data": f"<{type(self._data).__name__}>"}
+            # the string representation of datasets leaves out __init__
+            # arguments that are empty/None, equivalent here is _EMPTY
+            return {"data": None}  # pragma: no cover
+
+    def __getstate__(self) -> dict[str, Any]:
+        state = self.__dict__.copy()
+        state.pop("_lock", None)
+        return state
+
+    def __setstate__(self, state: dict[str, Any]) -> None:
+        self.__dict__.update(state)
+        self._lock = RLock()
 
 
 def _infer_copy_mode(data: Any) -> TCopyMode:

--- a/tests/inspection/test_node_pipeline_snapshot.py
+++ b/tests/inspection/test_node_pipeline_snapshot.py
@@ -2,17 +2,41 @@
 
 from __future__ import annotations
 
+import importlib.util
+import inspect
 from functools import partial
+from pathlib import Path
 
 import pytest
 
-from kedro.inspection.models import NodeSnapshot, PipelineSnapshot
+from kedro.inspection.models import NodeSnapshot, NodeSourceSnapshot, PipelineSnapshot
 from kedro.inspection.snapshot import _build_pipeline_snapshots, _node_to_snapshot
 from kedro.pipeline import Pipeline, node
 
 
 def _identity(x):
     return x
+
+
+def _load_external_function(tmp_path):
+    module_path = tmp_path / "external_nodes.py"
+    module_path.write_text(
+        "def external_identity(x):\n    return x\n",
+        encoding="utf-8",
+    )
+    spec = importlib.util.spec_from_file_location(
+        "external_nodes_for_inspection", module_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.external_identity, module_path
+
+
+@pytest.fixture
+def project_root():
+    return Path(__file__).resolve().parents[2]
 
 
 @pytest.fixture
@@ -51,6 +75,7 @@ class TestNodeSnapshot:
         assert snapshot.tags == []
         assert snapshot.inputs == []
         assert snapshot.outputs == []
+        assert snapshot.source is None
 
     def test_func_name_is_keyword_only(self):
         snapshot = NodeSnapshot("my_node", "my_namespace", func_name="my_func")
@@ -59,6 +84,18 @@ class TestNodeSnapshot:
 
         with pytest.raises(TypeError, match="func_name"):
             NodeSnapshot("my_node", "my_namespace")
+
+
+class TestNodeSourceSnapshot:
+    def test_instantiation(self):
+        snapshot = NodeSourceSnapshot(
+            filepath="src/my_package/pipeline.py",
+            line_start=10,
+            line_end=12,
+        )
+        assert snapshot.filepath == "src/my_package/pipeline.py"
+        assert snapshot.line_start == 10
+        assert snapshot.line_end == 12
 
 
 class TestNodeToSnapshot:
@@ -95,6 +132,69 @@ class TestNodeToSnapshot:
         assert snapshot.name == "partial_node"
         assert snapshot.func_name == "<partial>"
 
+    def test_source_populated_for_normal_function(self, simple_node, project_root):
+        snapshot = _node_to_snapshot(simple_node, project_path=project_root)
+        lines, line_start = inspect.getsourcelines(_identity)
+
+        assert snapshot.source == NodeSourceSnapshot(
+            filepath=str(Path(__file__).resolve().relative_to(project_root)),
+            line_start=line_start,
+            line_end=line_start + len(lines) - 1,
+        )
+
+    def test_source_populated_for_partial(self, project_root):
+        partial_node = node(
+            partial(_identity),
+            inputs="raw",
+            outputs="processed",
+            name="partial_node",
+        )
+
+        with pytest.warns(UserWarning, match="made from a 'partial' function"):
+            snapshot = _node_to_snapshot(partial_node, project_path=project_root)
+        lines, line_start = inspect.getsourcelines(_identity)
+
+        assert snapshot.source == NodeSourceSnapshot(
+            filepath=str(Path(__file__).resolve().relative_to(project_root)),
+            line_start=line_start,
+            line_end=line_start + len(lines) - 1,
+        )
+
+    def test_source_is_none_for_uninspectable_callable(self):
+        len_node = node(len, inputs="raw", outputs="processed", name="len_node")
+
+        snapshot = _node_to_snapshot(len_node)
+
+        assert snapshot.source is None
+
+    def test_source_is_none_for_lambda(self):
+        lambda_node = node(
+            lambda raw: raw,
+            inputs="raw",
+            outputs="processed",
+            name="lambda_node",
+        )
+
+        snapshot = _node_to_snapshot(lambda_node)
+
+        assert snapshot.source is None
+
+    def test_source_uses_absolute_filepath_outside_project(
+        self, tmp_path, project_root
+    ):
+        external_func, module_path = _load_external_function(tmp_path)
+        external_node = node(
+            external_func,
+            inputs="raw",
+            outputs="processed",
+            name="external_node",
+        )
+
+        snapshot = _node_to_snapshot(external_node, project_path=project_root)
+
+        assert snapshot.source is not None
+        assert snapshot.source.filepath == str(module_path.resolve())
+
 
 class TestPipelineSnapshot:
     def test_instantiation(self):
@@ -127,6 +227,16 @@ class TestBuildPipelineSnapshots:
         snapshots = _build_pipeline_snapshots({"__default__": simple_pipeline})
         assert snapshots[0].inputs == sorted(simple_pipeline.inputs())
         assert snapshots[0].outputs == sorted(simple_pipeline.outputs())
+
+    def test_nodes_receive_project_relative_source(self, simple_pipeline, project_root):
+        snapshots = _build_pipeline_snapshots(
+            {"__default__": simple_pipeline}, project_path=project_root
+        )
+
+        assert snapshots[0].nodes[0].source is not None
+        assert snapshots[0].nodes[0].source.filepath == str(
+            Path(__file__).resolve().relative_to(project_root)
+        )
 
     def test_empty_registry_returns_empty_list(self):
         assert _build_pipeline_snapshots({}) == []

--- a/tests/inspection/test_project_snapshot.py
+++ b/tests/inspection/test_project_snapshot.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import warnings
+
 import pytest
 
 from kedro.config import MissingConfigException
@@ -138,7 +140,7 @@ class TestBuildProjectSnapshot:
             "kedro.inspection.snapshot.pipelines",
             new={},
         )
-        mocker.patch(
+        self.mock_build_pipeline_snapshots = mocker.patch(
             "kedro.inspection.snapshot._build_pipeline_snapshots",
             return_value=self.pipeline_snapshots,
         )
@@ -171,6 +173,12 @@ class TestBuildProjectSnapshot:
     def test_pipelines_populated(self):
         result = _build_project_snapshot(self.project_path)
         assert result.pipelines is self.pipeline_snapshots
+
+    def test_pipeline_snapshots_built_with_project_path(self):
+        _build_project_snapshot(self.project_path)
+        self.mock_build_pipeline_snapshots.assert_called_once_with(
+            {}, self.project_path
+        )
 
     def test_datasets_populated(self):
         result = _build_project_snapshot(self.project_path)
@@ -298,8 +306,6 @@ class TestBuildProjectSnapshot:
             _build_project_snapshot(different_path, metadata=project_metadata)
 
     def test_no_warning_when_project_path_matches_metadata(self, project_metadata):
-        import warnings
-
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             _build_project_snapshot(

--- a/tests/io/test_data_catalog.py
+++ b/tests/io/test_data_catalog.py
@@ -1,8 +1,11 @@
 import logging
 import re
+import time
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
+from threading import Barrier
 
 import pandas as pd
 import pytest
@@ -26,6 +29,7 @@ from kedro.io.core import (
     generate_timestamp,
     parse_dataset_definition,
 )
+from kedro.io.data_catalog import _LazyDataset
 
 
 @pytest.fixture
@@ -382,6 +386,57 @@ class TestDataCatalog:
 
         data_catalog_copy = deepcopy(data_catalog_from_config)
         assert not data_catalog_copy == expected_catalog
+
+    def test_catalog_deepcopy_preserves_lock(self, data_catalog_from_config):
+        data_catalog_copy = deepcopy(data_catalog_from_config)
+
+        assert data_catalog_copy.keys() == data_catalog_from_config.keys()
+
+    def test_concurrent_get_materializes_lazy_dataset_once(self, monkeypatch):
+        materialized_datasets = []
+
+        def slow_materialize(self):
+            time.sleep(0.05)
+            dataset = MemoryDataset(data=len(materialized_datasets))
+            materialized_datasets.append(dataset)
+            return dataset
+
+        monkeypatch.setattr(_LazyDataset, "materialize", slow_materialize)
+        catalog = DataCatalog.from_config({"dataset": {"type": "MemoryDataset"}})
+        barrier = Barrier(2)
+
+        def get_dataset(_):
+            barrier.wait()
+            return catalog.get("dataset")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            datasets = list(executor.map(get_dataset, range(2)))
+
+        assert datasets[0] is datasets[1]
+        assert len(materialized_datasets) == 1
+
+    def test_concurrent_get_resolves_pattern_once(self, monkeypatch):
+        materialized_datasets = []
+
+        def slow_materialize(self):
+            time.sleep(0.05)
+            dataset = MemoryDataset(data=len(materialized_datasets))
+            materialized_datasets.append(dataset)
+            return dataset
+
+        monkeypatch.setattr(_LazyDataset, "materialize", slow_materialize)
+        catalog = DataCatalog.from_config({"dataset_{name}": {"type": "MemoryDataset"}})
+        barrier = Barrier(2)
+
+        def get_dataset(_):
+            barrier.wait()
+            return catalog.get("dataset_a")
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            datasets = list(executor.map(get_dataset, range(2)))
+
+        assert datasets[0] is datasets[1]
+        assert len(materialized_datasets) == 1
 
     def test_get_returns_none_dataset(self):
         catalog = DataCatalog(datasets={})

--- a/tests/io/test_memory_dataset.py
+++ b/tests/io/test_memory_dataset.py
@@ -1,5 +1,6 @@
 import re
 import sys
+from copy import deepcopy
 
 import numpy as np
 import pandas as pd
@@ -30,6 +31,18 @@ def _check_equals(data1, data2):
     if isinstance(data1, np.ndarray) and isinstance(data2, np.ndarray):
         return np.array_equal(data1, data2)
     return False  # pragma: no cover
+
+
+class TrackingLock:
+    def __init__(self):
+        self.enter_count = 0
+        self.exit_count = 0
+
+    def __enter__(self):
+        self.enter_count += 1
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.exit_count += 1
 
 
 @pytest.fixture
@@ -155,6 +168,28 @@ class TestMemoryDataset:
 
         dataset.save(new_data)
         assert dataset.exists()
+
+    def test_dataset_operations_are_locked(self):
+        dataset = MemoryDataset("initial")
+        tracking_lock = TrackingLock()
+        dataset._lock = tracking_lock
+
+        dataset.save("new")
+        dataset.load()
+        dataset.exists()
+        dataset._describe()
+        dataset.release()
+
+        assert tracking_lock.enter_count >= 5
+        assert tracking_lock.exit_count == tracking_lock.enter_count
+
+    def test_deepcopy_preserves_lock(self):
+        dataset = MemoryDataset("data")
+
+        copied_dataset = deepcopy(dataset)
+
+        copied_dataset.save("new data")
+        assert copied_dataset.load() == "new data"
 
 
 @pytest.mark.parametrize("data", [["a", "b"], [{"a": "b"}, {"c": "d"}]])


### PR DESCRIPTION
## Description

Fixes #5659 by adding thread-safety protections around shared `DataCatalog` state and `MemoryDataset` state used during threaded runs.

## Development notes

Added reentrant locks to `DataCatalog` to guard structural catalog state, including lazy dataset materialisation, pattern-resolved dataset creation, item registration, catalog snapshots, and shared-memory catalog iteration.

Added a reentrant lock to `MemoryDataset` to guard `load`, `save`, `exists`, `release`, and dataset description access to its internal `_data`.

Preserved deepcopy/pickle compatibility by excluding locks from object state and recreating them during restore.

Added tests for:
- concurrent lazy dataset materialisation
- concurrent pattern-backed dataset resolution
- deepcopy support with locks
- locked `MemoryDataset` operations

Tested with:
- `pre_commit run ruff --files kedro/io/data_catalog.py kedro/io/memory_dataset.py tests/io/test_data_catalog.py tests/io/test_memory_dataset.py`
- `pre_commit run ruff-format --files kedro/io/data_catalog.py kedro/io/memory_dataset.py tests/io/test_data_catalog.py tests/io/test_memory_dataset.py`
- `pytest --no-cov tests/io/test_data_catalog.py tests/io/test_memory_dataset.py`
- `pytest --no-cov tests/runner/test_thread_runner.py`


## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team