### PR TITLE
Add allowlisting mechanism for project configuration

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@
 
 ## Bug fixes and other changes
 
-- **Security fix**: Fixed arbitrary code execution vulnerability in logging configuration via unsafe import-before-validate ordering. The `class` field in `conf/logging.yml` is now validated against an allowlist before import, preventing malicious modules from executing arbitrary code at CLI startup. Allowed by default: `logging`, `kedro.logging`, and the project's own package. Additional modules can be allowed via `settings.LOGGING_MODULE_ALLOWLIST`.
+- **Security fix**: Fixed arbitrary code execution vulnerability in logging configuration via unsafe import-before-validate ordering. The `class` field in `conf/logging.yml` is now validated against an allowlist before import, preventing malicious modules from executing arbitrary code at CLI startup. Allowed by default: `logging` and `kedro.logging`. Additional modules can be allowed via `settings.LOGGING_MODULE_ALLOWLIST`.
 - Fixed a thread-safety issue in `_ProjectPipelines` where concurrent access could trigger duplicate pipeline loading or operate on a cleared cache; all shared state mutations are now protected by a reentrant lock.
 - Fixed a thread-safety issue in the Kedro HTTP server by adding a `serving_mode` argument to `KedroServiceSession.create()` that preloads all pipelines upfront.
 - Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by converting `settings.SESSION_STORE_ARGS` to a plain `dict` before deepcopying it.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,6 +11,7 @@
 
 ## Bug fixes and other changes
 
