### PR TITLE
docs: add MkDocs setup steps for projects without the docs tool

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,6 +8,7 @@
 * Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 
 ## Documentation changes
+* Added MkDocs setup steps to `docs/deploy/package_a_project.md` for projects created without the `docs` tool.
 ## Community contributions
 Many thanks to the following Kedroids for contributing PRs to this release:
 * [eeshsaxena](https://github.com/eeshsaxena)

--- a/docs/deploy/package_a_project.md
+++ b/docs/deploy/package_a_project.md
@@ -9,6 +9,79 @@ Kedro also has an advanced feature which supports packaging on a pipeline level 
 !!! note
     These steps are for projects without the `docs` tool option. You can verify this by looking to see if you don't have a `docs` directory in your project.
 
+If you selected the `docs` tool when running `kedro new`, your project already contains a Sphinx-based documentation setup in the `docs` directory. The steps below use [MkDocs](https://www.mkdocs.org/) instead, which is the documentation tool used for Kedro's own documentation site.
+
+### Install dependencies
+
+Run the following from your project root:
+
+```bash
+pip install mkdocs mkdocs-material mkdocstrings[python] mkdocs-autorefs
+```
+
+### Configure MkDocs
+
+Create an `mkdocs.yml` file in your project root:
+
+```yaml
+site_name: My Project
+site_url: https://example.com/
+repo_name: my-project
+repo_url: https://github.com/my-org/my-project
+
+theme:
+  name: material
+
+plugins:
+  - search
+  - autorefs
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            docstring_style: google
+
+nav:
+  - Home: index.md
+  - API reference: api.md
+```
+
+### Add documentation pages
+
+Create a `docs` directory and add two files. Replace `my_project` with the name of your Python package (the value of `python_package` in `pyproject.toml`).
+
+`docs/index.md`:
+
+```markdown
+# My Project
+
+Welcome to the documentation for My Project.
+```
+
+`docs/api.md`:
+
+```markdown
+# API reference
+
+::: my_project
+```
+
+### Build and preview
+
+Run the following from your project root to preview the site:
+
+```bash
+mkdocs serve
+```
+
+Then open `http://127.0.0.1:8000/` in your browser. To build the static site, run:
+
+```bash
+mkdocs build
+```
+
+The built site is written to the `site/` directory.
 
 ## Package a Kedro project
 


### PR DESCRIPTION
Fixes #5603.

The section for adding documentation when the docs tool was not selected was empty after Kedro migrated its own docs to MkDocs. This PR adds working MkDocs setup steps using Material and mkdocstrings so users can build a docs site with API docs generated from their project source.

Changes:
- Added a complete MkDocs setup section to docs/deploy/package_a_project.md
- Steps include installing dependencies, configuring mkdocs.yml, creating docs/index.md and docs/api.md, and running mkdocs serve/mkdocs build
- Notes the Sphinx-vs-MkDocs split so users who selected the docs tool know the existing scaffold is Sphinx-based
- Added a release note in RELEASE.md