### PR TITLE
fix: keep IPv6 hosts intact when parsing cloud filepaths

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,8 +3,11 @@
 * Added the node function name to project inspection snapshots as `NodeSnapshot.func_name`.
 
 ## Bug fixes and other changes
+* Fixed `_parse_filepath` truncating IPv6 host addresses (e.g. `s3://[2001:db8::1]:9000/bucket`) when stripping the port.
 ## Documentation changes
 ## Community contributions
+Many thanks to the following Kedroids for contributing PRs to this release:
+* [eeshsaxena](https://github.com/eeshsaxena)
 
 # Release 1.5.0
 ## Major features and improvements

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -73,7 +73,9 @@ def _parse_filepath(filepath: str) -> dict[str, str]:
 
     if parsed_path.netloc and protocol in CLOUD_PROTOCOLS:
         host_with_port = parsed_path.netloc.rsplit("@", 1)[-1]
-        host = host_with_port.rsplit(":", 1)[0]
+        # Strip a trailing ``:port`` only; a bare ``rsplit(":", 1)`` also cuts an
+        # IPv6 host such as ``[2001:db8::1]`` at its own colons.
+        host = re.sub(r":\d+$", "", host_with_port)
         options["path"] = host + options["path"]
         # - Azure Data Lake Storage Gen2 URIs can store the container name in the
         #   'username' field of a URL (@ syntax), so we need to add it to the path

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ import pytest
 from kedro.utils import (
     KedroExperimentalWarning,
     _is_unsafe_version,
+    _parse_filepath,
     experimental,
     find_config_file,
     get_close_matches,
@@ -19,6 +20,33 @@ T = TypeVar("T")
 
 class DummyClass:
     pass
+
+
+class TestParseFilepath:
+    @pytest.mark.parametrize(
+        "filepath, expected",
+        [
+            ("s3://bucket/key", {"protocol": "s3", "path": "bucket/key"}),
+            ("gcs://bucket/key", {"protocol": "gcs", "path": "bucket/key"}),
+            (
+                "s3://host:9000/bucket/key",
+                {"protocol": "s3", "path": "host/bucket/key"},
+            ),
+            ("/local/path", {"protocol": "file", "path": "/local/path"}),
+            # An IPv6 host must not be cut at its own colons when the port is
+            # stripped; with a bare rsplit(":", 1) these lost the address.
+            (
+                "s3://[2001:db8::1]/bucket/key",
+                {"protocol": "s3", "path": "[2001:db8::1]/bucket/key"},
+            ),
+            (
+                "s3://[2001:db8::1]:9000/bucket/key",
+                {"protocol": "s3", "path": "[2001:db8::1]/bucket/key"},
+            ),
+        ],
+    )
+    def test_parse_filepath(self, filepath, expected):
+        assert _parse_filepath(filepath) == expected
 
 
 class TestGetCloseMatches:


### PR DESCRIPTION
`_parse_filepath` stripped the port with `rsplit(':', 1)`, which also cut an IPv6 host like `[2001:db8::1]` at its own colons (e.g. `s3://[2001:db8::1]/bucket` parsed to path `[2001:db8:/bucket`). Strip only a trailing `:port` instead. Adds direct tests for `_parse_filepath` (it was only mocked before).