+- **Security fix**: Fixed arbitrary code execution vulnerability in logging configuration via unsafe import-before-validate ordering. The `class` field in `conf/logging.yml` is now validated against an allowlist before import, preventing malicious modules from executing arbitrary code at CLI startup. Allowed by default: `logging`, `kedro.logging`, and the project's own package. Additional modules can be allowed via `settings.LOGGING_MODULE_ALLOWLIST`.
 - Fixed a thread-safety issue in `_ProjectPipelines` where concurrent access could trigger duplicate pipeline loading or operate on a cleared cache; all shared state mutations are now protected by a reentrant lock.
 - Fixed a thread-safety issue in the Kedro HTTP server by adding a `serving_mode` argument to `KedroServiceSession.create()` that preloads all pipelines upfront.
 - Fixed a `RecursionError` when initialising a session with dynaconf-backed settings by converting `settings.SESSION_STORE_ARGS` to a plain `dict` before deepcopying it.

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -193,13 +193,12 @@ For security, Kedro restricts which modules can be referenced in the `class` fie
 
 - `logging` and `logging.handlers` (Python standard library)
 - `kedro.logging` (Kedro's logging extensions)
-- Your project's own package (after bootstrap)
 
-If you need to use a custom logging handler, filter, or formatter from a third-party library or other module, you can allow it via the `LOGGING_MODULE_ALLOWLIST` setting in your `settings.py`:
+If you need to use custom logging handlers, filters, or formatters from your project package or other modules, you must explicitly allow them via the `LOGGING_MODULE_ALLOWLIST` setting in your `settings.py`:
 
 ```python
 # settings.py
-LOGGING_MODULE_ALLOWLIST = ("my_logging_lib", "another_vendor_lib")
+LOGGING_MODULE_ALLOWLIST = ("my_project.logging", "my_logging_lib")
 ```
 
 This allows additional modules to be used in the `class` field of `logging.yml` alongside the default allowed modules.

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -187,6 +187,23 @@ root:
     Standard Python logging configuration also supports the `()` factory key for custom objects. Kedro does not allow `()` in `logging.yml` because it can execute arbitrary code.
     Use `class` for custom `logging.Filter` subclasses instead.
 
+### Module allowlist for logging classes
+
+For security, Kedro restricts which modules can be referenced in the `class` field of logging configuration. By default, only the following modules are allowed:
+
+- `logging` and `logging.handlers` (Python standard library)
+- `kedro.logging` (Kedro's logging extensions)
+- Your project's own package (after bootstrap)
+
+If you need to use a custom logging handler, filter, or formatter from a third-party library or other module, you can allow it via the `LOGGING_MODULE_ALLOWLIST` setting in your `settings.py`:
+
+```python
+# settings.py
+LOGGING_MODULE_ALLOWLIST = ("my_logging_lib", "another_vendor_lib")
+```
+
+This allows additional modules to be used in the `class` field of `logging.yml` alongside the default allowed modules.
+
 ## How to customise the `rich` handler
 
 Kedro's `kedro.logging.RichHandler` is a subclass of [`rich.logging.RichHandler`](https://rich.readthedocs.io/en/stable/reference/logging.html#rich.logging.RichHandler) and supports the same set of arguments. By default, `rich_tracebacks` is set to `True` to use `rich` to render exceptions. You can disable it by setting `rich_tracebacks: False`.

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -22,7 +22,7 @@ from dynaconf.validator import ValidationError, Validator
 
 from kedro.io import CatalogProtocol
 from kedro.pipeline import Pipeline, pipeline
-from kedro.utils import find_config_file
+from kedro.utils import _is_module_allowed, find_config_file
 
 if TYPE_CHECKING:
     import types
@@ -37,6 +37,10 @@ _LOGGING_BASE_CLASSES = (
     logging.Formatter,
     logging.Filter,
 )
+
+# Allowed modules for logging "class" entries. Checked before import.
+# Project's own package (PACKAGE_NAME) + custom allowlist also permitted.
+_LOGGING_ALLOWED_MODULE_PREFIXES = ("logging", "kedro.logging")
 
 
 def _get_default_class(class_import_path: str) -> Any:
@@ -140,6 +144,7 @@ class _ProjectSettings(LazySettings):
     _SESSION_STORE_ARGS = Validator("SESSION_STORE_ARGS", default={})
     _DISABLE_HOOKS_FOR_PLUGINS = Validator("DISABLE_HOOKS_FOR_PLUGINS", default=tuple())
     _RUNNER_MODULE_ALLOWLIST = Validator("RUNNER_MODULE_ALLOWLIST", default=tuple())
+    _LOGGING_MODULE_ALLOWLIST = Validator("LOGGING_MODULE_ALLOWLIST", default=tuple())
     _CONFIG_LOADER_CLASS = _HasSharedParentClassValidator(
         "CONFIG_LOADER_CLASS",
         default=_get_default_class("kedro.config.OmegaConfigLoader"),
@@ -165,6 +170,7 @@ class _ProjectSettings(LazySettings):
                 self._SESSION_STORE_ARGS,
                 self._DISABLE_HOOKS_FOR_PLUGINS,
                 self._RUNNER_MODULE_ALLOWLIST,
+                self._LOGGING_MODULE_ALLOWLIST,
                 self._CONFIG_LOADER_CLASS,
                 self._CONFIG_LOADER_ARGS,
                 self._DATA_CATALOG_CLASS,
@@ -347,6 +353,21 @@ class _ProjectLogging(UserDict):
         if not module_path:
             # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
             return None
+
+        # Only consult settings after bootstrap (PACKAGE_NAME set) to avoid
+        # triggering dynaconf validator machinery at CLI import time, causing
+        # circular import into this partially-initialised module.
+        extra_allowed = settings.LOGGING_MODULE_ALLOWLIST if PACKAGE_NAME else ()
+        if not _is_module_allowed(
+            module_path,
+            (*_LOGGING_ALLOWED_MODULE_PREFIXES, PACKAGE_NAME, *extra_allowed),
+        ):
+            raise ValueError(
+                f"Cannot use class '{class_path}' in logging configuration. "
+                f"Module '{module_path}' is not allowed. Only {_LOGGING_ALLOWED_MODULE_PREFIXES}, "
+                "the project's own package, and modules listed in "
+                "'LOGGING_MODULE_ALLOWLIST' via settings.py are permitted."
+            )
 
         try:
             module = importlib.import_module(module_path)

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -38,8 +38,8 @@ _LOGGING_BASE_CLASSES = (
     logging.Filter,
 )
 
-# Allowed modules for logging "class" entries. Checked before import.
-# Project's own package (PACKAGE_NAME) + custom allowlist also permitted.
+# Modules allowed for logging "class" entries, checked before import. Extend via
+# settings.LOGGING_MODULE_ALLOWLIST.
 _LOGGING_ALLOWED_MODULE_PREFIXES = ("logging", "kedro.logging")
 
 
@@ -329,21 +329,24 @@ class _ProjectLogging(UserDict):
 
         msg = f"Using '{path!s}' as logging configuration. " + msg
 
-        # Load and apply the logging configuration
+        # Runs before the project is bootstrapped, so settings.py isn't loaded yet;
+        # validate leniently here (see `configure`) and re-validate once it is.
+        self._raw_config: dict[str, Any] | None = None
         logging_config = Path(path).read_text(encoding="utf-8")
-        self.configure(yaml.safe_load(logging_config))
+        self.configure(yaml.safe_load(logging_config), strict=False)
         logger.info(msg)
 
-    def _resolve_logging_class(self, class_path: str) -> type[Any] | None:
+    def _resolve_logging_class(
+        self, class_path: str, strict: bool = True
+    ) -> tuple[type[Any] | None, bool]:
         """Resolve and validate that a class referenced in logging configuration is
         a legitimate logging class (i.e. a subclass of logging.Handler,
         logging.Formatter, or logging.Filter).
 
-        Args:
-            class_path: Dotted import path to the class, e.g. ``logging.StreamHandler``.
-
-        Returns:
-            Resolved class, or ``None`` for bare names resolved internally by logging.
+        Returns a ``(resolved_class, deferred)`` tuple. If ``strict`` is False, a
+        module that fails the allowlist check is deferred (returned as ``(None,
+        True)``) instead of raising - used pre-bootstrap, before settings.py can be
+        consulted.
 
         Raises:
             ValueError: If the class cannot be imported or is not a logging base class.
@@ -352,21 +355,22 @@ class _ProjectLogging(UserDict):
         module_path, _, class_name = class_path.rpartition(".")
         if not module_path:
             # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
-            return None
+            return None, False
 
-        # Only consult settings after bootstrap (PACKAGE_NAME set) to avoid
-        # triggering dynaconf validator machinery at CLI import time, causing
-        # circular import into this partially-initialised module.
-        extra_allowed = settings.LOGGING_MODULE_ALLOWLIST if PACKAGE_NAME else ()
+        # globals() lookup avoids a circular import: `settings` is assigned below,
+        # after `LOGGING` is constructed.
+        proj_settings = globals().get("settings")
+        allowlist = proj_settings.LOGGING_MODULE_ALLOWLIST if proj_settings else ()
         if not _is_module_allowed(
             module_path,
-            (*_LOGGING_ALLOWED_MODULE_PREFIXES, PACKAGE_NAME, *extra_allowed),
+            (*_LOGGING_ALLOWED_MODULE_PREFIXES, *allowlist),
         ):
+            if not strict:
+                return None, True
             raise ValueError(
                 f"Cannot use class '{class_path}' in logging configuration. "
-                f"Module '{module_path}' is not allowed. Only {_LOGGING_ALLOWED_MODULE_PREFIXES}, "
-                "the project's own package, and modules listed in "
-                "'LOGGING_MODULE_ALLOWLIST' via settings.py are permitted."
+                f"Module '{module_path}' is not allowed. Only {_LOGGING_ALLOWED_MODULE_PREFIXES} "
+                "and modules listed in 'LOGGING_MODULE_ALLOWLIST' via settings.py are permitted."
             )
 
         try:
@@ -390,41 +394,100 @@ class _ProjectLogging(UserDict):
                 f"Got {type(cls).__name__!r}."
             )
 
-        return cls
+        return cls, False
 
-    def _validate_logging_class(self, class_path: str) -> type[Any] | None:
+    def _validate_logging_class(
+        self, class_path: str, strict: bool = True
+    ) -> tuple[type[Any] | None, bool]:
         """Validate that a class referenced in logging configuration is a legitimate
         logging class (i.e. a subclass of logging.Handler, logging.Formatter, or
         logging.Filter)."""
-        return self._resolve_logging_class(class_path)
+        return self._resolve_logging_class(class_path, strict=strict)
+
+    def _validate_handlers_config(
+        self,
+        handlers: dict[str, Any],
+        resolved_logging_classes: dict[str, type[Any] | None] | None,
+        strict: bool,
+    ) -> dict[str, Any]:
+        """Validate the top-level ``handlers`` section.
+
+        Unlike filters, a handler's ``class`` is imported directly by
+        ``logging.config.dictConfig`` itself, so a deferred class must never reach
+        it as-is - it's replaced with a harmless ``NullHandler`` placeholder instead.
+        """
+        # `dictConfig` passes any key besides these to the handler's constructor as
+        # kwargs, so when substituting NullHandler they must be dropped too (e.g. a
+        # RichHandler's `rich_tracebacks` kwarg would otherwise raise a TypeError).
+        _DICTCONFIG_HANDLER_KEYS = {"class", "level", "formatter", "filters"}
+        validated_handlers = {}
+        for name, handler_config in handlers.items():
+            if not isinstance(handler_config, dict):
+                validated_handlers[name] = handler_config
+                continue
+            if "()" in handler_config:
+                raise ValueError(
+                    "The '()' key is not allowed in logging configuration as it poses a security risk."
+                )
+            validated = dict(handler_config)
+            if "class" in handler_config:
+                class_path = handler_config["class"]
+                resolved_class, deferred = self._validate_logging_class(
+                    class_path, strict=strict
+                )
+                if resolved_logging_classes is not None:
+                    resolved_logging_classes[class_path] = resolved_class
+                if deferred:
+                    validated = {
+                        k: v
+                        for k, v in validated.items()
+                        if k in _DICTCONFIG_HANDLER_KEYS
+                    }
+                    validated["class"] = "logging.NullHandler"
+            validated_handlers[name] = validated
+        return validated_handlers
 
     def _validate_logging_config(
         self,
         config: Any,
         resolved_logging_classes: dict[str, type[Any] | None] | None = None,
+        strict: bool = True,
     ) -> Any:
         """Recursively check the logging configuration and raise an error if dangerous
         '()' factory keys are encountered or if any 'class' value is not a legitimate
-        logging class."""
+        logging class. Handlers are validated separately (see
+        ``_validate_handlers_config``); a deferred filter/formatter class is simply
+        left inert, since Kedro (not ``dictConfig``) is what instantiates it.
+        """
         if isinstance(config, dict):
             if "()" in config:
                 raise ValueError(
                     "The '()' key is not allowed in logging configuration as it poses a security risk."
                 )
-            if "class" in config:
-                class_path = config["class"]
-                resolved_class = self._validate_logging_class(class_path)
-                if resolved_logging_classes is not None:
-                    resolved_logging_classes[class_path] = resolved_class
             validated = {}
             for k, v in config.items():
+                if k == "handlers" and isinstance(v, dict):
+                    validated[k] = self._validate_handlers_config(
+                        v, resolved_logging_classes, strict
+                    )
+                    continue
+                if k == "class":
+                    resolved_class, _deferred = self._validate_logging_class(
+                        v, strict=strict
+                    )
+                    if resolved_logging_classes is not None:
+                        resolved_logging_classes[v] = resolved_class
+                    validated[k] = v
+                    continue
                 validated[k] = self._validate_logging_config(
-                    v, resolved_logging_classes
+                    v, resolved_logging_classes, strict=strict
                 )
             return validated
         elif isinstance(config, list):
             return [
-                self._validate_logging_config(item, resolved_logging_classes)
+                self._validate_logging_config(
+                    item, resolved_logging_classes, strict=strict
+                )
                 for item in config
             ]
         else:
@@ -465,7 +528,7 @@ class _ProjectLogging(UserDict):
                 resolved_logging_classes[class_path]
                 if resolved_logging_classes is not None
                 and class_path in resolved_logging_classes
-                else self._resolve_logging_class(class_path)
+                else self._resolve_logging_class(class_path)[0]
             )
 
             if filter_class is None:
@@ -485,14 +548,19 @@ class _ProjectLogging(UserDict):
 
         return prepared_config
 
-    def configure(self, logging_config: dict[str, Any]) -> None:
+    def configure(self, logging_config: dict[str, Any], strict: bool = True) -> None:
         """Configure project logging using ``logging_config`` (e.g. from project
         logging.yml). We store this in the UserDict data so that it can be reconfigured
         in _bootstrap_subprocess.
+
+        If ``strict`` is False, classes failing the module allowlist are deferred
+        rather than raising (see ``_validate_logging_config``); ``set_project_logging``
+        re-validates strictly once the project is bootstrapped.
         """
+        self._raw_config = logging_config
         resolved_logging_classes: dict[str, type[Any] | None] = {}
         validated_config = self._validate_logging_config(
-            logging_config, resolved_logging_classes
+            logging_config, resolved_logging_classes, strict=strict
         )
         logging.config.dictConfig(
             self._prepare_logging_config(validated_config, resolved_logging_classes)
@@ -512,15 +580,22 @@ class _ProjectLogging(UserDict):
                 ``dictConfig``. This prevents runtime-added handlers from being wiped
                 when ``configure_project()`` is called after custom handlers have been
                 attached (e.g. in a long-running server process).
-        """
-        loggers = self.data.get("loggers", {})
-        if not loggers:
-            self.data["loggers"] = {}  # pragma: no cover
 
-        if package_name not in self.data["loggers"]:
-            self.data["loggers"][package_name] = {"level": "INFO"}
-            if not preserve_logging:
-                self.configure(self.data)
+        """
+        # Reconfigure from the raw config (not self.data) so classes deferred
+        # pre-bootstrap get re-validated now that settings.py is loaded. This must
+        # run even if `package_name` was already a logger in logging.yml.
+        raw_config = self._raw_config if self._raw_config is not None else self.data
+        raw_config.setdefault("loggers", {})
+
+        added_logger = package_name not in raw_config["loggers"]
+        if added_logger:
+            raw_config["loggers"][package_name] = {"level": "INFO"}
+
+        if not preserve_logging:
+            self.configure(raw_config, strict=True)
+        elif added_logger:
+            self.data.setdefault("loggers", {})[package_name] = {"level": "INFO"}
 
 
 PACKAGE_NAME = None

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -599,8 +599,8 @@ def test_configure_logging_reuses_validated_filter_class():
             logging_instance.configure(logging_config)
 
     assert resolve_logging_class.call_count == 2
-    resolve_logging_class.assert_any_call(filter_class)
-    resolve_logging_class.assert_any_call("logging.StreamHandler")
+    resolve_logging_class.assert_any_call(filter_class, strict=True)
+    resolve_logging_class.assert_any_call("logging.StreamHandler", strict=True)
 
 
 def test_prepare_logging_config_without_filters_does_not_add_filters_key():

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -466,6 +466,32 @@ def test_validate_logging_class_bare_name_passes():
     logging_instance._validate_logging_class("StreamHandler")  # should not raise
 
 
+def test_validate_logging_class_import_error_with_allowlist():
+    """A module that passes allowlist but cannot be imported must raise ValueError."""
+    from kedro.framework.project import _ProjectLogging, settings
+
+    logging_instance = _ProjectLogging()
+    # Mock PACKAGE_NAME to enable allowlist access from settings
+    with mock.patch("kedro.framework.project.PACKAGE_NAME", "test_project"):
+        with mock.patch.object(
+            settings, "LOGGING_MODULE_ALLOWLIST", ("nonexistent_module",)
+        ):
+            with pytest.raises(ValueError, match="Cannot import module"):
+                logging_instance._resolve_logging_class("nonexistent_module.Handler")
+
+
+def test_validate_logging_class_non_logging_class_with_allowlist():
+    """A non-logging class from allowlisted module must raise ValueError."""
+    from kedro.framework.project import _ProjectLogging, settings
+
+    logging_instance = _ProjectLogging()
+    # Mock PACKAGE_NAME to enable allowlist access from settings
+    with mock.patch("kedro.framework.project.PACKAGE_NAME", "test_project"):
+        with mock.patch.object(settings, "LOGGING_MODULE_ALLOWLIST", ("os",)):
+            with pytest.raises(ValueError, match="Invalid logging class"):
+                logging_instance._resolve_logging_class("os.system")
+
+
 def test_configure_logging_instantiates_custom_filter_class():
     from kedro.framework.project import _ProjectLogging, settings
 

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -436,7 +436,7 @@ def test_validate_logging_class_blocks_non_logging_classes(class_path):
     from kedro.framework.project import _ProjectLogging
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Invalid logging class"):
+    with pytest.raises(ValueError, match="not allowed"):
         logging_instance._validate_logging_class(class_path)
 
 
@@ -454,7 +454,7 @@ def test_validate_logging_class_blocks_nonexistent_module():
     from kedro.framework.project import _ProjectLogging
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Cannot import module"):
+    with pytest.raises(ValueError, match="not allowed"):
         logging_instance._validate_logging_class("totally.fake.module.Handler")
 
 
@@ -467,7 +467,7 @@ def test_validate_logging_class_bare_name_passes():
 
 
 def test_configure_logging_instantiates_custom_filter_class():
-    from kedro.framework.project import _ProjectLogging
+    from kedro.framework.project import _ProjectLogging, settings
 
     stream = io.StringIO()
     filter_class = f"{__name__}.KeepOnlyFilter"
@@ -486,7 +486,10 @@ def test_configure_logging_instantiates_custom_filter_class():
     }
 
     logging_instance = _ProjectLogging()
-    logging_instance.configure(logging_config)
+    with mock.patch.object(
+        settings, "LOGGING_MODULE_ALLOWLIST", ("tests.framework.project.test_logging",)
+    ):
+        logging_instance.configure(logging_config)
 
     [handler] = logging.getLogger().handlers
     assert isinstance(handler.filters[0], KeepOnlyFilter)
@@ -507,7 +510,7 @@ def test_configure_logging_instantiates_custom_filter_class():
 
 
 def test_configure_logging_passes_custom_filter_constructor_parameters():
-    from kedro.framework.project import _ProjectLogging
+    from kedro.framework.project import _ProjectLogging, settings
 
     stream = io.StringIO()
     filter_class = f"{__name__}.KeepOnlyFilter"
@@ -526,7 +529,10 @@ def test_configure_logging_passes_custom_filter_constructor_parameters():
     }
 
     logging_instance = _ProjectLogging()
-    logging_instance.configure(logging_config)
+    with mock.patch.object(
+        settings, "LOGGING_MODULE_ALLOWLIST", ("tests.framework.project.test_logging",)
+    ):
+        logging_instance.configure(logging_config)
 
     [handler] = logging.getLogger().handlers
     custom_filter = handler.filters[0]
@@ -539,7 +545,7 @@ def test_configure_logging_passes_custom_filter_constructor_parameters():
 
 
 def test_configure_logging_reuses_validated_filter_class():
-    from kedro.framework.project import _ProjectLogging
+    from kedro.framework.project import _ProjectLogging, settings
 
     filter_class = f"{__name__}.KeepOnlyFilter"
     logging_config = {
@@ -557,11 +563,14 @@ def test_configure_logging_reuses_validated_filter_class():
 
     logging_instance = _ProjectLogging()
     with mock.patch.object(
-        logging_instance,
-        "_resolve_logging_class",
-        wraps=logging_instance._resolve_logging_class,
-    ) as resolve_logging_class:
-        logging_instance.configure(logging_config)
+        settings, "LOGGING_MODULE_ALLOWLIST", ("tests.framework.project.test_logging",)
+    ):
+        with mock.patch.object(
+            logging_instance,
+            "_resolve_logging_class",
+            wraps=logging_instance._resolve_logging_class,
+        ) as resolve_logging_class:
+            logging_instance.configure(logging_config)
 
     assert resolve_logging_class.call_count == 2
     resolve_logging_class.assert_any_call(filter_class)
@@ -664,7 +673,7 @@ def test_validate_config_blocks_rce_via_class():
     }
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Invalid logging class"):
+    with pytest.raises(ValueError, match="not allowed"):
         logging_instance.configure(malicious_config)
 
 


