### PR TITLE
Rename RUNNER_MODULES_WHITELIST to RUNNER_MODULE_ALLOWLIST

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -17,6 +17,7 @@
 - Fixed `get_close_matches` returning duplicate suggestions when several inputs matched the same target, and being able to exhaust a one-shot iterable passed as `targets`.
 - Fixed docs generated with `kedro new --tools=docs` so the Sphinx HTML build runs `sphinx-apidoc` and creates API docs.
 - Deprecated `--async` flag for `kedro run` in favour of `--runner-params=is_async=True`.
+- Renamed `RUNNER_MODULES_WHITELIST` to `RUNNER_MODULE_ALLOWLIST` in `_ProjectSettings` with backward-compatibility support, and extracted `is_allowed_module` validation helper into `kedro.utils`.
 
 ## Documentation changes
 

--- a/docs/extend/serving.md
+++ b/docs/extend/serving.md
@@ -204,11 +204,11 @@ The server creates this session with `serving_mode=True` (see [Create a `KedroSe
 
 #### Runner security
 
-Short names (for example, `SequentialRunner`) always resolve against `kedro.runner`. Fully-qualified names (for example, `mypackage.runners.MyRunner`) must belong to `kedro.runner`, the project's own package, or a module listed in `RUNNER_MODULES_WHITELIST` in `settings.py`. The module is never imported otherwise.
+Short names (for example, `SequentialRunner`) always resolve against `kedro.runner`. Fully-qualified names (for example, `mypackage.runners.MyRunner`) must belong to `kedro.runner`, the project's own package, or a module listed in `RUNNER_MODULE_ALLOWLIST` in `settings.py`. The module is never imported otherwise.
 
 ```python
 # settings.py
-RUNNER_MODULES_WHITELIST = ["external_lib.runners"]
+RUNNER_MODULE_ALLOWLIST = ["external_lib.runners"]
 ```
 
 ### Interactive API reference

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -139,6 +139,7 @@ class _ProjectSettings(LazySettings):
     )
     _SESSION_STORE_ARGS = Validator("SESSION_STORE_ARGS", default={})
     _DISABLE_HOOKS_FOR_PLUGINS = Validator("DISABLE_HOOKS_FOR_PLUGINS", default=tuple())
+    _RUNNER_MODULE_ALLOWLIST = Validator("RUNNER_MODULE_ALLOWLIST", default=tuple())
     _RUNNER_MODULES_WHITELIST = Validator("RUNNER_MODULES_WHITELIST", default=tuple())
     _CONFIG_LOADER_CLASS = _HasSharedParentClassValidator(
         "CONFIG_LOADER_CLASS",
@@ -164,6 +165,7 @@ class _ProjectSettings(LazySettings):
                 self._SESSION_STORE_CLASS,
                 self._SESSION_STORE_ARGS,
                 self._DISABLE_HOOKS_FOR_PLUGINS,
+                self._RUNNER_MODULE_ALLOWLIST,
                 self._RUNNER_MODULES_WHITELIST,
                 self._CONFIG_LOADER_CLASS,
                 self._CONFIG_LOADER_ARGS,

--- a/kedro/server/http_server.py
+++ b/kedro/server/http_server.py
@@ -34,7 +34,7 @@ from kedro.server.utils import (
     KEDRO_SERVER_ENV,
     _resolve_project_path,
 )
-from kedro.utils import load_obj
+from kedro.utils import is_allowed_module, load_obj
 
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
@@ -183,20 +183,20 @@ def _validate_runner_module(runner_name: str | None, package_name: str | None) -
     A runner name without a module prefix (e.g. ``SequentialRunner``) always
     passes because ``load_obj`` will resolve it against ``kedro.runner``.
     Allowed prefixes are ``kedro.runner``, the project <package_name>, and any
-    additional entries in ``settings.RUNNER_MODULES_WHITELIST``.
+    additional entries in ``settings.RUNNER_MODULE_ALLOWLIST`` (or legacy
+    ``settings.RUNNER_MODULES_WHITELIST``).
     """
-    if runner_name is None or "." not in runner_name:
-        return True
-    module = runner_name.rsplit(".", 1)[0]
+    configured_allowlist = (
+        getattr(settings, "RUNNER_MODULE_ALLOWLIST", None)
+        or getattr(settings, "RUNNER_MODULES_WHITELIST", None)
+        or ()
+    )
     allowed_prefixes = [
         "kedro.runner",
         package_name,
-        *settings.RUNNER_MODULES_WHITELIST,
+        *configured_allowlist,
     ]
-    return any(
-        module == prefix or module.startswith(prefix + ".")
-        for prefix in allowed_prefixes
-    )
+    return is_allowed_module(runner_name, allowed_prefixes)
 
 
 def _execute_pipeline(
@@ -228,7 +228,7 @@ def _execute_pipeline(
             raise ValueError(
                 f"Runner module '{module}' is not allowed. "
                 "Only 'kedro.runner', the project package, or modules listed in "
-                "'RUNNER_MODULES_WHITELIST' via settings.py are permitted."
+                "'RUNNER_MODULE_ALLOWLIST' via settings.py are permitted."
             )
         runner_class = load_obj(runner_name, "kedro.runner")
         if not (

--- a/kedro/utils.py
+++ b/kedro/utils.py
@@ -325,3 +325,30 @@ def _is_unsafe_version(version: str) -> bool:
     and must not be a dot-only component (``.`` or ``..``).
     """
     return not version or "/" in version or "\\" in version or version in (".", "..")
+
+
+def is_allowed_module(
+    module_name: str | None, allowed_prefixes: Iterable[str | None]
+) -> bool:
+    """Return True when the module is in the allowed prefixes.
+
+    A module_name without a module prefix (e.g. ``None`` or containing no dots)
+    returns True. A module is permitted if its name matches any allowed prefix
+    exactly or as a sub-package.
+
+    Args:
+        module_name: Full dotted module or object path, or None.
+        allowed_prefixes: Iterable of allowed prefix strings or None.
+
+    Returns:
+        True if the module is allowed, False otherwise.
+    """
+    if module_name is None or "." not in module_name:
+        return True
+    module = module_name.rsplit(".", 1)[0]
+    valid_prefixes = [p for p in allowed_prefixes if p is not None]
+    return any(
+        module == prefix or module.startswith(f"{prefix}.")
+        for prefix in valid_prefixes
+    )
+

--- a/tests/server/test_run_endpoint.py
+++ b/tests/server/test_run_endpoint.py
@@ -455,7 +455,7 @@ class TestExecutePipeline:
         mock_session = mocker.Mock()
         mock_session._package_name = "mypackage"
         mock_load_obj = mocker.patch("kedro.server.http_server.load_obj")
-        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+        mocker.patch.object(settings, "RUNNER_MODULE_ALLOWLIST", [])
 
         result = _execute_pipeline(
             session=mock_session,
@@ -469,15 +469,15 @@ class TestExecutePipeline:
         mock_load_obj.assert_not_called()
         mock_session.run.assert_not_called()
 
-    def test_execute_pipeline_allows_whitelisted_module(self, mocker):
-        """Runner from a module listed in RUNNER_MODULES_WHITELIST is permitted."""
+    def test_execute_pipeline_allows_allowlisted_module(self, mocker):
+        """Runner from a module listed in RUNNER_MODULE_ALLOWLIST is permitted."""
         mock_session = mocker.Mock()
         mock_session._package_name = "mypackage"
         mocker.patch(
             "kedro.server.http_server.load_obj",
             return_value=_FakeRunner,
         )
-        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", ["external.runners"])
+        mocker.patch.object(settings, "RUNNER_MODULE_ALLOWLIST", ["external.runners"])
 
         result = _execute_pipeline(
             session=mock_session,
@@ -487,15 +487,34 @@ class TestExecutePipeline:
         assert result.status == "success"
         mock_session.run.assert_called_once()
 
-    def test_execute_pipeline_allows_project_package_module(self, mocker):
-        """Runner from the project's own package namespace is permitted without whitelisting."""
+    def test_execute_pipeline_allows_legacy_whitelisted_module(self, mocker):
+        """Runner from a module listed in legacy RUNNER_MODULES_WHITELIST is permitted."""
         mock_session = mocker.Mock()
         mock_session._package_name = "mypackage"
         mocker.patch(
             "kedro.server.http_server.load_obj",
             return_value=_FakeRunner,
         )
-        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+        mocker.patch.object(settings, "RUNNER_MODULE_ALLOWLIST", [])
+        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", ["legacy.runners"])
+
+        result = _execute_pipeline(
+            session=mock_session,
+            request=RunRequest(runner="legacy.runners.MyRunner"),
+        )
+
+        assert result.status == "success"
+        mock_session.run.assert_called_once()
+
+    def test_execute_pipeline_allows_project_package_module(self, mocker):
+        """Runner from the project's own package namespace is permitted without allowlisting."""
+        mock_session = mocker.Mock()
+        mock_session._package_name = "mypackage"
+        mocker.patch(
+            "kedro.server.http_server.load_obj",
+            return_value=_FakeRunner,
+        )
+        mocker.patch.object(settings, "RUNNER_MODULE_ALLOWLIST", [])
 
         result = _execute_pipeline(
             session=mock_session,
@@ -506,14 +525,14 @@ class TestExecutePipeline:
         mock_session.run.assert_called_once()
 
     def test_execute_pipeline_allows_project_subpackage_module(self, mocker):
-        """Runner from a subpackage of the project package is permitted without whitelisting."""
+        """Runner from a subpackage of the project package is permitted without allowlisting."""
         mock_session = mocker.Mock()
         mock_session._package_name = "mypackage"
         mocker.patch(
             "kedro.server.http_server.load_obj",
             return_value=_FakeRunner,
         )
-        mocker.patch.object(settings, "RUNNER_MODULES_WHITELIST", [])
+        mocker.patch.object(settings, "RUNNER_MODULE_ALLOWLIST", [])
 
         result = _execute_pipeline(
             session=mock_session,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ from kedro.utils import (
     experimental,
     find_config_file,
     get_close_matches,
+    is_allowed_module,
     load_obj,
 )
 
@@ -332,3 +333,25 @@ def test_is_unsafe_version_rejects(version):
 )
 def test_is_unsafe_version_allows(version):
     assert _is_unsafe_version(version) is False
+
+
+class TestIsAllowedModule:
+    @pytest.mark.parametrize(
+        "module_name,allowed_prefixes,expected",
+        [
+            (None, ["kedro.runner"], True),
+            ("SequentialRunner", ["kedro.runner"], True),
+            ("kedro.runner.SequentialRunner", ["kedro.runner"], True),
+            ("kedro.runner.submodule.MyRunner", ["kedro.runner"], True),
+            ("mypackage.runners.CustomRunner", ["kedro.runner", "mypackage"], True),
+            ("mypackage.sub.runners.CustomRunner", ["kedro.runner", "mypackage"], True),
+            ("external.runners.ThirdPartyRunner", ["kedro.runner", "external.runners"], True),
+            ("os.system", ["kedro.runner", "mypackage"], False),
+            ("mypackage_other.runners.Runner", ["kedro.runner", "mypackage"], False),
+            ("builtins.eval", [], False),
+            ("custom.runner.Runner", [None, "kedro.runner"], False),
+        ],
+    )
+    def test_is_allowed_module(self, module_name, allowed_prefixes, expected):
+        assert is_allowed_module(module_name, allowed_prefixes) is expected
+


### PR DESCRIPTION
## Description

Resolves #5731. Follow up from #5652.

- Renamed \RUNNER_MODULES_WHITELIST\ setting to \RUNNER_MODULE_ALLOWLIST\ in \_ProjectSettings\.
- Extracted common module allowlist validation into reusable helper \is_allowed_module\ in \kedro.utils\.
- Updated \kedro.server.http_server._validate_runner_module\ to use \is_allowed_module\ and prioritize \RUNNER_MODULE_ALLOWLIST\ while falling back to legacy \RUNNER_MODULES_WHITELIST\ for backward compatibility.
- Updated documentation in \docs/extend/serving.md\ and added release note to \RELEASE.md\.
- Updated server run endpoint test suite and added unit tests for \is_allowed_module\ and backward compatibility.

## Development notes

- Tested with \pytest tests/test_utils.py tests/server/test_run_endpoint.py\ (84/84 tests passed).

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [x] Linked to a relevant GitHub issue (#5731)
- [x] Signed off each commit with a [DCO](https://developercertificate.org/)
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [\RELEASE.md\](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
