### PR TITLE
Reformat both .agents/ and .github/ using mdformat

### DIFF
--- a/.agents/skills/kedro-babysit/SKILL.md
+++ b/.agents/skills/kedro-babysit/SKILL.md
@@ -13,6 +13,7 @@ description: >-
   ad-hoc** — Kedro's pre-commit configuration, pyproject settings, and an
   isolated venv are required for the results to match CI.
 ---
+
 # Babysit Kedro PR
 
 Drive Kedro changes toward a mergeable state — locally before push, or on an open PR with failing CI. Fix mechanical CI failures, resolve clear merge conflicts, ensure DCO sign-off. Use a conservative posture: stop and ask the user before every commit, push, force-push, and merge-conflict resolution.
@@ -25,10 +26,10 @@ This skill complements `review-kedro-pr` (judgment-based code review). It does *
 
 **Pick a track first**, then run only the steps that track requires. There are two tracks, mapped to the two real situations users hit:
 
-| Track | When the user says... | What to do |
-|---|---|---|
-| **L. Local dev** | "babysit my local changes", "verify before push", "run checks locally", "are my changes ready?", "lint my diff" | Step 2 (env) → Step 5a (full sweep to surface FAILs) → Step 4 (per-failure fix loop with targeted commands) → Step 5a (final re-verify) → optional Step 5b (commit + push). **No PR required.** Skips GitHub fetch entirely. |
-| **C. CI diagnosis & fix** | "CI is failing", "fix the lint job", "what's failing on CI?", "fix the X check on this PR", "babysit this PR" | Step 1 (PR detection) → Step 2 (env) → Step 3 (snapshot via `scripts/watch_ci.sh`) → Step 4 (fix only the failing checks; verify each with the most targeted command — see [reference.md](reference.md) section "Fast lint iteration") → Step 5b (commit + push). **Skip Step 5a** — per-check verify already happened in Step 4. |
+| Track                     | When the user says...                                                                                           | What to do                                                                                                                                                                                                                                                                                                                        |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **L. Local dev**          | "babysit my local changes", "verify before push", "run checks locally", "are my changes ready?", "lint my diff" | Step 2 (env) → Step 5a (full sweep to surface FAILs) → Step 4 (per-failure fix loop with targeted commands) → Step 5a (final re-verify) → optional Step 5b (commit + push). **No PR required.** Skips GitHub fetch entirely.                                                                                                      |
+| **C. CI diagnosis & fix** | "CI is failing", "fix the lint job", "what's failing on CI?", "fix the X check on this PR", "babysit this PR"   | Step 1 (PR detection) → Step 2 (env) → Step 3 (snapshot via `scripts/watch_ci.sh`) → Step 4 (fix only the failing checks; verify each with the most targeted command — see [reference.md](reference.md) section "Fast lint iteration") → Step 5b (commit + push). **Skip Step 5a** — per-check verify already happened in Step 4. |
 
 ### Picking the right track
 
