### PR TITLE
fix: ship Makefile + make.bat with docs tool and generate modules via apidoc

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@
 * Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by converting `settings.SESSION_STORE_ARGS` to a plain `dict` before deepcopying it.
 * Excluded `kedro_benchmarks` from the built wheel so benchmark tests are no longer shipped with the package.
 * Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
+* Fixed the `docs` tool so that the shipped `Makefile` and `make.bat` run `sphinx-apidoc` before `sphinx-build`, ensuring the `modules` page is generated when building HTML documentation.
 
 ## Documentation changes
 ## Community contributions

--- a/docs/create/new_project_tools.md
+++ b/docs/create/new_project_tools.md
@@ -240,7 +240,8 @@ To learn more about using logging in your project, or modifying the logging conf
 
 ### Documentation
 
-Including the Documentation tool adds a `docs` directory to your project structure and includes the Sphinx setup files, `conf.py` and `index.rst`, with some added features such as auto generation of HTML documentation.
+Including the Documentation tool adds a `docs` directory to your project structure and includes the Sphinx setup files, `conf.py` and `index.rst`, along with a `Makefile` (and `make.bat` on Windows) that builds the HTML documentation.
+Run `make html` in the `docs` directory (or `docs\make.bat html` on Windows) to generate the API docs with `sphinx-apidoc` and then build the site with `sphinx-build`.
 The aim of this tool reflects Kedro's commitment to best practices in understanding code and facilitating collaboration by helping you create and maintain guides and API docs.
 
 If you did not initially select `docs` and want to add it later, follow the [official documentation](https://docs.kedro.org/en/stable/deploy/package_a_project/#add-documentation-to-a-kedro-project-if-you-have-not-selected-docs-tool) for guidance on adding documentation to a Kedro project.

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/Makefile
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/Makefile
@@ -1,0 +1,26 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SPHINXAPIDOC  ?= sphinx-apidoc
+SOURCEDIR     = source
+BUILDDIR      = build
+PACKAGEDIR    = ../src/{{ cookiecutter.python_package }}
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile html
+
+html: Makefile
+	@$(SPHINXAPIDOC) --module-first -o "$(SOURCEDIR)" "$(PACKAGEDIR)" --force
+	@$(SPHINXBUILD) -M html "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/make.bat
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/make.bat
@@ -1,0 +1,29 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+set PACKAGEDIR=..\src\{{ cookiecutter.python_package }}
+
+if "%1" == "" goto help
+
+if "%1" == "html" (
+	sphinx-apidoc --module-first -o %SOURCEDIR% %PACKAGEDIR% --force
+	%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	goto end
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/index.rst
+++ b/kedro/templates/project/{{ cookiecutter.repo_name }}/docs/source/index.rst
@@ -2,6 +2,8 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. Run ``make html`` in the docs directory to build the API docs.
+
 Welcome to project {{ cookiecutter.python_package }}'s API docs!
 =============================================
 

--- a/tests/framework/cli/starters/utils.py
+++ b/tests/framework/cli/starters/utils.py
@@ -186,7 +186,7 @@ def _get_expected_files(tools: str, example_pipeline: str):
         "1": 0,  # Linting does not add any files
         "2": 3,  # If Testing is selected, we add 2 init.py files and 1 test_run.py
         "3": 1,  # If Logging is selected, we add logging.py
-        "4": 2,  # If Documentation is selected, we add conf.py and index.rst
+        "4": 4,  # If Documentation is selected, we add conf.py, index.rst, Makefile and make.bat
         "5": 8,  # If Data Structure is selected, we add 8 .gitkeep files
         "6": 0,  # PySpark selection no longer adds extra starter files
     }  # files added to template by each tool


### PR DESCRIPTION
Fixes #5592.

When kedro new --tools=docs is selected, the generated docs/source/index.rst references a modules page that is never created because sphinx-apidoc is never run. This PR ships a docs/Makefile and docs/make.bat whose html target runs sphinx-apidoc then sphinx-build, so the modules reference always resolves.

### Changes
- Added docs/Makefile with html target running sphinx-apidoc then sphinx-build
- Added docs/make.bat for Windows parity
- Added a one-line comment in docs/source/index.rst pointing users at make html
- Updated 	ests/framework/cli/starters/utils.py to expect 4 docs files instead of 2

### Testing
The existing starter tests (_get_expected_files) now account for the two new files.