### PR TITLE
Fix CachedDataset.__repr__ mislabelling the cache dataset type

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -18,6 +18,7 @@
 - Fixed docs generated with `kedro new --tools=docs` so the Sphinx HTML build runs `sphinx-apidoc` and creates API docs.
 - Deprecated `--async` flag for `kedro run` in favour of `--runner-params=is_async=True`.
 - Redacted credentials, signed-URL query parameters and fragments from dataset filepaths in `AbstractDataset.__repr__`, `DatasetError` messages, and HTTP server `/snapshot` and `/run` responses.
+- Fixed `CachedDataset.__repr__` mislabelling the cache with the wrapped dataset's class name instead of `MemoryDataset`.
 
 ## Documentation changes
 

--- a/kedro/io/cached_dataset.py
+++ b/kedro/io/cached_dataset.py
@@ -99,7 +99,7 @@ class CachedDataset(AbstractDataset):
     def __repr__(self) -> str:
         object_description = {
             "dataset": self._dataset._pretty_repr(self._dataset._describe()),
-            "cache": self._dataset._pretty_repr(self._cache._describe()),
+            "cache": self._cache._pretty_repr(self._cache._describe()),
         }
         return self._pretty_repr(object_description)
 

--- a/tests/io/test_cached_dataset.py
+++ b/tests/io/test_cached_dataset.py
@@ -133,6 +133,19 @@ class TestCachedDataset:
             """cache='kedro.io.memory_dataset.MemoryDataset()')"""
         )
 
+    def test_repr_wrapping_non_memory_dataset(self):
+        """The cache is always a ``MemoryDataset`` regardless of the wrapped
+        dataset's type, and the repr must say so rather than mislabelling the
+        cache with the wrapped dataset's class."""
+        representation = repr(CachedDataset(CSVDataset(filepath="example.csv")))
+        assert (
+            representation
+            == """kedro.io.cached_dataset.CachedDataset(dataset="kedro_datasets."""
+            """pandas.csv_dataset.CSVDataset(filepath=PurePosixPath('example.csv'), """
+            """protocol='file', load_args={}, save_args={'index': False})", """
+            """cache='kedro.io.memory_dataset.MemoryDataset()')"""
+        )
+
     def test_str(self):
         assert (
             str(CachedDataset(MemoryDataset(42)))


### PR DESCRIPTION
Closes #5749.

## What this does

\`CachedDataset.__repr__\` built its \`cache\` entry with \`self._dataset._pretty_repr(self._cache._describe())\` — calling \`_pretty_repr\` on the *wrapped* dataset instead of on the cache. \`AbstractDataset._pretty_repr\` prefixes its output with \`type(self).__module__\`/\`__name__\`, so the cache (always a \`MemoryDataset\`) was rendered under the wrapped dataset's class:

\`\`\`
cache="kedro_datasets.pandas.csv_dataset.CSVDataset(data='<DataFrame>')"
\`\`\`

— a \`CSVDataset\` label around \`MemoryDataset\`-shaped \`_describe()\` contents. The sibling \`dataset\` entry on the line above is correct; this was a copy-paste slip from #3987. \`_describe()\` already uses each component's own method, so \`__repr__\`/\`__str__\` were the only affected paths.

## Fix

\`\`\`diff
 object_description = {
     "dataset": self._dataset._pretty_repr(self._dataset._describe()),
-    "cache": self._dataset._pretty_repr(self._cache._describe()),
+    "cache": self._cache._pretty_repr(self._cache._describe()),
 }
\`\`\`

## Tests

The existing \`test_repr\`/\`test_str\` wrap a \`MemoryDataset\`, so both \`_pretty_repr\` receivers happen to share a class name and the bug is invisible. Added \`test_repr_wrapping_non_memory_dataset\`, which wraps a \`CSVDataset\` instead — it fails on \`main\` and passes with this change. Also added a \`RELEASE.md\` note.

\`pytest tests/io/test_cached_dataset.py\` — 17/17 passing. \`ruff check\` / \`ruff format --check\` clean.

@ankatiyar — tagging you per your note on #5749.