### PR TITLE
ci: pass the branch to git clone through env and quote it

### DIFF
--- a/.github/workflows/pipeline-performance-test.yml
+++ b/.github/workflows/pipeline-performance-test.yml
@@ -49,8 +49,10 @@ jobs:
 
     - name: Pull specific branch from Kedro and install it
       if: github.event.action == 'labeled' && contains(github.event.label.name, 'performance')
+      env:
+        HEAD_REF: ${{ github.event.pull_request.head.ref }}
       run: |
-        git clone --branch ${{ github.event.pull_request.head.ref }} https://github.com/kedro-org/kedro.git
+        git clone --branch "$HEAD_REF" https://github.com/kedro-org/kedro.git
         cd kedro
         make install
 


### PR DESCRIPTION
Hi, and thanks for Kedro.

In `.github/workflows/pipeline-performance-test.yml`, the branch to clone is interpolated straight into the command, unquoted:

```yaml
run: |
  git clone --branch ${{ github.event.pull_request.head.ref }} https://github.com/kedro-org/kedro.git
```

Actions expands `${{ ... }}` into the script text before bash runs, so the branch name lands as script rather than as an argument. Git allows `$`, `(`, `)`, backticks and spaces in branch names, and `$(...)` executes inside double quotes — and being unquoted, a name with a space would also split into two arguments and make `git clone` do something unintended.

The guard here is real and worth crediting: the step only runs on

```yaml
if: github.event.action == 'labeled' && contains(github.event.label.name, 'performance')
```

so someone with write access has to apply the `performance` label first. That makes this defence in depth rather than an open door, and I would rather say so than imply otherwise.

The change passes the ref through `env:` and quotes it:

```yaml
env:
  HEAD_REF: ${{ github.event.pull_request.head.ref }}
run: |
  git clone --branch "$HEAD_REF" https://github.com/kedro-org/kedro.git
```

Same clone, same branch; `cd kedro` and `make install` untouched.

Disclosure: I used AI assistance to help spot this and prepare the change, and I read the workflow and its label guard myself.
