### PR TITLE
Resolve recursion error with new `dynaconf`

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,6 +3,7 @@
 * Added the node function name to project inspection snapshots as `NodeSnapshot.func_name`.
 
 ## Bug fixes and other changes
+* Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by replacing `deepcopy(settings.SESSION_STORE_ARGS)` with a plain `dict()` conversion.
 * Excluded `kedro_benchmarks` from the built wheel so benchmark tests are no longer shipped with the package.
 * Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -3,7 +3,7 @@
 * Added the node function name to project inspection snapshots as `NodeSnapshot.func_name`.
 
 ## Bug fixes and other changes
-* Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by replacing `deepcopy(settings.SESSION_STORE_ARGS)` with a plain `dict()` conversion.
+* Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by converting `settings.SESSION_STORE_ARGS` to a plain `dict` before deepcopying it.
 * Excluded `kedro_benchmarks` from the built wheel so benchmark tests are no longer shipped with the package.
 * Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -192,7 +192,7 @@ class KedroSession(AbstractSession):
     def _init_store(self) -> BaseSessionStore:
         store_class = settings.SESSION_STORE_CLASS
         classpath = f"{store_class.__module__}.{store_class.__qualname__}"
-        store_args = deepcopy(settings.SESSION_STORE_ARGS)
+        store_args = deepcopy(dict(settings.SESSION_STORE_ARGS))
         store_args.setdefault("path", (self._project_path / "sessions").as_posix())
         store_args["session_id"] = self.session_id
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -192,7 +192,9 @@ class KedroSession(AbstractSession):
     def _init_store(self) -> BaseSessionStore:
         store_class = settings.SESSION_STORE_CLASS
         classpath = f"{store_class.__module__}.{store_class.__qualname__}"
-        store_args = deepcopy(dict(settings.SESSION_STORE_ARGS))
+        store_args = deepcopy(
+            dict(settings.SESSION_STORE_ARGS)
+        )  # dynaconf runs into a recursion error when trying to deepcopy the settings object, so we convert it to a dict first
         store_args.setdefault("path", (self._project_path / "sessions").as_posix())
         store_args["session_id"] = self.session_id
 

--- a/kedro/framework/session/session.py
+++ b/kedro/framework/session/session.py
@@ -192,9 +192,9 @@ class KedroSession(AbstractSession):
     def _init_store(self) -> BaseSessionStore:
         store_class = settings.SESSION_STORE_CLASS
         classpath = f"{store_class.__module__}.{store_class.__qualname__}"
-        store_args = deepcopy(
-            dict(settings.SESSION_STORE_ARGS)
-        )  # dynaconf runs into a recursion error when trying to deepcopy the settings object, so we convert it to a dict first
+        # dynaconf can raise RecursionError when deepcopying its settings objects, so
+        # convert to a plain dict first.
+        store_args = deepcopy(dict(settings.SESSION_STORE_ARGS))
         store_args.setdefault("path", (self._project_path / "sessions").as_posix())
         store_args["session_id"] = self.session_id
 


### PR DESCRIPTION
## Description
<!-- Why was this PR created? -->
Fix #5676 

## Development notes
<!-- What have you changed, and how has this been tested? -->
Users hitting a `RecursionError` when running the `KedroSession` multiple times since deepcopying of the `SESSION_STORE_ARGS` (which is `LazySettings`/`DynaBox`) have circular internal references.

Simple solution is to cast it into a `dict` here.

I verified that this works with the user example in the tagged issue:

```
from kedro.framework.startup import bootstrap_project
from kedro.framework.session import KedroSession

bootstrap_project(p)
s1 = KedroSession.create(project_path=p)
s1.load_context()                     # populates the stateful hook with the context

bootstrap_project(p)
KedroSession.create(project_path=p)   # RecursionError on dynaconf>=3.3, OK on <3.3
```

## Developer Certificate of Origin
We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

If your PR is blocked due to unsigned commits, then you must follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR. This will retroactively add the sign-off to all unsigned commits and allow the DCO check to pass.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team
