### PR TITLE
Document state isolation for KedroServiceSession hooks

### DIFF
--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -185,7 +185,7 @@ On failure the response also contains an `error` object with the exception type 
 !!! note
     `RunRequest` model uses strict validation, unknown fields return an error rather than being ignored.
 
-The first `/run` request creates a `KedroServiceSession` which the following requests reuse. The endpoint runs in a thread pool, so concurrent `/run` requests share the same session and pipeline runs are not isolated from each other.
+The first `/run` request creates a `KedroServiceSession` which the following requests reuse. The endpoint runs in a thread pool, so concurrent `/run` requests share the same session and pipeline runs are not isolated from each other. Hooks are also reused across requests; see [how to keep hooks isolated between service runs](./session.md#keep-hooks-isolated-between-service-runs).
 
 !!! note
     `env` and `conf_source` are not accepted per-request. Set them at server startup through the `--env` and `--conf-source` options instead.

--- a/docs/extend/session.md
+++ b/docs/extend/session.md
@@ -84,6 +84,17 @@ session.run(runtime_params={"param1": "value2"})
 session.close()
 ```
 
+### Keep hooks isolated between service runs
+
+`KedroServiceSession` creates its hook manager once and reuses the same
+registered hook instances for every call to `run()`. Mutable state stored on a
+hook therefore persists into later runs. Concurrent calls to `run()` can also
+invoke the same hook instance from different threads.
+
+Prefer stateless hooks. If a hook must collect per-run state, isolate that state
+by `run_params["run_id"]`, protect shared mutable data from concurrent access,
+and clean up state in both `after_pipeline_run` and `on_pipeline_error`.
+
 You can provide the following optional arguments in `KedroServiceSession.create()`:
 
 - `session_id`: Identifier for the session; if not provided, a unique session ID will be generated automatically


### PR DESCRIPTION
Closes #5656.

## Summary

- Document that `KedroServiceSession` reuses its hook manager and registered hook instances across runs.
- Explain how stateful hooks can leak state between sequential runs or race during concurrent runs.
- Recommend stateless hooks or per-run state keyed by `run_params["run_id"]`, with synchronization and cleanup on success and error paths.
- Link the HTTP serving guide to the new state-isolation guidance.

## Validation

- `DISABLE_MKDOCS_2_WARNING=true python -m mkdocs build --strict`
- `git diff --check`
