### PR TITLE
Update PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,18 +4,18 @@
 ## Development notes
 <!-- What have you changed, and how has this been tested? -->
 
+> [!IMPORTANT]
+> Every PR must link to a well-described GitHub issue. If there isn't one yet, [open an issue](https://github.com/kedro-org/kedro/issues/new/choose) first and discuss the approach before submitting a PR. See our [contribution guidelines](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) for details.
 
 ## Developer Certificate of Origin
-We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).
-
-If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.
+All commits must be signed off to comply with the [DCO](https://developercertificate.org/). If your PR is blocked due to unsigned commits, follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR.
 
 ## Checklist
 
 - [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
-- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
+- [ ] Linked to a relevant GitHub issue
+- [ ] Signed off each commit with a [DCO](https://developercertificate.org/)
 - [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
 - [ ] Updated the documentation to reflect the code changes
 - [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
 - [ ] Added tests to cover my changes
-- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team


### PR DESCRIPTION
## Description
Follow-up to #5639.

Updates the PR template to align with the recently revised contribution guidelines:
- Added a note requiring every PR to link to a well-described GitHub issue
- Shortened the Developer Certificate of Origin section
- Streamlined the checklist

## Development notes
No code changes — template-only update.

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