### PR DESCRIPTION
## Description

**Fixes:** Incomplete fix of CVE-2026-35171

### Problem
`_resolve_logging_class` imported modules before validating they are logging classes, allowing arbitrary code execution on any `kedro` command via malicious `conf/logging.yml`.

## Development notes


### Solution
Validate module path against allowlist **before** import:
- Allowed by default: `logging`, `kedro.logging`
- After bootstrap: Project's own package (`PACKAGE_NAME`)
- Configurable: `settings.LOGGING_MODULE_ALLOWLIST`

### Changes
- Add `_LOGGING_ALLOWED_MODULE_PREFIXES` and `_LOGGING_MODULE_ALLOWLIST` validator
- Check allowlist before `importlib.import_module()` in `_resolve_logging_class`
- Update tests to mock allowlist for custom filter classes

### Questions for reviewers
*  Should we restrict the selection just to `logging` and `kedro.logging` and not add allowlisting mechanism just yet?


## Developer Certificate of Origin

All commits must be signed off to comply with the [DCO](https://developercertificate.org/). If your PR is blocked due to unsigned commits, follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR.

## Checklist

- [ ] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Linked to a relevant GitHub issue
- [ ] Signed off each commit with a [DCO](https://developercertificate.org/)
- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [ ] Added tests to cover my changes
