### PR TITLE
docs: fix open_args_load example using text mode with encoding

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -23,6 +23,7 @@
 - Added a new "Vibe coding with skills" page documenting the `kedro-skills` plugin.
 - Added `mdformat` as a Markdown autoformatter, run via `make lint` and as a pre-commit hook, and reformatted the existing Markdown. Fixed several step-by-step guides where numbered lists were rendering as repeated "1." instead of counting up, because their content wasn't indented under the right list item.
 - Fixed the `DaskRunner` example on the Dask deployment page.
+- Fixed the `open_args_load` examples in the data catalog documentation to use text mode so the `encoding` option applies.
 
 ## Community contributions
 
@@ -33,6 +34,7 @@ Many thanks to the following Kedroids for contributing PRs to this release:
 - [Shizoqua](https://github.com/Shizoqua)
 - [BALOGUN DAVID TAIWO](https://github.com/BALOGUN-DAVID)
 - [kingjaiteh](https://github.com/kingjaiteh)
+- [Muhtasim Munif Fahim](https://github.com/Muhtasim-Munif-Fahim)
 
 # Release 1.5.0
 

--- a/docs/catalog-data/data_catalog_yaml_examples.md
+++ b/docs/catalog-data/data_catalog_yaml_examples.md
@@ -7,7 +7,7 @@ This page contains a set of examples to help you structure your YAML configurati
     Datasets are not included in the core Kedro package from Kedro version **`0.19.0`**. Import them from the [`kedro-datasets`](https://github.com/kedro-org/kedro-plugins/tree/main/kedro-datasets) package instead.
     From version **`2.0.0`** of `kedro-datasets`, all dataset names have changed to replace the capital letter "S" in "DataSet" with a lower case "s". For example, `CSVDataSet` is now `CSVDataset`.
 
-## Load data from a local binary file using `utf-8` encoding
+## Load data from a local text file using `utf-8` encoding
 
 The `open_args_load` and `open_args_save` parameters are passed to the filesystem `open` method to configure how a dataset file (on a specific filesystem) is opened during a load or save operation respectively.
 
@@ -16,7 +16,7 @@ test_dataset:
   type: ...
   fs_args:
     open_args_load:
-      mode: "rb"
+      mode: "r"
       encoding: "utf-8"
 ```
 

--- a/docs/catalog-data/how_to_configure_the_data_catalog.md
+++ b/docs/catalog-data/how_to_configure_the_data_catalog.md
@@ -36,14 +36,14 @@ test_dataset:
 
 The `open_args_load` and `open_args_save` keys nested inside `fs_args` are passed to the filesystem's `open` method to configure how a dataset file is opened during a load or save operation.
 
-To load data from a local binary file using `utf-8` encoding:
+To load data from a local text file using `utf-8` encoding:
 
 ```yaml
 test_dataset:
   type: ...
   fs_args:
     open_args_load:
-      mode: "rb"
+      mode: "r"
       encoding: "utf-8"
 ```
 

--- a/docs/catalog-data/how_to_configure_the_data_catalog.md
+++ b/docs/catalog-data/how_to_configure_the_data_catalog.md
@@ -37,14 +37,14 @@ test_dataset:
 
 The `open_args_load` and `open_args_save` keys nested inside `fs_args` are passed to the filesystem's `open` method to configure how a dataset file is opened during a load or save operation.
 
-To load data from a local binary file using `utf-8` encoding:
+To load data from a local text file using `utf-8` encoding:
 
 ```yaml
 test_dataset:
   type: ...
   fs_args:
     open_args_load:
-      mode: "rb"
+      mode: "r"
       encoding: "utf-8"
 ```
 


### PR DESCRIPTION
﻿The Data Catalog how-to example combined mode: "rb" (binary read) with encoding: "utf-8". Python's open() raises ValueError when encoding is passed in binary mode, so the example was invalid.

Changed mode to "r" (text mode) and updated the narrative from "binary file" to "text file", which matches the intent of specifying a text encoding.

Closes #5708