@@ -41,7 +42,7 @@ Each step header below is annotated with the tracks that need it (e.g. `Tracks: 
 
 ## Workflow
 
-### 1. Identify the PR + preflight   _Track: C_
+### 1. Identify the PR + preflight _Track: C_
 
 Detect the PR from the current branch, or accept a PR URL/number from the user:
 
@@ -55,11 +56,12 @@ gh pr view <number-or-url> --json number,title,baseRefName,headRefName
 If the user provided an explicit PR, **thread it through every subsequent command** as `gh pr view <num> ...` and `bash scripts/watch_ci.sh --pr <num>`. The default (no `--pr`) only works for the current branch's PR.
 
 Preflight checks:
+
 - `gh` is installed and authenticated. If not, stop and ask the user to install/authenticate.
 - The working tree is clean enough to operate on. Run `git status --porcelain`; if there are uncommitted changes unrelated to the planned fixes, warn the user and ask whether to stash or proceed.
 - A PR exists for the current branch. **If no PR exists**, ask the user whether to switch to Track L (local-only) or stop and open a PR first (`gh pr create`); creating PRs is out of scope for this skill.
 
-### 2. Set up the Python environment   _Tracks: L, C_
+### 2. Set up the Python environment _Tracks: L, C_
 
 Run `scripts/bootstrap_env.sh`. The script:
 
@@ -69,12 +71,13 @@ Run `scripts/bootstrap_env.sh`. The script:
 - Probes for system tools `vale`, `lychee`, `gh`. Prints platform-specific install hints if missing; does not install them.
 
 **Determining whether to pass `--with-docs`:**
+
 - Track L (no PR exists, so `origin/main` is the default base): `git diff --name-only "$(git merge-base HEAD origin/main)"...HEAD | grep -E '^docs/|\.md$'`. Pass `--with-docs` if there's a match.
 - Track C (PR's actual base may differ): `gh pr view --json files -q '.files[].path' | grep -E '^docs/|\.md$'`. Pass `--with-docs` if there's a match.
 
 Read [reference.md](reference.md) section "Environment setup" for manual recipes and cross-platform install hints.
 
-### 3. Snapshot the PR state   _Track: C_
+### 3. Snapshot the PR state _Track: C_
 
 Single read-only pass:
 
@@ -90,13 +93,14 @@ Drop the `[<num>]` / `[--pr <num>]` brackets when operating on the current branc
 Don't hardcode `origin/main` — Kedro PRs may target `develop` or other branches.
 
 Show the user a one-screen summary:
+
 - Mergeable status (`CLEAN` / `BEHIND` / `DIRTY` / `BLOCKED`).
 - Failing CI checks, each annotated with the local Make target from [reference.md](reference.md) section "CI-to-local mapping".
 - Commits missing DCO `Signed-off-by:` trailer.
 
 `scripts/watch_ci.sh` is snapshot-only: it fetches the current state and exits without blocking on still-running checks. Re-run it later for a refreshed snapshot.
 
-### 4. Fix in this fixed order   _Tracks: L, C — sub-bullets gate per track too_
+### 4. Fix in this fixed order _Tracks: L, C — sub-bullets gate per track too_
 
 Each sub-step ends with **stop and ask before staging / committing / pushing / amending**.
 
@@ -105,18 +109,25 @@ The Track C sub-bullets (Merge conflicts → CI failures → DCO sign-off) run i
 **Merge conflicts** (Track C). If `mergeStateStatus` is `DIRTY` or `BEHIND`, sync with the base branch. Resolve conflicts only when the intent is unambiguous; otherwise stop and ask the user.
 
 **CI failures** (Track C). For each failing check:
-1. Look up the local invocation in [reference.md](reference.md) section "CI-to-local mapping" (and the cookbook entry below it for `e2e-tests`, which is intentionally out of scope locally).
-2. The failed-job logs were already dumped by `watch_ci.sh` in Step 3. If the snapshot is stale (e.g., new check runs completed since Step 3), re-run `bash scripts/watch_ci.sh [--pr <num>]` for a fresh snapshot — keep the `--pr` flag if the user supplied a PR in Step 1.
-3. Propose the smallest scoped fix using [reference.md](reference.md) section "Common CI failures and fixes".
-4. Apply the fix to the working tree only (no `git add` / `git commit`).
-5. **Verify with the most targeted command available** — almost never `make lint`, which runs *every* pre-commit hook on *every* file plus mypy on the whole `kedro/` package (typically 3–5 min per iteration). Instead:
-   - For a single failing pre-commit hook: `pre-commit run <hook-id> --files <changed-files>` (seconds).
-   - For ruff/format: `ruff check --fix <file>` or `ruff format <file>` (sub-second).
-   - For mypy: `mypy <file> --strict --allow-any-generics --no-warn-unused-ignores` (5–10s vs. 1–2 min).
-   - For Import Linter: `lint-imports --config pyproject.toml` (it scans the whole project regardless — but skips pre-commit overhead).
-   - For unit tests: `pytest --no-cov tests/path/to/test_thing.py::TestClass::test_method` (sub-second per test) instead of `make test` (~6 min for the full suite + 100% coverage check). **`--no-cov` is required** because `pyproject.toml` always applies `--cov` with `fail_under = 100`, which would otherwise exit non-zero even on a passing single-test run. **Never run `make test` during the fix loop** — pick the failing test path from the CI log and target it directly. **Sandbox: always request `all` permissions when running any `pytest` in this repo** (see [reference.md](reference.md) section "Sandbox & permissions").
 
-   Full per-hook recipes in [reference.md](reference.md) section "Fast lint iteration". Track C does **not** run `scripts/run_local_checks.sh` here.
+1. Look up the local invocation in [reference.md](reference.md) section "CI-to-local mapping" (and the cookbook entry below it for `e2e-tests`, which is intentionally out of scope locally).
+
+2. The failed-job logs were already dumped by `watch_ci.sh` in Step 3. If the snapshot is stale (e.g., new check runs completed since Step 3), re-run `bash scripts/watch_ci.sh [--pr <num>]` for a fresh snapshot — keep the `--pr` flag if the user supplied a PR in Step 1.
+
+3. Propose the smallest scoped fix using [reference.md](reference.md) section "Common CI failures and fixes".
+
+4. Apply the fix to the working tree only (no `git add` / `git commit`).
+
+5. **Verify with the most targeted command available** — almost never `make lint`, which runs *every* pre-commit hook on *every* file plus mypy on the whole `kedro/` package (typically 3–5 min per iteration). Instead:
+
+    - For a single failing pre-commit hook: `pre-commit run <hook-id> --files <changed-files>` (seconds).
+    - For ruff/format: `ruff check --fix <file>` or `ruff format <file>` (sub-second).
+    - For mypy: `mypy <file> --strict --allow-any-generics --no-warn-unused-ignores` (5–10s vs. 1–2 min).
+    - For Import Linter: `lint-imports --config pyproject.toml` (it scans the whole project regardless — but skips pre-commit overhead).
+    - For unit tests: `pytest --no-cov tests/path/to/test_thing.py::TestClass::test_method` (sub-second per test) instead of `make test` (~6 min for the full suite + 100% coverage check). **`--no-cov` is required** because `pyproject.toml` always applies `--cov` with `fail_under = 100`, which would otherwise exit non-zero even on a passing single-test run. **Never run `make test` during the fix loop** — pick the failing test path from the CI log and target it directly. **Sandbox: always request `all` permissions when running any `pytest` in this repo** (see [reference.md](reference.md) section "Sandbox & permissions").
+
+    Full per-hook recipes in [reference.md](reference.md) section "Fast lint iteration". Track C does **not** run `scripts/run_local_checks.sh` here.
+
 6. Move to the next finding.
 
 **DCO sign-off** (Track C). List commits without `Signed-off-by:`. Apply one of the recipes from [reference.md](reference.md) section "DCO sign-off recipes" (typically `git rebase <base> --signoff` for older commits). Ask the user before amending; **explicitly warn that amend requires a force-push** (`git push --force-with-lease`).
@@ -127,7 +138,7 @@ The Track C sub-bullets (Merge conflicts → CI failures → DCO sign-off) run i
 
 Two sub-steps. Run the ones your track requires.
 
-#### 5a. Verify locally (full sweep)   _Track: L_
+#### 5a. Verify locally (full sweep) _Track: L_
 
 ```bash
 bash scripts/run_local_checks.sh
@@ -138,6 +149,7 @@ The script auto-detects scope from the changed files (`code`, `docs`, or `code+d
 **Local scope is narrower than CI's path filter.** Only `docs/**` changes trigger local docs checks. Generic `*.md` files outside `docs/` (e.g., `RELEASE.md`, root `README.md`) are skipped locally because they don't affect the docs build — but CI's `docs-only-checks` workflow *will* still fire on them. The script prints a one-line note when this divergence applies, with the recommended local pre-check command (`make linkcheck` / `make language-lint dir=docs`). If those checks fail on CI later, Track C is the safety net.
 
 **Before invoking the script, warn the user about the wait time.** Total wall time depends on scope:
+
 - `code` only: **~10–12 min** (lint ~3-5 + test ~6 + detect-secrets ~30s)
 - `docs` only: **~5–10 min** (lint ~3-5 + linkcheck ~2-5 + language-lint ~30s)
 - `code+docs` (mixed PR): **~12–17 min** (everything above)
@@ -150,9 +162,10 @@ Show the user the per-check pass/fail/skip summary at the end. Any FAILs feed in
 
 **Track C skips 5a entirely** — per-check verification already happened in Step 4 for the specific failing checks; running the full sweep would be redundant and slow.
 
-#### 5b. Commit + push   _Tracks: L (optional), C_
+#### 5b. Commit + push _Tracks: L (optional), C_
 
 On user confirmation:
+
 - `git add` only the touched files.
 - `git commit` with a message you propose (or the user provides). Use `-s` for DCO sign-off.
 - `git push` (or `git push --force-with-lease` for the DCO rebase case — warn explicitly).

--- a/.agents/skills/kedro-babysit/reference.md
+++ b/.agents/skills/kedro-babysit/reference.md
@@ -4,7 +4,7 @@ Detailed reference for the `kedro-babysit` skill. Read sections selectively — 
 
 For the **invocation tracks** (L = Local dev / C = CI diagnosis & fix) and which workflow steps each track requires, see [SKILL.md](SKILL.md) section "How to invoke this skill". This reference does not duplicate that routing — it just provides the underlying recipes each step calls into.
 
----
+______________________________________________________________________
 
 ## Environment setup
 
@@ -73,11 +73,11 @@ make install-docs-requirements   # uv pip install -e ".[docs]"
 
 Three external tools may be required depending on what checks run:
 
-| Tool     | Used by                          | Required for             |
-| -------- | -------------------------------- | ------------------------ |
-| `gh`     | `watch_ci.sh`, `bootstrap_env.sh`| All CI interactions      |
-| `vale`   | `make language-lint`             | Docs language linter     |
-| `lychee` | `make linkcheck`                 | Docs link check          |
+| Tool     | Used by                           | Required for         |
+| -------- | --------------------------------- | -------------------- |
+| `gh`     | `watch_ci.sh`, `bootstrap_env.sh` | All CI interactions  |
+| `vale`   | `make language-lint`              | Docs language linter |
+| `lychee` | `make linkcheck`                  | Docs link check      |
 
 Install hints (skill prints these if missing; never installs them itself):
 
@@ -87,42 +87,42 @@ Install hints (skill prints these if missing; never installs them itself):
 
 Docs checks that depend on missing system tools are reported as `[SKIP missing tool]` rather than `[FAIL]`.
 
----
+______________________________________________________________________
 
 ## Sandbox & permissions
 
 When invoking the commands below through a sandboxed shell tool, **request the listed permissions upfront** — guessing wrong wastes a run.
 
-| Command | Permissions |
-|---|---|
-| `make test`, `pytest …` (any path) | **`all`** |
-| `make linkcheck`, `bash scripts/watch_ci.sh`, `bash scripts/bootstrap_env.sh` (install flow) | **`network`** |
-| `make lint`, per-hook recipes (`pre-commit run …`, `ruff …`, `mypy …`, `lint-imports`), `make language-lint` | default |
-| `bash scripts/run_local_checks.sh` | union of the above based on the plan it prints |
+| Command                                                                                                      | Permissions                                    |
+| ------------------------------------------------------------------------------------------------------------ | ---------------------------------------------- |
+| `make test`, `pytest …` (any path)                                                                           | **`all`**                                      |
+| `make linkcheck`, `bash scripts/watch_ci.sh`, `bash scripts/bootstrap_env.sh` (install flow)                 | **`network`**                                  |
+| `make lint`, per-hook recipes (`pre-commit run …`, `ruff …`, `mypy …`, `lint-imports`), `make language-lint` | default                                        |
+| `bash scripts/run_local_checks.sh`                                                                           | union of the above based on the plan it prints |
 
 **Rule for `pytest`**: always `all`, regardless of which path or test method you're targeting. Kedro's shared CLI test fixtures invoke `cookiecutter` during fixture setup, which writes `~/.cookiecutter_replay/<template>.json` outside the workspace. Some narrow paths (`tests/io/...`, `tests/runner/...`) don't strictly need it, but the cost of an unnecessary approval click is trivial vs. wasting a 6-min test run on a sandbox block.
 
----
+______________________________________________________________________
 
 ## CI-to-local mapping
 
 Canonical mapping of CI check name -> local invocation. The skill always prefers the Make target.
 
-| CI check                     | Workflow file                                                          | Local command                                              | Notes                                                                                                              |
-| ---------------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| `lint`                       | [lint.yml](../../../.github/workflows/lint.yml)                        | `make lint` (full sweep, 3–5 min) **or** targeted recipes  | See "Fast lint iteration" below. Fires on both code and docs PRs.                                                  |
-| `unit-tests`                 | [unit-tests.yml](../../../.github/workflows/unit-tests.yml)            | `make test` (~6 min)                                       | See cookbook entry "`unit-tests` failure" below. Coverage `fail_under = 100` enforced via `pyproject.toml`.        |
-| `e2e-tests`                  | [e2e-tests.yml](../../../.github/workflows/e2e-tests.yml)              | **Out of scope locally** (would be `make e2e-tests`)       | See cookbook entry "`e2e-tests` failure" below.                                                                    |
-| `detect-secrets`             | [detect-secrets.yml](../../../.github/workflows/detect-secrets.yml)    | `git ls-files -z \| xargs -0 detect-secrets-hook --baseline .secrets.baseline` | **No Make target.** Full-tree scan. Differs from the pre-commit hook in `make lint` (which only checks changed files) and can fail in CI even when `make lint` is green. |
-| `docs-linkcheck`             | [docs-linkcheck.yml](../../../.github/workflows/docs-linkcheck.yml)    | `make linkcheck`                                           | `mkdocs build --strict` + `lychee --max-concurrency 32 --exclude "@.lycheeignore" site/`. Slow + needs network. Requires `lychee`. **CI fires on any `**.md` change; `run_local_checks.sh` auto-detect only fires on `docs/**`** — for `*.md` files outside docs/ (`RELEASE.md` etc.), invoke `make linkcheck` directly if you want to pre-check, or rely on Track C after push. |
-| `docs-language-linter`       | [docs-language-linter.yml](../../../.github/workflows/docs-language-linter.yml) | `make language-lint dir=docs`                              | `vale docs`. **Non-blocking** — `merge-gatekeeper` ignores `runner / vale` (see the `ignored:` setting in [merge-gatekeeper.yml](../../../.github/workflows/merge-gatekeeper.yml)). Requires `vale`. Same auto-detect divergence as `docs-linkcheck` above. |
-| `merge-gatekeeper`           | [merge-gatekeeper.yml](../../../.github/workflows/merge-gatekeeper.yml) | n/a                                                        | Aggregator. Turns green when all required checks pass. Nothing to fix directly.                                    |
-| `pipeline-performance-test`  | [pipeline-performance-test.yml](../../../.github/workflows/pipeline-performance-test.yml) | n/a                                                        | Label-triggered (only fires when a maintainer adds the `performance` label). Reports timing, not pass/fail. The skill surfaces the timing delta but does not auto-fix perf regressions. |
-| DCO sign-off                 | GitHub App `dco` (not a workflow file)                                 | `git log <base>..HEAD --format='%H %(trailers:key=Signed-off-by)'` | Detects missing `Signed-off-by:` trailers. See "DCO sign-off recipes" below.                                       |
+| CI check                    | Workflow file                                                                             | Local command                                                                  | Notes                                                                                                                                                                                                                                                                                                                                                                            |
+| --------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `lint`                      | [lint.yml](../../../.github/workflows/lint.yml)                                           | `make lint` (full sweep, 3–5 min) **or** targeted recipes                      | See "Fast lint iteration" below. Fires on both code and docs PRs.                                                                                                                                                                                                                                                                                                                |
+| `unit-tests`                | [unit-tests.yml](../../../.github/workflows/unit-tests.yml)                               | `make test` (~6 min)                                                           | See cookbook entry "`unit-tests` failure" below. Coverage `fail_under = 100` enforced via `pyproject.toml`.                                                                                                                                                                                                                                                                      |
+| `e2e-tests`                 | [e2e-tests.yml](../../../.github/workflows/e2e-tests.yml)                                 | **Out of scope locally** (would be `make e2e-tests`)                           | See cookbook entry "`e2e-tests` failure" below.                                                                                                                                                                                                                                                                                                                                  |
+| `detect-secrets`            | [detect-secrets.yml](../../../.github/workflows/detect-secrets.yml)                       | `git ls-files -z \| xargs -0 detect-secrets-hook --baseline .secrets.baseline` | **No Make target.** Full-tree scan. Differs from the pre-commit hook in `make lint` (which only checks changed files) and can fail in CI even when `make lint` is green.                                                                                                                                                                                                         |
+| `docs-linkcheck`            | [docs-linkcheck.yml](../../../.github/workflows/docs-linkcheck.yml)                       | `make linkcheck`                                                               | `mkdocs build --strict` + `lychee --max-concurrency 32 --exclude "@.lycheeignore" site/`. Slow + needs network. Requires `lychee`. **CI fires on any `**.md` change; `run_local_checks.sh` auto-detect only fires on `docs/**`** — for `*.md` files outside docs/ (`RELEASE.md` etc.), invoke `make linkcheck` directly if you want to pre-check, or rely on Track C after push. |
+| `docs-language-linter`      | [docs-language-linter.yml](../../../.github/workflows/docs-language-linter.yml)           | `make language-lint dir=docs`                                                  | `vale docs`. **Non-blocking** — `merge-gatekeeper` ignores `runner / vale` (see the `ignored:` setting in [merge-gatekeeper.yml](../../../.github/workflows/merge-gatekeeper.yml)). Requires `vale`. Same auto-detect divergence as `docs-linkcheck` above.                                                                                                                      |
+| `merge-gatekeeper`          | [merge-gatekeeper.yml](../../../.github/workflows/merge-gatekeeper.yml)                   | n/a                                                                            | Aggregator. Turns green when all required checks pass. Nothing to fix directly.                                                                                                                                                                                                                                                                                                  |
+| `pipeline-performance-test` | [pipeline-performance-test.yml](../../../.github/workflows/pipeline-performance-test.yml) | n/a                                                                            | Label-triggered (only fires when a maintainer adds the `performance` label). Reports timing, not pass/fail. The skill surfaces the timing delta but does not auto-fix perf regressions.                                                                                                                                                                                          |
+| DCO sign-off                | GitHub App `dco` (not a workflow file)                                                    | `git log <base>..HEAD --format='%H %(trailers:key=Signed-off-by)'`             | Detects missing `Signed-off-by:` trailers. See "DCO sign-off recipes" below.                                                                                                                                                                                                                                                                                                     |
 
 All other workflows in [.github/workflows/](../../../.github/workflows/) (`benchmark-performance`, `check-release`, `nightly-build`, `release-starters`, `auto-merge-prs`, `sync`, `label-community-issues`, `no-response`) are scheduled, release-triggered, or issue-only — out of scope for this skill.
 
----
+______________________________________________________________________
 
 ## DCO sign-off recipes
 
@@ -166,7 +166,7 @@ make sign-off
 
 This installs `.git/hooks/commit-msg` to append `Signed-off-by:` automatically (see the `sign-off` target in [Makefile](../../../Makefile)). One-time setup per clone.
 
----
+______________________________________________________________________
 
 ## Fast lint iteration
 
@@ -176,24 +176,24 @@ This installs `.git/hooks/commit-msg` to append `Signed-off-by:` automatically (
 
 1. **Identify which hook is failing** from the CI log or local output (the hook name appears in `make lint` output as `>>>>>>>> <hook name>`).
 2. **Run only that hook on only the changed files**: `pre-commit run <hook-id> --files <file1> <file2> ...`. If you don't know the changed file list, derive it relative to the PR's base branch:
-   ```bash
-   BASE="$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)"
-   git diff --name-only "origin/$BASE"...HEAD
-   ```
-   This mirrors the auto-detect logic in `scripts/run_local_checks.sh`. Don't hardcode `origin/main` — Kedro PRs may target `develop` or other branches.
+    ```bash
+    BASE="$(gh pr view --json baseRefName -q .baseRefName 2>/dev/null || echo main)"
+    git diff --name-only "origin/$BASE"...HEAD
+    ```
+    This mirrors the auto-detect logic in `scripts/run_local_checks.sh`. Don't hardcode `origin/main` — Kedro PRs may target `develop` or other branches.
 3. **For tools that can be invoked directly**, skip pre-commit altogether (faster, no hook overhead): see the per-tool recipes below.
 4. **Re-run `make lint`** only as a final belt-and-suspenders check before commit/push.
 
 ### Per-hook recipes
 
-| Failing CI / local check | Targeted command (fast) | Notes |
-|---|---|---|
-| `ruff` (lint) | `ruff check --fix <file>` or `pre-commit run ruff --files <file>` | The hook is configured with `--fix --exit-non-zero-on-fix`, so it auto-fixes and reports. Direct `ruff check --fix` is fastest. |
-| `ruff-format` | `ruff format <file>` or `pre-commit run ruff-format --files <file>` | Reformats in place. |
-| `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-json`, `debug-statements`, `requirements-txt-fixer`, `check-added-large-files`, `check-case-conflict`, `check-merge-conflict` | `pre-commit run <hook-id> --files <file>` | Auto-fixers (whitespace, EOF) modify in place; checkers report violations. |
-| `imports` (Import Linter) | `lint-imports --config pyproject.toml` | The hook has `pass_filenames: false`, so `--files` is ignored — it always scans the whole project. Direct invocation is the same speed but skips pre-commit's setup overhead. Contracts live in the `[[tool.importlinter.contracts]]` blocks of [pyproject.toml](../../../pyproject.toml). |
-| `detect-secrets` (pre-commit hook on changed files) | `pre-commit run detect-secrets --files <file>` | Different from the CI's full-tree scan. To reproduce CI's check, see the cookbook entry below. |
-| `mypy` | `mypy <file> --strict --allow-any-generics --no-warn-unused-ignores` or `mypy <subpackage>/ --strict --allow-any-generics --no-warn-unused-ignores` | Single file: ~5–10s (vs. 1–2 min for the whole `kedro/` package). Mypy config in the `[tool.mypy]` section of [pyproject.toml](../../../pyproject.toml). |
+| Failing CI / local check                                                                                                                                                                       | Targeted command (fast)                                                                                                                             | Notes                                                                                                                                                                                                                                                                                      |
+| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `ruff` (lint)                                                                                                                                                                                  | `ruff check --fix <file>` or `pre-commit run ruff --files <file>`                                                                                   | The hook is configured with `--fix --exit-non-zero-on-fix`, so it auto-fixes and reports. Direct `ruff check --fix` is fastest.                                                                                                                                                            |
+| `ruff-format`                                                                                                                                                                                  | `ruff format <file>` or `pre-commit run ruff-format --files <file>`                                                                                 | Reformats in place.                                                                                                                                                                                                                                                                        |
+| `trailing-whitespace`, `end-of-file-fixer`, `check-yaml`, `check-json`, `debug-statements`, `requirements-txt-fixer`, `check-added-large-files`, `check-case-conflict`, `check-merge-conflict` | `pre-commit run <hook-id> --files <file>`                                                                                                           | Auto-fixers (whitespace, EOF) modify in place; checkers report violations.                                                                                                                                                                                                                 |
+| `imports` (Import Linter)                                                                                                                                                                      | `lint-imports --config pyproject.toml`                                                                                                              | The hook has `pass_filenames: false`, so `--files` is ignored — it always scans the whole project. Direct invocation is the same speed but skips pre-commit's setup overhead. Contracts live in the `[[tool.importlinter.contracts]]` blocks of [pyproject.toml](../../../pyproject.toml). |
+| `detect-secrets` (pre-commit hook on changed files)                                                                                                                                            | `pre-commit run detect-secrets --files <file>`                                                                                                      | Different from the CI's full-tree scan. To reproduce CI's check, see the cookbook entry below.                                                                                                                                                                                             |
+| `mypy`                                                                                                                                                                                         | `mypy <file> --strict --allow-any-generics --no-warn-unused-ignores` or `mypy <subpackage>/ --strict --allow-any-generics --no-warn-unused-ignores` | Single file: ~5–10s (vs. 1–2 min for the whole `kedro/` package). Mypy config in the `[tool.mypy]` section of [pyproject.toml](../../../pyproject.toml).                                                                                                                                   |
 
 ### Convenience: `make lint hook=<id>`
 
@@ -202,11 +202,12 @@ The Makefile already supports `make lint hook=<hook-id>` (see the `lint` target 
 ### When to fall back to `make lint`
 
 Run the full sweep when:
+
 - Final verification before commit/push (or just call `bash scripts/run_local_checks.sh` which wraps it).
 - You've changed something cross-cutting (renamed a public API, edited many files) and want the whole-tree confidence.
 - The targeted recipes pass but you suspect side effects in untouched files.
 
----
+______________________________________________________________________
 
 ## Common CI failures and fixes
 
@@ -270,7 +271,7 @@ Not auto-fixed. The skill reports the timing delta and asks the user to investig
 
 Nothing to fix directly. Turns green when all required checks pass.
 
----
+______________________________________________________________________
 
 ## gh CLI cheatsheet
 

--- a/.agents/skills/kedro-docs-draft-writer/SKILL.md
+++ b/.agents/skills/kedro-docs-draft-writer/SKILL.md
@@ -8,6 +8,7 @@ description: >-
   X", "document this feature", "polish my draft", or wants to beat blank-page
   paralysis on any Kedro docs page.
 ---
+
 # Kedro docs draft writer
 
 Write a first draft of a Kedro documentation page, or polish a draft the user already has. The output is always a starting point for human review — not a finished document.
@@ -16,19 +17,19 @@ Write a first draft of a Kedro documentation page, or polish a draft the user al
 
 The user can supply any combination of:
 
-| Input | Example |
-|---|---|
-| Topic only | "draft docs for the new `llm_context_node`" |
-| Topic + doc type | "write a how-to for streaming nodes" |
-| PR / branch context | "draft docs for the changes on this branch" |
-| Nothing (infer from branch) | "draft docs" |
+| Input                        | Example                                                                           |
+| ---------------------------- | --------------------------------------------------------------------------------- |
+| Topic only                   | "draft docs for the new `llm_context_node`"                                       |
+| Topic + doc type             | "write a how-to for streaming nodes"                                              |
+| PR / branch context          | "draft docs for the changes on this branch"                                       |
+| Nothing (infer from branch)  | "draft docs"                                                                      |
 | **Existing draft to polish** | "polish this draft", "clean up my docs", "check my draft against the style guide" |
 
 **If the user provides an existing draft to polish**, skip straight to [Polish mode](#polish-mode) below.
 
 Otherwise, work out what's missing from context. Before generating anything, confirm with the user: **topic**, **doc type**, and **proposed target file path** in a single message. Don't ask three separate questions, and don't ask again in Step 3.
 
----
+______________________________________________________________________
 
 ## Workflow
 
@@ -47,22 +48,22 @@ gh pr view --json title,body 2>/dev/null
 
 Read changed files under `kedro/` to understand what the branch adds or changes. Summarise in one sentence for the user before continuing.
 
----
+______________________________________________________________________
 
 ### 2. Classify the doc type
 
 Use the Diátaxis framework. Pick one:
 
-| Type | Purpose | Signals |
-|---|---|---|
-| **How-to** | Guide a practitioner through a specific task | "How to X", task-oriented, assumes prior knowledge |
-| **Tutorial** | Teach by doing — complete worked example | Sequential learning, beginner-oriented, has a "by the end" goal |
-| **Explanation** | Build understanding of a concept or design decision | "What is X", "Why does Kedro do X this way", no steps |
-| **Reference** | Precise, complete technical information | Config keys, CLI flags, API parameters |
+| Type            | Purpose                                             | Signals                                                         |
+| --------------- | --------------------------------------------------- | --------------------------------------------------------------- |
+| **How-to**      | Guide a practitioner through a specific task        | "How to X", task-oriented, assumes prior knowledge              |
+| **Tutorial**    | Teach by doing — complete worked example            | Sequential learning, beginner-oriented, has a "by the end" goal |
+| **Explanation** | Build understanding of a concept or design decision | "What is X", "Why does Kedro do X this way", no steps           |
+| **Reference**   | Precise, complete technical information             | Config keys, CLI flags, API parameters                          |
 
 If the user specified a doc type, use that. Otherwise infer from the topic. When ambiguous, ask.
 
----
+______________________________________________________________________
 
 ### 3. Map to a docs/ path
 
@@ -75,27 +76,30 @@ Use the directory map in [reference.md](reference.md) section "Directory map" to
 
 Include the proposed path in the single confirmation message from Step 1. Do not ask a second time here.
 
----
+______________________________________________________________________
 
 ### 4. Gather context
 
 Read the following before drafting. This is the most important step — the draft quality depends on accurate source material.
 
 **Always:**
+
 - Any existing doc in the same `docs/` subdirectory that covers a similar topic. Use it as a structural model for heading hierarchy and section order. To find candidates: `ls docs/<subdir>/`.
 - The relevant source files under `kedro/` for accurate class names, method signatures, parameter names, and default values. Read docstrings first — they are the primary source of truth for how a feature behaves.
 
 **For how-tos and tutorials:**
+
 - One existing how-to or tutorial of similar scope. Mirror its step structure and tone.
 
 **For explanations and reference:**
+
 - One existing explanation or reference page in the same directory.
 
 Read multiple files in parallel where possible. Take notes on: key classes/functions, important parameters, any caveats or version constraints, and related docs pages to cross-link.
 
 **Gap rule:** If source material is missing, ambiguous, or contradictory, do not fill the gap with plausible-sounding content. Insert a `<!-- TODO: verify — <what's unclear> -->` comment in the draft and list the gap in Step 8. Gaps are expected in a first draft; invented facts are not.
 
----
+______________________________________________________________________
 
 ### 5. Draft the page
 
@@ -110,6 +114,7 @@ Apply all style rules from [reference.md](reference.md) section "Style rules" as
 Required elements by doc type:
 
 **How-to:**
+
 - Opening sentence: one sentence stating what the reader will achieve and what prerequisite knowledge is assumed.
 - Numbered steps. Each step starts with an imperative verb.
 - Code blocks with language lexers (`python`, `bash`, `yaml`).
@@ -117,6 +122,7 @@ Required elements by doc type:
 - No explanatory tangents — link to explanation pages instead.
 
 **Tutorial:**
+
 - Opening "by the end of this tutorial" sentence.
 - Numbered sections. Each section builds on the last.
 - Complete, runnable code examples.
@@ -124,23 +130,25 @@ Required elements by doc type:
 - Expected output shown where relevant.
 
 **Explanation:**
+
 - Opening paragraph answering "what is this and why does it exist".
 - No numbered steps.
 - Use `##` subsections to group related ideas.
 - Cross-link to the relevant how-to at the end.
 
 **Reference:**
+
 - Table or definition-list format for parameters/options.
 - Every entry: name, type, default, description.
 - No prose padding — just precise facts.
 
----
+______________________________________________________________________
 
 ### 6. Write to file
 
 Write the draft to the confirmed path using the Write tool.
 
----
+______________________________________________________________________
 
 ### 7. Run Vale and fix all findings
 
@@ -160,11 +168,12 @@ Apply the fix rules from [reference.md](reference.md) section "Common Vale fixes
 
 **If Vale is not installed**, apply the manual style checklist from [reference.md](reference.md) section "Manual style checklist" as a substitute pass, then warn the user: _"Vale is not installed — install it with `brew install vale` (macOS) or `snap install vale` (Linux) and run `vale <path>` to verify the draft."_
 
----
+______________________________________________________________________
 
 ### 8. Report to the user
 
 Tell the user:
+
 - The path of the written file.
 - What the draft covers and what it deliberately leaves out (so the user knows the scope).
 - Every `<!-- TODO: verify -->` gap — list them explicitly so the user can resolve them before opening a PR.
@@ -173,9 +182,9 @@ Tell the user:
 
 Be direct about what the draft is: a starting point. The user should read it, fill the gaps, and do a final review before it goes anywhere. Don't present it as ready to ship.
 
----
+______________________________________________________________________
 
----
+______________________________________________________________________
 
 ## Polish mode
 
@@ -194,6 +203,7 @@ Follow the same Vale / manual checklist process as Step 7 in the main workflow. 
 Fix anything that is clearly wrong and has no judgment involved: Vale rule violations, spelling, sentence length, passive voice, banned terms (see [reference.md](reference.md) "Common Vale fixes").
 
 **Do not:**
+
 - Restructure sections without being asked.
 - Add content that isn't already there, implied by the source code, or requested.
 - Remove content because you think it's unnecessary — flag it instead.
@@ -206,11 +216,12 @@ For anything that would require a decision — restructuring, missing informatio
 ### P5. Report changes
 
 Tell the user:
+
 - A short list of mechanical fixes applied.
 - Every `<!-- SUGGESTION: … -->` item, with a one-line explanation of why you flagged it.
 - Any gaps you noticed (things that seem underspecified or unverifiable against the source code).
 
----
+______________________________________________________________________
 
 ## Out of scope
 

--- a/.agents/skills/kedro-docs-draft-writer/reference.md
+++ b/.agents/skills/kedro-docs-draft-writer/reference.md
@@ -4,30 +4,30 @@ Detailed reference for the `kedro-docs-draft-writer` skill. Use section headers 
 
 The full style guide is in [style-guide.md](style-guide.md). The sections below are quick-lookup summaries used during drafting and Vale triage.
 
----
+______________________________________________________________________
 
 ## Directory map
 
 Use this to pick the right `docs/` subdirectory.
 
-| Topic area | Directory |
-|---|---|
-| First steps, installation, project concepts | `docs/getting-started/` |
-| Creating projects, starters, project structure | `docs/create/` |
-| Configuration, environments, credentials, parameters | `docs/configure/` |
-| Data Catalog, datasets, factories | `docs/catalog-data/` |
-| Nodes, pipelines, pipeline registry | `docs/build/` |
-| Development: logging, debugging, testing, linting | `docs/develop/` |
-| Deployment: packaging, Docker, cloud platforms | `docs/deploy/` |
-| Extending Kedro: custom datasets, plugins, Hooks, sessions | `docs/extend/` |
-| Inspecting pipelines, Kedro-Viz | `docs/inspect/` |
-| IDE setup | `docs/ide/` |
-| Third-party integrations | `docs/integrations-and-plugins/` |
-| Step-by-step tutorials (learning-oriented) | `docs/tutorials/` |
+| Topic area                                                 | Directory                        |
+| ---------------------------------------------------------- | -------------------------------- |
+| First steps, installation, project concepts                | `docs/getting-started/`          |
+| Creating projects, starters, project structure             | `docs/create/`                   |
+| Configuration, environments, credentials, parameters       | `docs/configure/`                |
+| Data Catalog, datasets, factories                          | `docs/catalog-data/`             |
+| Nodes, pipelines, pipeline registry                        | `docs/build/`                    |
+| Development: logging, debugging, testing, linting          | `docs/develop/`                  |
+| Deployment: packaging, Docker, cloud platforms             | `docs/deploy/`                   |
+| Extending Kedro: custom datasets, plugins, Hooks, sessions | `docs/extend/`                   |
+| Inspecting pipelines, Kedro-Viz                            | `docs/inspect/`                  |
+| IDE setup                                                  | `docs/ide/`                      |
+| Third-party integrations                                   | `docs/integrations-and-plugins/` |
+| Step-by-step tutorials (learning-oriented)                 | `docs/tutorials/`                |
 
 When the topic spans two areas, prefer the more specific one. If in doubt, check the existing MkDocs nav in `docs/meta/` or `mkdocs.yml`.
 
----
+______________________________________________________________________
 
 ## Style rules (quick reference)
 
@@ -43,40 +43,40 @@ Full rules are in [style-guide.md](style-guide.md). These are the most commonly 
 - **Links**: descriptive anchor text. MkDocs autorefs (`[kedro.io.AbstractDataset][]`) for API links.
 - **Admonitions**: `!!! note`, `!!! warning`, `!!! important` — not plain bold.
 
----
+______________________________________________________________________
 
 ## Kedro-specific terms (quick reference)
 
-| Write | Not |
-|---|---|
-| `dataset` | `data set` |
-| data catalog | Data Catalog (concept); `DataCatalog` in code |
-| `Hooks` | `hooks` (Kedro Hooks system) |
-| `pipeline` | `Pipeline` (concept; `Pipeline` only for the class in code) |
-| backend | back end |
-| runtime | run time |
-| Kedro | kedro |
+| Write        | Not                                                         |
+| ------------ | ----------------------------------------------------------- |
+| `dataset`    | `data set`                                                  |
+| data catalog | Data Catalog (concept); `DataCatalog` in code               |
+| `Hooks`      | `hooks` (Kedro Hooks system)                                |
+| `pipeline`   | `Pipeline` (concept; `Pipeline` only for the class in code) |
+| backend      | back end                                                    |
+| runtime      | run time                                                    |
+| Kedro        | kedro                                                       |
 
----
+______________________________________________________________________
 
 ## Common Vale fixes
 
-| Rule | Finding | Fix |
-|---|---|---|
-| `Kedro.words` | "data set" | "dataset" |
-| `Kedro.words` | "in order to" | "to" |
-| `Kedro.words` | "utilize", "leverage" | "use" |
-| `Kedro.words` | "simply", "easily", "quickly", "just", "please" | delete |
-| `Kedro.words` | "via" | "with" or "through" |
-| `Kedro.words` | "Note that" | `!!! note` or rephrase |
-| `Kedro.words` | "once" (meaning "after") | "after" |
-| `Kedro.headings` | Title case heading | Convert to sentence case |
-| `Kedro.sentencelength` | Sentence > 30 words | Split into two sentences |
-| `Kedro.weaselwords` | "absolutely", "basically", etc. | delete or rewrite |
-| `Kedro.ukspelling` | "customize", "initialize", etc. | add a `u`: "customise", "initialise" |
-| `Vale.Passive` | Passive construction | Rewrite in active voice |
+| Rule                   | Finding                                         | Fix                                  |
+| ---------------------- | ----------------------------------------------- | ------------------------------------ |
+| `Kedro.words`          | "data set"                                      | "dataset"                            |
+| `Kedro.words`          | "in order to"                                   | "to"                                 |
+| `Kedro.words`          | "utilize", "leverage"                           | "use"                                |
+| `Kedro.words`          | "simply", "easily", "quickly", "just", "please" | delete                               |
+| `Kedro.words`          | "via"                                           | "with" or "through"                  |
+| `Kedro.words`          | "Note that"                                     | `!!! note` or rephrase               |
+| `Kedro.words`          | "once" (meaning "after")                        | "after"                              |
+| `Kedro.headings`       | Title case heading                              | Convert to sentence case             |
+| `Kedro.sentencelength` | Sentence > 30 words                             | Split into two sentences             |
+| `Kedro.weaselwords`    | "absolutely", "basically", etc.                 | delete or rewrite                    |
+| `Kedro.ukspelling`     | "customize", "initialize", etc.                 | add a `u`: "customise", "initialise" |
+| `Vale.Passive`         | Passive construction                            | Rewrite in active voice              |
 
----
+______________________________________________________________________
 
 ## Manual style checklist
 

--- a/.agents/skills/kedro-docs-draft-writer/style-guide.md
+++ b/.agents/skills/kedro-docs-draft-writer/style-guide.md
@@ -4,7 +4,7 @@ A synthesised reference for anyone writing Kedro docs. Rules here draw from the 
 
 When this guide is silent on something, defer to the Microsoft Writing Style Guide.
 
----
+______________________________________________________________________
 
 ## Voice and tone
 
@@ -14,7 +14,7 @@ Kedro docs have three qualities: **simple**, **friendly**, and **functional**.
 - **Friendly**: approachable, never negative or condescending. Write like a knowledgeable colleague explaining something, not a manual.
 - **Functional**: get to the point. Tell the reader what they need to do or know, then stop.
 
----
+______________________________________________________________________
 
 ## Language
 
@@ -22,16 +22,16 @@ Kedro docs have three qualities: **simple**, **friendly**, and **functional**.
 
 Kedro uses UK English. Common differences from US English:
 
-| UK (use this) | US (not this) |
-|---|---|
-| customise | customize |
-| initialise | initialize |
-| colour | color |
-| behaviour | behavior |
-| centre | center |
-| catalogue | catalog (exception: see [Kedro terms](#kedro-specific-terms)) |
-| licence (noun) | license (noun) |
-| organise | organize |
+| UK (use this)  | US (not this)                                                 |
+| -------------- | ------------------------------------------------------------- |
+| customise      | customize                                                     |
+| initialise     | initialize                                                    |
+| colour         | color                                                         |
+| behaviour      | behavior                                                      |
+| centre         | center                                                        |
+| catalogue      | catalog (exception: see [Kedro terms](#kedro-specific-terms)) |
+| licence (noun) | license (noun)                                                |
+| organise       | organize                                                      |
 
 ### Contractions
 
@@ -41,23 +41,23 @@ Use contractions to keep the tone friendly: _it's, you'll, you're, we're, let's,
 
 Write in active voice. The "by zombies" test: if you can add "by zombies" after the verb and the sentence still makes sense, rewrite it.
 
-| Passive (avoid) | Active (use) |
-|---|---|
-| The pipeline is run by the runner. | The runner executes the pipeline. |
-| Parameters can be configured in `parameters.yml`. | Configure parameters in `parameters.yml`. |
+| Passive (avoid)                                         | Active (use)                                 |
+| ------------------------------------------------------- | -------------------------------------------- |
+| The pipeline is run by the runner.                      | The runner executes the pipeline.            |
+| Parameters can be configured in `parameters.yml`.       | Configure parameters in `parameters.yml`.    |
 | Credentials should not be committed to version control. | Don't commit credentials to version control. |
 
 ### Imperative mood
 
 Start instructions with a verb. Remove "you can" and "you should" — they add length and weaken the instruction.
 
-| Weak | Strong |
-|---|---|
-| You can run the pipeline with `kedro run`. | Run the pipeline with `kedro run`. |
-| There is a way to create custom datasets. | Create a custom dataset by … |
+| Weak                                            | Strong                               |
+| ----------------------------------------------- | ------------------------------------ |
+| You can run the pipeline with `kedro run`.      | Run the pipeline with `kedro run`.   |
+| There is a way to create custom datasets.       | Create a custom dataset by …         |
 | You should avoid storing credentials in `base`. | Avoid storing credentials in `base`. |
 
----
+______________________________________________________________________
 
 ## Structure and length
 
@@ -69,8 +69,8 @@ Keep sentences to 30 words or fewer. If a sentence is longer, split it. Shorter 
 
 Lead with the most important information. Don't bury the key fact or action in the middle of a paragraph.
 
-| Back-loaded | Front-loaded |
-|---|---|
+| Back-loaded                                                                                     | Front-loaded                                       |
+| ----------------------------------------------------------------------------------------------- | -------------------------------------------------- |
 | If you want to run only part of your pipeline, there is a flag you can use called `--to-nodes`. | Use `--to-nodes` to run a subset of your pipeline. |
 
 ### Paragraphs
@@ -81,7 +81,7 @@ One idea per paragraph. Three to five sentences maximum.
 
 Prune every excess word. Ask: does this word or sentence add information the reader needs? If not, delete it.
 
----
+______________________________________________________________________
 
 ## Headings
 
@@ -91,7 +91,7 @@ Prune every excess word. Ask: does this word or sentence add information the rea
 - Use noun phrases for concept and reference headings: "Pipeline slicing" not "How to slice a pipeline".
 - Capitalise proper nouns and Kedro-specific terms that are always capitalised (see [Kedro terms](#kedro-specific-terms)).
 
----
+______________________________________________________________________
 
 ## Lists
 
@@ -101,7 +101,7 @@ Prune every excess word. Ask: does this word or sentence add information the rea
 - Use **unordered** lists for everything else — options, features, related items.
 - Use the Oxford (serial) comma in running prose: "nodes, pipelines, and datasets" not "nodes, pipelines and datasets".
 
----
+______________________________________________________________________
 
 ## Punctuation
 
@@ -110,7 +110,7 @@ Prune every excess word. Ask: does this word or sentence add information the rea
 - Use a colon to introduce a list or a code block, not a semicolon.
 - Skip end punctuation on list items of three or fewer words.
 
----
+______________________________________________________________________
 
 ## Code and commands
 
@@ -120,7 +120,7 @@ Prune every excess word. Ask: does this word or sentence add information the rea
 - Use inline code formatting for: file names, directory names, class names, method names, parameters, config keys, and CLI flags.
 - Do not use inline code for general concepts: write "the data catalog", not "`the data catalog`".
 
----
+______________________________________________________________________
 
 ## Links
 
@@ -129,12 +129,12 @@ Prune every excess word. Ask: does this word or sentence add information the rea
 - For internal links, use relative paths from the current file.
 - For Kedro API cross-references, use MkDocs autorefs syntax: `[kedro.io.AbstractDataset][]`.
 
-| Avoid | Use |
-|---|---|
-| Download the starter [here](link). | [Download the starter](link). |
+| Avoid                                       | Use                                                    |
+| ------------------------------------------- | ------------------------------------------------------ |
+| Download the starter [here](link).          | [Download the starter](link).                          |
 | See [this page](link) for more information. | See [configuration basics](link) for more information. |
 
----
+______________________________________________________________________
 
 ## Admonitions
 
@@ -153,51 +153,51 @@ Use MkDocs admonition blocks sparingly. Only use them when the information is ge
 
 Do not use plain bold text as a substitute for a `!!! note` block, and don't use `Note that` as a sentence opener — it is flagged by Vale. Use the admonition or rephrase.
 
----
+______________________________________________________________________
 
 ## Kedro-specific terms
 
 Use these terms consistently. Inconsistency confuses readers and breaks docs search.
 
-| Write | Not |
-|---|---|
-| `dataset` | `data set` |
-| data catalog | Data Catalog (the concept) |
-| `DataCatalog` | `Data Catalog` (the class — use inline code) |
-| `Hooks` | `hooks` (the Kedro Hooks system, capitalised following React convention) |
-| `pipeline` | `Pipeline` (the concept — use lowercase; reserve `Pipeline` for the class in code) |
-| backend | back end |
-| frontend | front end |
-| runtime | run time |
-| Kedro | kedro (always capitalise the product name) |
-| Kedro-Viz | KedroViz, kedro-viz |
+| Write         | Not                                                                                |
+| ------------- | ---------------------------------------------------------------------------------- |
+| `dataset`     | `data set`                                                                         |
+| data catalog  | Data Catalog (the concept)                                                         |
+| `DataCatalog` | `Data Catalog` (the class — use inline code)                                       |
+| `Hooks`       | `hooks` (the Kedro Hooks system, capitalised following React convention)           |
+| `pipeline`    | `Pipeline` (the concept — use lowercase; reserve `Pipeline` for the class in code) |
+| backend       | back end                                                                           |
+| frontend      | front end                                                                          |
+| runtime       | run time                                                                           |
+| Kedro         | kedro (always capitalise the product name)                                         |
+| Kedro-Viz     | KedroViz, kedro-viz                                                                |
 
 ### Terms from the Vale word list
 
 The following substitutions are enforced by Vale. Apply them in prose:
 
-| Use | Not |
-|---|---|
-| acknowledgment | acknowledgement |
-| autocomplete | auto-complete |
-| few, several, or many | a number of |
-| and / or | and/or |
-| examine, investigate, or analyse | drill down, drill into |
-| determine | figure out |
-| customise, optimise, or refine | fine-tune |
-| generally or usually | for the most part |
-| consider | keep in mind |
-| use | leverage, utilize |
-| after | once (when meaning "after") |
-| select or click | hit |
-| to | in order to |
-| real-time | on the fly |
-| see or read | refer to, visit |
-| trade-off | tradeoff |
-| use | leverage |
-| with or through | via |
+| Use                              | Not                         |
+| -------------------------------- | --------------------------- |
+| acknowledgment                   | acknowledgement             |
+| autocomplete                     | auto-complete               |
+| few, several, or many            | a number of                 |
+| and / or                         | and/or                      |
+| examine, investigate, or analyse | drill down, drill into      |
+| determine                        | figure out                  |
+| customise, optimise, or refine   | fine-tune                   |
+| generally or usually             | for the most part           |
+| consider                         | keep in mind                |
+| use                              | leverage, utilize           |
+| after                            | once (when meaning "after") |
+| select or click                  | hit                         |
+| to                               | in order to                 |
+| real-time                        | on the fly                  |
+| see or read                      | refer to, visit             |
+| trade-off                        | tradeoff                    |
+| use                              | leverage                    |
+| with or through                  | via                         |
 
----
+______________________________________________________________________
 
 ## Capitalisation reference
 
@@ -214,7 +214,7 @@ Never capitalise:
 - cloud, internet, machine learning, analytics
 - General terms: catalog, configuration, parameter, environment
 
----
+______________________________________________________________________
 
 ## Inclusive language
 
@@ -225,13 +225,13 @@ Never capitalise:
 - Rewrite to use second person ("you") wherever possible — it is cleaner and more direct.
 - Use role-based terms instead of gendered ones.
 
-| Avoid | Use |
-|---|---|
-| man-hours | person-hours |
-| mankind | people, humanity |
-| manpower | workforce, staff |
-| chairman | chair, moderator |
-| salesman | sales representative |
+| Avoid     | Use                  |
+| --------- | -------------------- |
+| man-hours | person-hours         |
+| mankind   | people, humanity     |
+| manpower  | workforce, staff     |
+| chairman  | chair, moderator     |
+| salesman  | sales representative |
 
 ### Disability
 
@@ -241,26 +241,26 @@ Never capitalise:
 - Don't call non-disabled people "normal" or "healthy" as a contrast.
 - Avoid euphemisms: "differently abled" and "special needs" are considered patronising by many disability advocates.
 
-| Avoid | Use |
-|---|---|
-| The blind | People who are blind or have low vision |
-| Suffers from | Has |
-| Blind to the problem | Unaware of the problem |
-| Crippled by legacy code | Slowed by legacy code |
-| Dumb variable name | Unclear variable name |
+| Avoid                   | Use                                     |
+| ----------------------- | --------------------------------------- |
+| The blind               | People who are blind or have low vision |
+| Suffers from            | Has                                     |
+| Blind to the problem    | Unaware of the problem                  |
+| Crippled by legacy code | Slowed by legacy code                   |
+| Dumb variable name      | Unclear variable name                   |
 
 ### Non-inclusive technical terms
 
 These terms have problematic historical associations. Use the replacements in all new documentation.
 
-| Avoid | Use |
-|---|---|
-| whitelist | allowlist |
-| blacklist | denylist |
+| Avoid          | Use                                                         |
+| -------------- | ----------------------------------------------------------- |
+| whitelist      | allowlist                                                   |
+| blacklist      | denylist                                                    |
 | master / slave | primary / replica, primary / secondary, controller / worker |
-| sanity check | check, verify, validate |
-| dummy value | placeholder value, example value |
-| native speaker | (rephrase to discuss the feature directly) |
+| sanity check   | check, verify, validate                                     |
+| dummy value    | placeholder value, example value                            |
+| native speaker | (rephrase to discuss the feature directly)                  |
 
 When a Kedro API or third-party tool still uses these terms in its interface, format them in code (`master`, `whitelist`) and use the preferred term in surrounding prose.
 
@@ -275,30 +275,30 @@ When a Kedro API or third-party tool still uses these terms in its interface, fo
 
 Avoid figurative violent language in prose.
 
-| Avoid | Use |
-|---|---|
-| kill the process | stop the process, terminate the process |
-| hit the endpoint | call the endpoint, send a request to the endpoint |
-| nuke the database | delete the database, drop all tables |
-| hang (as in "the process hangs") | stop responding, become unresponsive |
+| Avoid                            | Use                                               |
+| -------------------------------- | ------------------------------------------------- |
+| kill the process                 | stop the process, terminate the process           |
+| hit the endpoint                 | call the endpoint, send a request to the endpoint |
+| nuke the database                | delete the database, drop all tables              |
+| hang (as in "the process hangs") | stop responding, become unresponsive              |
 
----
+______________________________________________________________________
 
 ## What not to write
 
 These are common patterns that make docs harder to read. Vale flags most of them.
 
-| Pattern | Why | Fix |
-|---|---|---|
-| "simply", "easily", "quickly", "just" | Implies the task is trivial — alienating when it isn't | Delete |
-| "please" | Unnecessary in instructions | Delete |
-| "obviously", "of course", "clearly" | Condescending | Delete |
-| "Note that" | Verbose opener | Use `!!! note` or rephrase |
-| "in order to" | Verbose | Replace with "to" |
-| "utilize" | Bureaucratic | Replace with "use" |
-| "leverage" | Jargon | Replace with "use" |
-| "allows" | Incorrect | Replace with "enables" |
-| "via" | Ambiguous | Replace with "with" or "through" |
-| "once" (meaning "after") | Ambiguous | Replace with "after" |
-| Weasel adverbs: "absolutely", "basically", "arguably" | Hedge without adding meaning | Delete |
-| Too-wordy phrases: "a number of", "due to the fact that" | Verbose | Use shorter equivalents |
+| Pattern                                                  | Why                                                    | Fix                              |
+| -------------------------------------------------------- | ------------------------------------------------------ | -------------------------------- |
+| "simply", "easily", "quickly", "just"                    | Implies the task is trivial — alienating when it isn't | Delete                           |
+| "please"                                                 | Unnecessary in instructions                            | Delete                           |
+| "obviously", "of course", "clearly"                      | Condescending                                          | Delete                           |
+| "Note that"                                              | Verbose opener                                         | Use `!!! note` or rephrase       |
+| "in order to"                                            | Verbose                                                | Replace with "to"                |
+| "utilize"                                                | Bureaucratic                                           | Replace with "use"               |
+| "leverage"                                               | Jargon                                                 | Replace with "use"               |
+| "allows"                                                 | Incorrect                                              | Replace with "enables"           |
+| "via"                                                    | Ambiguous                                              | Replace with "with" or "through" |
+| "once" (meaning "after")                                 | Ambiguous                                              | Replace with "after"             |
+| Weasel adverbs: "absolutely", "basically", "arguably"    | Hedge without adding meaning                           | Delete                           |
+| Too-wordy phrases: "a number of", "due to the fact that" | Verbose                                                | Use shorter equivalents          |

--- a/.agents/skills/kedro-security-review/SKILL.md
+++ b/.agents/skills/kedro-security-review/SKILL.md
@@ -30,6 +30,7 @@ Then run the numbered Workflow below:
 ## References
 
 Read these before triaging findings:
+
 - [../../../docs/about/security_model.md](../../../docs/about/security_model.md)
 - [reference.md](reference.md)
 
@@ -49,22 +50,22 @@ If the user already stated the scope, do not ask again.
 ## Defaults
 
 - Runtime:
-  - `semgrep`
-  - otherwise `uvx --from semgrep semgrep`
-  - otherwise `uv tool run --from semgrep semgrep`
+    - `semgrep`
+    - otherwise `uvx --from semgrep semgrep`
+    - otherwise `uv tool run --from semgrep semgrep`
 - Rulesets:
-  - `p/security-audit`
-  - `p/secrets`
-  - `p/python`
-  - `.agents/skills/kedro-security-review/rules/kedro-security-patterns.yml`
+    - `p/security-audit`
+    - `p/secrets`
+    - `p/python`
+    - `.agents/skills/kedro-security-review/rules/kedro-security-patterns.yml`
 - Path exclusions (every Semgrep invocation):
-  - `--exclude tests/`
-  - `--exclude docs/`
-  - `--exclude features/`
-  - `--exclude .agents/`
+    - `--exclude tests/`
+    - `--exclude docs/`
+    - `--exclude features/`
+    - `--exclude .agents/`
 - Temporary working directory:
-  - create with `mktemp -d`
-  - delete at the end unless the user explicitly asks to keep artifacts
+    - create with `mktemp -d`
+    - delete at the end unless the user explicitly asks to keep artifacts
 
 Always use `--metrics=off`.
 
@@ -95,6 +96,7 @@ and there is no PR to attach it to in full-codebase mode. If a user asks to
 post a full-codebase scan, fall back to chat mode and tell the user why.
 
 In post mode:
+
 - still do all scanning and triage locally first
 - construct one final GitHub review payload
 - post it after the review is complete
@@ -109,6 +111,7 @@ Use when the user asks to scan the repo, codebase, project, or current branch
 without narrowing to a PR.
 
 Target:
+
 - the current repo root
 
 ### PR mode
@@ -117,6 +120,7 @@ Use when the user asks to scan a PR or when the request names a PR number or
 URL.
 
 Resolve the PR from:
+
 - the explicit PR number or URL if provided
 - otherwise the current branch via `gh pr view`
 
@@ -287,13 +291,15 @@ ruleset output, count it once.
 ### 6. Triage against the Kedro security model
 
 For every unique finding:
+
 - open the flagged file and inspect the surrounding code
 - classify it using [reference.md](reference.md)
 - tie the reasoning back to the code-vs-data boundary in
-  [../../../docs/about/security_model.md](../../../docs/about/security_model.md)
+    [../../../docs/about/security_model.md](../../../docs/about/security_model.md)
 - include the **Suggested next step** from the matching bucket in `reference.md`
 
 Use these buckets:
+
 - `candidate_kedro_vulnerability`
 - `project_developer_responsibility`
 - `deployment_or_environment_issue`
@@ -306,9 +312,10 @@ After triaging Semgrep output, run the **Manual review checks** from
 `reference.md` against the scan target.
 
 For each check:
+
 - Search the scanned files for the pattern described
 - If found and unmitigated, add it to the findings list with classification
-  `candidate_kedro_vulnerability` or `needs_manual_review`
+    `candidate_kedro_vulnerability` or `needs_manual_review`
 - If not found, the check was clean — do not itemise it
 
 When all checks are clean, report them as a single line in the final report
@@ -339,6 +346,7 @@ Keep the report short and decisive. The classification summary already carries
 the counts — do not repeat non-actionable findings as prose.
 
 Always include:
+
 - mode used: full codebase or PR
 - scan scope: framework code or Kedro project
 - target scanned
@@ -347,13 +355,15 @@ Always include:
 - highest Semgrep severities present
 
 **Only itemise actionable findings** in the Findings section:
+
 - Always: `candidate_kedro_vulnerability`, `needs_manual_review`
 - When scope is **Kedro project**: also `project_developer_responsibility`
-  (this is the primary actionable bucket for the project owner — include file,
-  line, rule id, and suggested fix for each finding)
+    (this is the primary actionable bucket for the project owner — include file,
+    line, rule id, and suggested fix for each finding)
 
 **Do not itemise** findings in these buckets — they are reflected in the
 classification summary counts and that is sufficient:
+
 - `false_positive_or_informational`
 - `deployment_or_environment_issue`
 - `project_developer_responsibility` when scope is **Kedro framework**
@@ -363,6 +373,7 @@ that names the non-actionable counts (e.g. "None actionable. 2 false positives
 on pre-existing lines.").
 
 For each actionable finding, include:
+
 - file
 - line
 - rule id
@@ -434,6 +445,7 @@ Write one GitHub review payload:
 ```
 
 Use inline comments only for actionable findings tied to changed PR lines:
+
 - Always: `candidate_kedro_vulnerability`, `needs_manual_review`
 - When scope is **Kedro project**: also `project_developer_responsibility`
 

--- a/.agents/skills/kedro-security-review/reference.md
+++ b/.agents/skills/kedro-security-review/reference.md
@@ -10,6 +10,7 @@ finding is actually a Kedro issue.
 ### `candidate_kedro_vulnerability`
 
 Use when the finding points to behavior in Kedro framework code where:
+
 - data may become executable behavior
 - Kedro appears to use unsafe deserialization on user-controlled input
 - Kedro appears to bypass or fail a documented safety restriction
@@ -19,15 +20,15 @@ Severity determines how the finding is surfaced to the user (the skill itself
 does not enforce anything — it only reports):
 
 - **ERROR severity** — the rule has high confidence and critical impact (e.g.
-  RCE, arbitrary code execution, credential exposure). **Flag prominently and
-  recommend fixing before the code is merged or released.** Suggest discussing
-  with maintainers as part of the PR review. If the same pattern is later
-  confirmed to exist in an already-released version, that is when a Security
-  Advisory becomes relevant — not at PR time.
+    RCE, arbitrary code execution, credential exposure). **Flag prominently and
+    recommend fixing before the code is merged or released.** Suggest discussing
+    with maintainers as part of the PR review. If the same pattern is later
+    confirmed to exist in an already-released version, that is when a Security
+    Advisory becomes relevant — not at PR time.
 - **WARNING severity** — plausible risk but lower confidence or limited impact.
-  **Recommend investigating and fixing, but it does not need to block the
-  merge.** Suggest opening a maintainer follow-up issue if it can't be resolved
-  in the current PR.
+    **Recommend investigating and fixing, but it does not need to block the
+    merge.** Suggest opening a maintainer follow-up issue if it can't be resolved
+    in the current PR.
 
 ### `project_developer_responsibility`
 
@@ -76,9 +77,10 @@ For every function that takes a `dict` from user config (YAML, env var, API),
 ask: **does this library treat any key as a callable specification?**
 
 Known dangerous key conventions:
+
 - `()` — Python logging `dictConfig` factory callable
 - `class` — Python logging `dictConfig` handler/formatter class (fully-qualified
-  dotted path, resolved via dynamic import)
+    dotted path, resolved via dynamic import)
 - `py/object`, `py/reduce` — jsonpickle
 - `!!python/object` — yaml.load without safe loader
 - `_target_` — Hydra/OmegaConf structured config instantiation
@@ -101,39 +103,43 @@ no validation, classify as `candidate_kedro_vulnerability`.
 
 For any new code that constructs a file path from a string that originates
 outside Kedro's own defaults (CLI arg, env var, catalog config, API param):
+
 - Check whether `..` or absolute path segments are rejected before use
 - If not: `needs_manual_review` at minimum
 
 ### 4. Security suppression comments
 
 Search scanned files for comments that suppress security scanner findings:
+
 - `# nosec` (Bandit)
 - `# nosemgrep` (Semgrep)
 - `# type: ignore[` used alongside a `nosec` or `nosemgrep` on the same line
-  (occasionally combined to silence both type-checker and security scanner)
+    (occasionally combined to silence both type-checker and security scanner)
 
 A suppression comment makes the flagged code invisible to the scanner. If the
 suppression is unjustified or outdated, it silently masks a real vulnerability.
 
 For every match, classify as `needs_manual_review` and ask the reviewer to
 verify:
+
 1. The suppression is still necessary — the underlying issue has not been
-   refactored away.
+    refactored away.
 2. The risk is documented — there is an adjacent comment explaining **why** the
-   suppression is safe.
+    suppression is safe.
 3. There is no code-level fix that would remove the need for suppression
-   entirely.
+    entirely.
 
 **PR mode — new vs. pre-existing suppressions:**
 
 In PR mode, compare each hit against the PR diff (`gh pr diff <number>`).
+
 - A suppression whose line appears in the diff (added or modified) is a **new
-  suppression** — flag it with higher priority. New suppressions in a PR are
-  the primary concern: they indicate that a contributor is actively silencing a
-  scanner finding on code that is about to be merged.
+    suppression** — flag it with higher priority. New suppressions in a PR are
+    the primary concern: they indicate that a contributor is actively silencing a
+    scanner finding on code that is about to be merged.
 - A suppression on a line not in the diff is **pre-existing** — still flag it
-  as `needs_manual_review`, but note that it predates this PR so it may be
-  tracked separately (e.g. in a follow-up cleanup issue).
+    as `needs_manual_review`, but note that it predates this PR so it may be
+    tracked separately (e.g. in a follow-up cleanup issue).
 
 In full-codebase mode, all suppressions are treated equally (there is no diff
 to distinguish new from old).
@@ -178,16 +184,16 @@ class paths, pipeline modules, and settings are all loaded this way from
 project config.
 
 - If the module path originates from `catalog.yml`, `settings.py`, or other
-  **project developer-authored config**, classify as
-  `project_developer_responsibility`.
+    **project developer-authored config**, classify as
+    `project_developer_responsibility`.
 - If the module path could be influenced by **external runtime input** with no
-  validation (e.g. user-supplied parameters flowing into an import call),
-  classify as `candidate_kedro_vulnerability`.
+    validation (e.g. user-supplied parameters flowing into an import call),
+    classify as `candidate_kedro_vulnerability`.
 - If the call is inside Kedro framework code and the input path is not
-  validated or allowlisted before importing, classify as
-  `candidate_kedro_vulnerability`.
+    validated or allowlisted before importing, classify as
+    `candidate_kedro_vulnerability`.
 - In most cases this will be `false_positive_or_informational` — confirm by
-  tracing where the argument originates.
+    tracing where the argument originates.
 
 ### `kedro-taint-config-to-callable-sink`
 
@@ -208,14 +214,14 @@ any config data reaching a callable sink is tracked regardless of how it was
 parsed.
 
 - If the tainted value flows into any sink with no sanitization and the source
-  is user-controllable at runtime (env var, API, external file): classify as
-  `candidate_kedro_vulnerability`.
+    is user-controllable at runtime (env var, API, external file): classify as
+    `candidate_kedro_vulnerability`.
 - If the source is a framework-internal default file with no external override
-  path: classify as `false_positive_or_informational`.
+    path: classify as `false_positive_or_informational`.
 - If the source is developer-authored project config not reachable by external
-  users: classify as `project_developer_responsibility`.
+    users: classify as `project_developer_responsibility`.
 - Trace whether the taint path crosses a sanitizer (e.g. `()` key rejection,
-  allowlist check) before classifying.
+    allowlist check) before classifying.
 
 ### `kedro-taint-string-param-to-path`
 
@@ -226,17 +232,18 @@ are intentionally out of scope to limit noise — flag any untyped string
 parameters reaching path sinks as `needs_manual_review` instead.
 
 Triage steps:
+
 1. Trace where the `str` parameter originates. If it comes from developer-authored
-   config (`catalog.yml`, `settings.py`, project code), classify as
-   `project_developer_responsibility`.
+    config (`catalog.yml`, `settings.py`, project code), classify as
+    `project_developer_responsibility`.
 2. If the parameter can be set by an untrusted external caller (API input, CI
-   trigger, multi-tenant platform), classify as `candidate_kedro_vulnerability`
-   if there is no `..` / absolute-path check anywhere in the call chain, or
-   `deployment_or_environment_issue` if the deployment is expected to sanitize.
+    trigger, multi-tenant platform), classify as `candidate_kedro_vulnerability`
+    if there is no `..` / absolute-path check anywhere in the call chain, or
+    `deployment_or_environment_issue` if the deployment is expected to sanitize.
 3. If the path operation is a read-only probe (`.exists()`, `.is_absolute()`,
-   `.is_dir()`), classify as `false_positive_or_informational`.
+    `.is_dir()`), classify as `false_positive_or_informational`.
 4. If the flagged function is itself a sanitizer (checking for `..` or absolute
-   paths), classify as `false_positive_or_informational`.
+    paths), classify as `false_positive_or_informational`.
 
 ### `kedro-subprocess-shell-injection`
 
@@ -245,26 +252,25 @@ plain string literal. This includes:
 
 - Variable-derived strings (most common case — possible RCE)
 - List-form calls (`subprocess.run([cmd], shell=True)`) — flagged because
-  Python only passes the first list element to the shell, which is rarely
-  intentional and easy to misuse, even when the list contents are literals
+    Python only passes the first list element to the shell, which is rarely
+    intentional and easy to misuse, even when the list contents are literals
 
 Triage steps:
 
-1. **List with only literal elements** (e.g. `subprocess.run(["ls", "-l"],
-   shell=True)`): code smell but not exploitable in isolation. Classify as
-   `false_positive_or_informational`; recommend converting to `shell=False`
-   with the same list.
+1. **List with only literal elements** (e.g. `subprocess.run(["ls", "-l"], shell=True)`): code smell but not exploitable in isolation. Classify as
+    `false_positive_or_informational`; recommend converting to `shell=False`
+    with the same list.
 2. Trace where `$CMD` originates. If it is a hardcoded string assembled only
-   from framework-internal defaults (no external input), classify as
-   `false_positive_or_informational`.
+    from framework-internal defaults (no external input), classify as
+    `false_positive_or_informational`.
 3. If `$CMD` is constructed from a developer-authored project value
-   (e.g. a Kedro node name, pipeline name, or catalog key provided in
-   `catalog.yml`), classify as `project_developer_responsibility`.
+    (e.g. a Kedro node name, pipeline name, or catalog key provided in
+    `catalog.yml`), classify as `project_developer_responsibility`.
 4. If `$CMD` can be influenced by an untrusted external caller (env var, API
-   input, CI trigger, user-supplied CLI flag) with no allowlist or escaping,
-   classify as `candidate_kedro_vulnerability` at ERROR severity.
+    input, CI trigger, user-supplied CLI flag) with no allowlist or escaping,
+    classify as `candidate_kedro_vulnerability` at ERROR severity.
 5. If the origin is unclear without deeper runtime context, classify as
-   `needs_manual_review`.
+    `needs_manual_review`.
 
 Note: `shell=False` with an explicit list argument (`[cmd, arg1, arg2]`) is
 always safe regardless of where the arguments come from, because the shell
@@ -277,22 +283,22 @@ Fires on `yaml.load()` without a safe Loader. Kedro should always use
 config files are user-controlled data.
 
 - If found in **Kedro framework code** (`kedro/` package): classify as
-  `candidate_kedro_vulnerability` — unsafe YAML deserialization on
-  user-controlled config can execute arbitrary Python objects.
+    `candidate_kedro_vulnerability` — unsafe YAML deserialization on
+    user-controlled config can execute arbitrary Python objects.
 - If found in **project developer code**: classify as
-  `project_developer_responsibility`.
+    `project_developer_responsibility`.
 - `yaml.safe_load()` is a separate function and is never matched by this rule
-  (the pattern is `yaml.load(...)` only). For `yaml.load(...)`, safe loaders
-  are excluded via `pattern-not` for both the fully-qualified forms
-  (`Loader=yaml.SafeLoader`, `Loader=yaml.CSafeLoader`, and positional
-  `yaml.SafeLoader` / `yaml.CSafeLoader`) and the unqualified forms used after
-  `from yaml import SafeLoader` (`Loader=SafeLoader`, `Loader=CSafeLoader`,
-  and positional `SafeLoader` / `CSafeLoader`).
+    (the pattern is `yaml.load(...)` only). For `yaml.load(...)`, safe loaders
+    are excluded via `pattern-not` for both the fully-qualified forms
+    (`Loader=yaml.SafeLoader`, `Loader=yaml.CSafeLoader`, and positional
+    `yaml.SafeLoader` / `yaml.CSafeLoader`) and the unqualified forms used after
+    `from yaml import SafeLoader` (`Loader=SafeLoader`, `Loader=CSafeLoader`,
+    and positional `SafeLoader` / `CSafeLoader`).
 - `yaml.CLoader` is **not** safe — it is the C extension of `FullLoader`, not
-  `SafeLoader`. Do not treat `yaml.load(..., Loader=yaml.CLoader)` as safe; the
-  rule will fire on it and it should be classified as
-  `candidate_kedro_vulnerability` in Kedro framework code.
+    `SafeLoader`. Do not treat `yaml.load(..., Loader=yaml.CLoader)` as safe; the
+    rule will fire on it and it should be classified as
+    `candidate_kedro_vulnerability` in Kedro framework code.
 - `yaml.FullLoader` is **not** excluded — it is not safe for user-controlled
-  data (can deserialise Python objects via `!!python/object/apply`). Treat any
-  `yaml.load(..., Loader=yaml.FullLoader)` in Kedro framework code as
-  `candidate_kedro_vulnerability`.
+    data (can deserialise Python objects via `!!python/object/apply`). Treat any
+    `yaml.load(..., Loader=yaml.FullLoader)` in Kedro framework code as
+    `candidate_kedro_vulnerability`.

--- a/.agents/skills/review-kedro-pr/SKILL.md
+++ b/.agents/skills/review-kedro-pr/SKILL.md
@@ -5,6 +5,7 @@ description: >-
   clarity. Optionally post findings as a GitHub PR comment. Use when the user
   asks to review a PR, review this PR, or do a PR review.
 ---
+
 # Review Kedro PR
 
 Review a Kedro pull request. Start with general review guidelines (any project), then apply Kedro-specific checks. Output findings to chat by default, or post to GitHub when asked.
@@ -38,6 +39,7 @@ Work through the general review guidelines first, then the Kedro-specific review
 ### 4. Verify findings
 
 Before delivering, go through every finding one by one and check:
+
 - Is this actually a problem, or a false positive?
 - Is the file path and line number correct?
 - Is the severity (Critical vs Suggestion) appropriate?
@@ -52,7 +54,7 @@ Format findings using the "Output format" section at the end of this file. Two m
 - **Review only (default):** Output all findings as chat messages. The user can read, edit, or discard before deciding whether to post.
 - **Review and post:** When the user explicitly says "post", "submit", or "review and post", post findings directly to the PR on GitHub. See "Output format" for the exact commands.
 
----
+______________________________________________________________________
 
 ## General review guidelines
 
@@ -62,9 +64,9 @@ These apply to any project. Work through them in order.
 
 - Understand what problem the PR is solving.
 - Read the PR description thoroughly, including:
-  - Dev notes
-  - Linked issues
-  - Any prior discussions or comments
+    - Dev notes
+    - Linked issues
+    - Any prior discussions or comments
 
 ### 2. Evaluate PR scope
 
@@ -77,22 +79,22 @@ These apply to any project. Work through them in order.
 - Check if QA/testing steps are mentioned in the PR description.
 - If not, ask the author to add clear steps to validate the changes.
 - Mentally walk through the described QA steps and verify:
-  - Expected functionality
-  - Edge cases and failure scenarios
+    - Expected functionality
+    - Edge cases and failure scenarios
 - Watch out for regressions or unintended side effects.
 
 ### 4. Code review and readability
 
 - Go through the file changes and understand the logic.
 - Suggest improvements where needed:
-  - Better variable/function names
-  - Cleaner structure or readability
+    - Better variable/function names
+    - Cleaner structure or readability
 
 ### 5. Code design and modularity
 
 - Look for opportunities to improve structure:
-  - Can large functions be split?
-  - Can logic be broken into smaller, reusable pieces?
+    - Can large functions be split?
+    - Can logic be broken into smaller, reusable pieces?
 - Suggest helper/utility functions if the same logic is repeated.
 - Aim for simple, maintainable code.
 
@@ -101,18 +103,18 @@ These apply to any project. Work through them in order.
 - Check if docstrings are present on new/changed classes, functions, and methods.
 - Docstrings must use Google style (`Args:`, `Returns:`, `Raises:`) to avoid rendering issues in the API docs.
 - For public APIs:
-  - Ensure inputs/outputs are clearly documented.
-  - Suggest adding examples if helpful.
+    - Ensure inputs/outputs are clearly documented.
+    - Suggest adding examples if helpful.
 
 ### 7. Testing and coverage
 
 - Check if there are enough unit tests.
 - Make sure tests cover:
-  - Core logic
-  - Edge cases
+    - Core logic
+    - Edge cases
 - Tests should be meaningful and easy to follow, not just for coverage.
 
----
+______________________________________________________________________
 
 ## Kedro-specific: PR checklist compliance
 
@@ -145,7 +147,7 @@ If the PR changes public API behavior or adds new features, check whether the Ke
 
 If the change affects pipeline structure, metadata, catalog behavior, or dataset output, flag for Viz team coordination.
 
----
+______________________________________________________________________
 
 ## Kedro-specific: API usage
 
@@ -161,7 +163,7 @@ For full API signatures and the complete list of base classes, read [reference.m
 
 **Non-obvious patterns:** Some files use complex patterns on purpose (e.g. `__getattr__`, `__init_subclass__` wrapping). If the PR touches `kedro/io/core.py`, `kedro/framework/hooks/manager.py`, or `kedro/io/shared_memory_dataset.py`, read [reference.md](reference.md) section "Non-obvious patterns" before flagging anything — those patterns are intentional.
 
----
+______________________________________________________________________
 
 ## Out of scope
 
@@ -170,15 +172,15 @@ Do NOT flag:
 - **Pre-existing issues** — only review changes in the diff.
 - **Security issues** — handled by the separate `kedro-security-review` skill.
 - **Anything CI already checks mechanically** — the following are handled by the `kedro-babysit` skill, which runs and fixes them automatically:
-  - Linting and formatting (ruff)
-  - Running unit tests (pytest)
-  - Import-linter contract execution (architecture compliance)
-  - DCO sign-off verification
-  - Any other CI check with a pass/fail outcome
+    - Linting and formatting (ruff)
+    - Running unit tests (pytest)
+    - Import-linter contract execution (architecture compliance)
+    - DCO sign-off verification
+    - Any other CI check with a pass/fail outcome
 
 This skill is about reviewing code, not running checks.
 
----
+______________________________________________________________________
 
 ## Output format
 
@@ -187,6 +189,7 @@ Each finding gets an **inline comment** on the specific line, plus there's a **s
 ### Review only (default) — output to chat
 
 Present all findings as chat messages. For each finding, include:
+
 - The file path and line number.
 - **Critical:** or **Suggestion:** prefix.
 - A concise explanation and suggested fix.

--- a/.agents/skills/review-kedro-pr/reference.md
+++ b/.agents/skills/review-kedro-pr/reference.md
@@ -2,7 +2,7 @@
 
 Detailed reference for the `review-kedro-pr` skill. Read sections selectively — use the section headers to find what you need.
 
----
+______________________________________________________________________
 
 ## Kedro public API surface
 
@@ -11,6 +11,7 @@ Detailed reference for the `review-kedro-pr` skill. Read sections selectively �
 Exports (`__all__`): `AbstractDataset`, `AbstractVersionedDataset`, `CachedDataset`, `CatalogProtocol`, `CatalogConfigResolver`, `DatasetAlreadyExistsError`, `DatasetError`, `DatasetNotFoundError`, `DataCatalog`, `MemoryDataset`, `SharedMemoryDataset`, `SharedMemoryDataCatalog`, `SharedMemoryCatalogProtocol`, `Version`.
 
 **`AbstractDataset(ABC, Generic[_DI, _DO])`** — base class for all datasets:
+
 - `load() -> _DO` — abstract, load data
 - `save(data: _DI) -> None` — abstract, save data
 - `_describe() -> dict[str, Any]` — abstract, return dataset description for repr
@@ -19,6 +20,7 @@ Exports (`__all__`): `AbstractDataset`, `AbstractVersionedDataset`, `CachedDatas
 - `from_config(name, config, load_version, save_version) -> AbstractDataset` — class method, creates instance from catalog config dict
 
 **`AbstractVersionedDataset`** — extends `AbstractDataset` with:
+
 - `filepath` property, `Version` namedtuple (load/save), version path resolution helpers
 - `_get_load_path()`, `_get_save_path()`, `_get_versioned_path()` for version-aware file access
 
@@ -27,6 +29,7 @@ Exports (`__all__`): `AbstractDataset`, `AbstractVersionedDataset`, `CachedDatas
 Exports (`__all__`): `AbstractRunner`, `ParallelRunner`, `SequentialRunner`, `Task`, `ThreadRunner`.
 
 **`AbstractRunner(ABC)`** — base class for all runners:
+
 - `__init__(is_async: bool = False)`
 - `run(pipeline, catalog, hook_manager=None, run_id=None, only_missing_outputs=False) -> dict[str, Any]` — validates inputs, calls `_run`
 - `_run(pipeline, catalog, hook_manager=None, run_id=None) -> None` — abstract, actual execution logic
@@ -39,10 +42,12 @@ Concrete runners: `SequentialRunner`, `ParallelRunner`, `ThreadRunner`.
 Exports (`__all__`): `node`, `pipeline`, `Node`, `Pipeline`, `GroupedNodes`, `llm_context_node`, `LLMContext`, `LLMContextNode`, `tool`.
 
 **`Pipeline`** — DAG of nodes:
+
 - `pipeline(*args)` factory function for creating pipelines
 - `Pipeline.filter()`, `Pipeline.inputs()`, `Pipeline.outputs()`, `Pipeline.nodes`, `Pipeline.datasets()`
 
 **`Node`** — single computation unit:
+
 - `node(func, inputs, outputs, name=None, ...)` factory function
 - `Node.run(inputs)`, `Node.name`, `Node.inputs`, `Node.outputs`
 
@@ -64,10 +69,12 @@ Exports (`__all__`): `AbstractConfigLoader`, `BadConfigException`, `MissingConfi
 - **`KedroContextSpecs`**: `after_context_created(context)`
 
 **Markers** (from `kedro/framework/hooks/markers.py`):
+
 - `hook_spec` — marks a method as a hook specification
 - `hook_impl` — marks a method as a hook implementation (this is what plugin/hook authors use)
 
 **CLI hooks** (separate namespace `kedro_cli`):
+
 - `CLICommandSpecs`: `before_command_run(project_metadata, command_args)`, `after_command_run(project_metadata, command_args)`
 - Markers: `cli_hook_spec`, `cli_hook_impl`
 
@@ -77,7 +84,7 @@ Exports (`__all__`): `AbstractConfigLoader`, `BadConfigException`, `MissingConfi
 - **`KedroSession`** — entry point for running pipelines, manages lifecycle.
 - **`KedroServiceSession`** — new session implementation for multiple runs and data injection (under active development).
 
----
+______________________________________________________________________
 
 ## Non-obvious patterns
 
@@ -86,6 +93,7 @@ These patterns look unusual but are intentional. Don't flag them. Read this sect
 ### `AbstractDataset.__init_subclass__` (kedro/io/core.py)
 
 When a class subclasses `AbstractDataset`, `__init_subclass__` automatically:
+
 1. **Wraps `__init__`** to capture `_init_args` (the arguments passed at construction time) for later use by `_init_config()`.
 2. **Aliases `_load`/`_save` to `load`/`save`** if the subclass defines `_load` or `_save` (legacy pattern).
 3. **Wraps `load` and `save`** with `_load_wrapper`/`_save_wrapper` for logging and error handling. Uses `__loadwrapped__`/`__savewrapped__` flags to avoid double-wrapping.
@@ -104,7 +112,7 @@ Returns `self` for any attribute, so hook calls do nothing when there's no real 
 
 Passes attribute access through to the underlying `MemoryDataset`. The `__setstate__` guard prevents infinite recursion when unpickling.
 
----
+______________________________________________________________________
 
 ## RELEASE.md format
 

--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -4,24 +4,28 @@ about: If something isn't working
 title: '<Title>'
 labels: 'Issue: Bug Report'
 assignees: ''
-
 ---
 
 ## Description
+
 <!-- Short description of the problem here. -->
 
 ## Context
+
 <!-- How has this bug affected you? What were you trying to accomplish? -->
 
 ## Steps to Reproduce
+
 <!-- 1. [First Step]
 2. [Second Step]
 3. [And so on...] -->
 
 ## Expected Result
+
 <!-- Tell us what should happen. -->
 
 ## Actual Result
+
 <!-- Tell us what happens instead. -->
 
 ```
@@ -33,8 +37,9 @@ assignees: ''
 ```
 
 ## Your Environment
+
 <!-- Include as many relevant details about the environment in which you experienced the bug: -->
 
-* Kedro version used (`pip show kedro` or `kedro -V`):
-* Python version used (`python -V`):
-* Operating system and version:
+- Kedro version used (`pip show kedro` or `kedro -V`):
+- Python version used (`python -V`):
+- Operating system and version:

--- a/.github/ISSUE_TEMPLATE/doc-improvement.md
+++ b/.github/ISSUE_TEMPLATE/doc-improvement.md
@@ -2,14 +2,16 @@
 name: Documentation improvement
 about: If something could be clarified or added to the docs
 labels: 'Component: Documentation'
-
 ---
 
 ## Description
+
 <!-- Short description of the improvement suggestion. -->
 
 ### Documentation page (if applicable)
+
 <!-- https://docs.kedro.org/en/stable/... -->
 
 ## Context
+
 <!-- Extra context. -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -4,17 +4,20 @@ about: Let us know if you have a feature request or enhancement
 title: '<Title>'
 labels: 'Issue: Feature Request'
 assignees: ''
-
 ---
 
 ## Description
+
 <!-- Is your feature request related to a problem? A clear and concise description of what the problem is: "I'm always frustrated when ..." -->
 
 ## Context
+
 <!-- Why is this change important to you? How would you use it? How can it benefit other users? -->
 
 ## Possible Implementation
+
 <!-- (Optional) Suggest an idea for implementing the addition or change. -->
 
 ## Possible Alternatives
+
 <!-- (Optional) Describe any alternative solutions or features you've considered. -->

--- a/.github/ISSUE_TEMPLATE/software_design_proposal.md
+++ b/.github/ISSUE_TEMPLATE/software_design_proposal.md
@@ -4,16 +4,18 @@ about: To propose and request comments on a software design decision
 title: '<Title>'
 labels: 'Type: Design Proposal'
 assignees: ''
-
 ---
 
 ## Introduction
+
 <!-- A high-level, short overview of the problem(s) you are designing a solution for. -->
 
 ## Background
+
 <!-- Provide the reader with the context surrounding the problem(s) you are trying to solve. -->
 
 ## Problem
+
 <!-- Be as concrete as you can about: -->
 
 ### What's in scope
@@ -21,16 +23,21 @@ assignees: ''
 ### What's not in scope
 
 ## Design
+
 <!-- Explain your design to the solution here. Diagrams could help. -->
 
 ### Alternatives considered
+
 <!-- Explain the trade off between different alternatives to your solution. -->
 
 ## Testing
+
 <!-- Explain the testing strategies to verify your design correctness (if possible). -->
 
 ## Rollout strategy
+
 <!-- Is the change backward compatible? If not, what is the migration strategy? -->
 
 ## Future iterations
+
 <!-- Will there be future iterations of this design? -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,13 +1,16 @@
 ## Description
+
 <!-- Why was this PR created? -->
 
 ## Development notes
+
 <!-- What have you changed, and how has this been tested? -->
 
 > [!IMPORTANT]
 > Every PR must link to a well-described GitHub issue. If there isn't one yet, [open an issue](https://github.com/kedro-org/kedro/issues/new/choose) first and discuss the approach before submitting a PR. See our [contribution guidelines](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) for details.
 
 ## Developer Certificate of Origin
+
 All commits must be signed off to comply with the [DCO](https://developercertificate.org/). If your PR is blocked due to unsigned commits, follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR.
 
 ## Checklist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,7 @@ repos:
           # PR in the stack reformats one area and removes that area from here.
           # TODO(after the mdformat rollout stack merges): drop everything below
           # docs/getting-started/commands_reference.md.
-          exclude: "^kedro/templates/|^features/test_starter/|^docs/api/|^docs/getting-started/commands_reference\\.md$|^\\.agents/|^\\.github/|^docs/|^README\\.md$|^RELEASE\\.md$|^LICENSE\\.md$|^CODE_OF_CONDUCT\\.md$|^CONTRIBUTING\\.md$|^SECURITY\\.md$|^kedro_benchmarks/"
+          exclude: "^kedro/templates/|^features/test_starter/|^docs/api/|^docs/getting-started/commands_reference\\.md$|^docs/|^README\\.md$|^RELEASE\\.md$|^LICENSE\\.md$|^CODE_OF_CONDUCT\\.md$|^CONTRIBUTING\\.md$|^SECURITY\\.md$|^kedro_benchmarks/"
 
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.6.0


### PR DESCRIPTION
## Description

Second PR in the mdformat stack (see #5722). Applies the autoformatter added in #5722 to the Markdown skill and template files under `.agents/` and `.github/` — split out from the docs reformat (#5643) per review feedback, since it's a separate area of the repo.

Mechanical only: normalises list markers, blank lines, emphasis markers and table padding. No prose is reflowed (`wrap=keep`) and the formatting is idempotent.

Stack:
1. #5722 — add the hook (targets `main`)
2. **This PR** — reformat `.agents/` and `.github/` (targets #5722's branch)
3. #5643 (targets this branch) — fix broken list numbering + reformat `docs/` and root Markdown

## Developer Certificate of Origin

We need all contributions to comply with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). All commits must be signed off by including a `Signed-off-by` line in the commit message. [See our wiki for guidance](https://github.com/kedro-org/kedro/wiki/Guidelines-for-contributing-developers/).

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Signed off each commit with a [Developer Certificate of Origin (DCO)](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-the-commit-signoff-policy-for-your-repository)
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file (folded into #5643, last in the stack)
- [ ] Added tests to cover my changes
- [ ] Checked if this change will affect Kedro-Viz, and if so, communicated that with the Viz team

🤖 Generated with [Claude Code](https://claude.com/claude-code)