### PR TITLE
Add mdformat as a new repo-wide Markdown formatter

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,8 @@
+# Numbered steps in tutorials/deployment guides use sequential numbering
+# (1, 2, 3...) rather than mdformat's default lazy "1." for every item --
+# easier to scan, review in diffs, and edit. See:
+# https://mdformat.readthedocs.io/en/stable/users/style.html#ordered-lists
+number = true
+
+# Don't reflow prose; only normalise Markdown syntax.
+wrap = "keep"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,6 +16,26 @@ repos:
           files: "^kedro/|^features/|^tests/"
           exclude: "^features/test_starter|^kedro/templates/"
 
+    - repo: https://github.com/hukkin/mdformat
+      rev: 1.0.0
+      hooks:
+        - id: mdformat
+          name: "mdformat on Markdown files"
+          additional_dependencies:
+            - mdformat-mkdocs==5.3.0 # MkDocs/Material syntax (admonitions, tabs, snippets)
+            - mdformat-gfm==1.0.0 # GitHub Flavored Markdown (tables, strikethrough, autolinks)
+            - mdformat-frontmatter==2.1.2 # YAML front matter
+          # docs/api/ (mkdocstrings) and commands_reference.md (mkdocs-click) use
+          # ::: directives whose indented options mdformat strips; exclude them
+          # permanently. The rest of the exclude list below is temporary, rolled
+          # out incrementally across a stack of PRs so each lands with a passing
+          # `make lint` -- pre-commit checks the whole tree, not just the diff, so
+          # the hook can't be added ahead of the files it would then flag. Each
+          # PR in the stack reformats one area and removes that area from here.
+          # TODO(after the mdformat rollout stack merges): drop everything below
+          # docs/getting-started/commands_reference.md.
+          exclude: "^kedro/templates/|^features/test_starter/|^docs/api/|^docs/getting-started/commands_reference\\.md$|^\\.agents/|^\\.github/|^docs/|^README\\.md$|^RELEASE\\.md$|^LICENSE\\.md$|^CODE_OF_CONDUCT\\.md$|^CONTRIBUTING\\.md$|^SECURITY\\.md$|^kedro_benchmarks/"
+
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0
       hooks:


### PR DESCRIPTION
## Description

First PR in a stack that adds [mdformat](https://mdformat.readthedocs.io/) as a Markdown autoformatter, split out per review feedback on #5643 so each affected area lands as its own, easier-to-review PR.

This PR just adds the pre-commit hook and config — no files are reformatted yet.

- `mdformat` + `mdformat-mkdocs`/`gfm`/`frontmatter`, run via `make lint` and as a pre-commit hook, matching how `ruff-format` is set up for Python.
- Templates and the test starter are excluded (matching ruff), as are `docs/api/` (mkdocstrings) and `commands_reference.md` (mkdocs-click), since mdformat strips the indented options under their `:::` directives.
- Ordered lists use sequential numbering (`1, 2, 3...`), not mdformat's default lazy `1.` for every item, via `number = true` in `.mdformat.toml` — easier to scan/review/edit in raw source.

Stack:
1. **This PR** — add the hook (targets `main`)
2. #5643-agents-github (targets this branch) — reformat `.agents/` and `.github/`
3. #5643 (targets that branch) — fix broken list numbering + reformat `docs/` and root Markdown

## Developer Certificate of Origin

We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file (folded into #5643, last in the stack)
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team

🤖 Generated with [Claude Code](https://claude.com/claude-code)