### PR TITLE
Add environment variable to allowlist custom logging modules

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,7 +4,7 @@
 
 ## Bug fixes and other changes
 
-- Fixed a remote code execution vulnerability in logging configuration. `logging`, `logging.handlers`, and `kedro.logging` are trusted by default. Other modules can be opted in via the new `KEDRO_LOGGING_MODULE_ALLOWLIST` environment variable.
+- Hardened validation of custom classes in `conf/logging.yml`: modules are now checked against an allowlist before import. `logging`, `logging.handlers`, and `kedro.logging` are trusted by default. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to allow additional modules.
 
 ## Documentation changes
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,6 +4,8 @@
 
 ## Bug fixes and other changes
 
+- Fixed a remote code execution vulnerability in logging configuration. `logging`, `logging.handlers`, and `kedro.logging` are trusted by default. Other modules can be opted in via the new `KEDRO_LOGGING_MODULE_ALLOWLIST` environment variable.
+
 ## Documentation changes
 
 ## Breaking changes to the API

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,11 +4,11 @@
 
 ## Bug fixes and other changes
 
-- Hardened validation of custom classes in `conf/logging.yml`: modules are now checked against an allowlist before import. `logging`, `logging.handlers`, and `kedro.logging` are trusted by default. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to allow additional modules.
-
 ## Documentation changes
 
 ## Breaking changes to the API
+
+- **Security fix**: Custom logging handler, filter or formatter classes referenced in `conf/logging.yml` are no longer imported unless their module is on the logging allowlist. Only the `logging` standard-library package (including `logging.handlers`) and `kedro.logging` are trusted by default. Projects that point `conf/logging.yml` at their own logging classes must now list those modules in the `KEDRO_LOGGING_MODULE_ALLOWLIST` environment variable (comma-separated) to keep them working.
 
 ## Community contributions
 

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -182,7 +182,7 @@ root:
   level: INFO
 ```
 
-By default, Kedro only allows `class` values from `logging`, `logging.handlers`, and `kedro.logging`, so a custom class such as `your_project.logging.KeepOnlyFilter` is rejected unless you explicitly allow its module. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to a comma-separated list of trusted module prefixes:
+By default, Kedro allows `class` values from `logging`, `logging.handlers`, and `kedro.logging`, so a custom class such as `your_project.logging.KeepOnlyFilter` is rejected unless you explicitly allow its module. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to a comma-separated list of trusted module prefixes:
 
 ```bash
 export KEDRO_LOGGING_MODULE_ALLOWLIST=your_project.logging

--- a/docs/develop/logging.md
+++ b/docs/develop/logging.md
@@ -182,10 +182,16 @@ root:
   level: INFO
 ```
 
+By default, Kedro only allows `class` values from `logging`, `logging.handlers`, and `kedro.logging`, so a custom class such as `your_project.logging.KeepOnlyFilter` is rejected unless you explicitly allow its module. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to a comma-separated list of trusted module prefixes:
+
+```bash
+export KEDRO_LOGGING_MODULE_ALLOWLIST=your_project.logging
+```
+
 !!! note
 
     Standard Python logging configuration also supports the `()` factory key for custom objects. Kedro does not allow `()` in `logging.yml` because it can execute arbitrary code.
-    Use `class` for custom `logging.Filter` subclasses instead.
+    Use `class` for custom `logging.Handler`, `logging.Formatter`, and `logging.Filter` subclasses instead.
 
 ## How to customise the `rich` handler
 

--- a/kedro/framework/project/__init__.py
+++ b/kedro/framework/project/__init__.py
@@ -22,7 +22,7 @@ from dynaconf.validator import ValidationError, Validator
 
 from kedro.io import CatalogProtocol
 from kedro.pipeline import Pipeline, pipeline
-from kedro.utils import find_config_file
+from kedro.utils import _is_module_allowed, find_config_file
 
 if TYPE_CHECKING:
     import types
@@ -37,6 +37,10 @@ _LOGGING_BASE_CLASSES = (
     logging.Formatter,
     logging.Filter,
 )
+
+# Modules trusted by default to supply logging handler/formatter/filter classes.
+# Extended via the KEDRO_LOGGING_MODULE_ALLOWLIST env var.
+_DEFAULT_LOGGING_MODULE_ALLOWLIST = ("logging", "kedro.logging")
 
 
 def _get_default_class(class_import_path: str) -> Any:
@@ -301,6 +305,20 @@ class _ProjectLogging(UserDict):
         """Initialise project logging. The path to logging configuration is given in
         environment variable KEDRO_LOGGING_CONFIG (defaults to conf/logging.yml)."""
         logger = logging.getLogger(__name__)
+
+        # Extra trusted logging modules, on top of _DEFAULT_LOGGING_MODULE_ALLOWLIST.
+        _logging_module_allowlist_env = os.environ.get(
+            "KEDRO_LOGGING_MODULE_ALLOWLIST", ""
+        )
+        _extra_allowlist_logging_modules = tuple(
+            module.strip()
+            for module in _logging_module_allowlist_env.split(",")
+            if module.strip()
+        )
+        self._logging_module_allowlist = (
+            _DEFAULT_LOGGING_MODULE_ALLOWLIST + _extra_allowlist_logging_modules
+        )
+
         user_logging_path = os.environ.get("KEDRO_LOGGING_CONFIG")
         project_logging_path = find_config_file("conf/logging")
         default_logging_path = Path(
@@ -347,6 +365,16 @@ class _ProjectLogging(UserDict):
         if not module_path:
             # Bare name (e.g. "StreamHandler") resolved internally by logging machinery.
             return None
+
+        # Check against the allowlist before importing, so an untrusted module's
+        # top-level code can't run regardless of what the class check finds.
+        if not _is_module_allowed(module_path, self._logging_module_allowlist):
+            raise ValueError(
+                f"Module '{module_path}' specified as a logging class is not "
+                "permitted. Only 'logging', 'kedro.logging', and modules listed "
+                "in the KEDRO_LOGGING_MODULE_ALLOWLIST environment variable are "
+                "allowed."
+            )
 
         try:
             module = importlib.import_module(module_path)

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -21,6 +21,10 @@ class KeepOnlyFilter(logging.Filter):
         return "KEEP" in record.getMessage()
 
 
+class NotALoggingClass:
+    """A plain class, not a subclass of Handler, Formatter, or Filter."""
+
+
 @pytest.fixture
 def default_logging_config_with_project():
     logging_config = {
@@ -432,11 +436,11 @@ def test_validate_logging_class_allows_legitimate_classes(class_path):
     ],
 )
 def test_validate_logging_class_blocks_non_logging_classes(class_path):
-    """Non-logging classes (e.g. subprocess.Popen) must be rejected."""
+    """Non-logging classes (e.g. subprocess.Popen) must be rejected as not allowlisted."""
     from kedro.framework.project import _ProjectLogging
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Invalid logging class"):
+    with pytest.raises(ValueError, match="is not permitted"):
         logging_instance._validate_logging_class(class_path)
 
 
@@ -450,12 +454,27 @@ def test_validate_logging_class_blocks_nonexistent_class():
 
 
 def test_validate_logging_class_blocks_nonexistent_module():
-    """A class from a non-importable module must be rejected."""
+    """A class from a non-allowlisted module must be rejected before import is attempted."""
     from kedro.framework.project import _ProjectLogging
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Cannot import module"):
+    with pytest.raises(ValueError, match="is not permitted"):
         logging_instance._validate_logging_class("totally.fake.module.Handler")
+
+
+def test_validate_logging_class_blocks_import_before_validation(tmp_path, monkeypatch):
+    """Regression test: an attacker-named module must never be imported to validate it."""
+    from kedro.framework.project import _ProjectLogging
+
+    monkeypatch.syspath_prepend(str(tmp_path))
+    marker_module = tmp_path / "kedro_test_marker_module.py"
+    marker_module.write_text("EXECUTED = True\nclass NotAHandler:\n    pass\n")
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="is not permitted"):
+        logging_instance._validate_logging_class("kedro_test_marker_module.NotAHandler")
+
+    assert "kedro_test_marker_module" not in sys.modules
 
 
 def test_validate_logging_class_bare_name_passes():
@@ -466,9 +485,54 @@ def test_validate_logging_class_bare_name_passes():
     logging_instance._validate_logging_class("StreamHandler")  # should not raise
 
 
-def test_configure_logging_instantiates_custom_filter_class():
+def test_validate_logging_class_allowlist_env_var(monkeypatch):
+    """KEDRO_LOGGING_MODULE_ALLOWLIST opts a module in on top of the defaults."""
     from kedro.framework.project import _ProjectLogging
 
+    class_path = f"{__name__}.KeepOnlyFilter"
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="is not permitted"):
+        logging_instance._validate_logging_class(class_path)
+
+    monkeypatch.setenv("KEDRO_LOGGING_MODULE_ALLOWLIST", __name__)
+    logging_instance = _ProjectLogging()
+    assert logging_instance._validate_logging_class(class_path) is KeepOnlyFilter
+
+
+def test_validate_logging_class_covers_custom_formatter(monkeypatch):
+    """Formatters must go through the same allowlist + issubclass check as handlers."""
+    from kedro.framework.project import _ProjectLogging
+
+    formatter_class = f"{__name__}.NotALoggingClass"
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {"custom": {"class": formatter_class}},
+        "handlers": {
+            "stream": {"class": "logging.StreamHandler", "formatter": "custom"}
+        },
+        "root": {"handlers": ["stream"]},
+    }
+
+    # Blocked by the allowlist check even before the issubclass check.
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="is not permitted"):
+        logging_instance.configure(logging_config)
+
+    # Allowlisted, but still rejected: NotALoggingClass isn't a Handler,
+    # Formatter, or Filter subclass.
+    monkeypatch.setenv("KEDRO_LOGGING_MODULE_ALLOWLIST", __name__)
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Invalid logging class"):
+        logging_instance.configure(logging_config)
+
+
+def test_configure_logging_instantiates_custom_filter_class(monkeypatch):
+    from kedro.framework.project import _ProjectLogging
+
+    # A custom filter class outside the default allowlist requires opt-in.
+    monkeypatch.setenv("KEDRO_LOGGING_MODULE_ALLOWLIST", __name__)
     stream = io.StringIO()
     filter_class = f"{__name__}.KeepOnlyFilter"
     logging_config = {
@@ -506,9 +570,33 @@ def test_configure_logging_instantiates_custom_filter_class():
     assert logged_messages == "KEEP this message\n"
 
 
-def test_configure_logging_passes_custom_filter_constructor_parameters():
+def test_configure_logging_rejects_custom_filter_class_without_allowlist():
+    """A custom filter class must be rejected without KEDRO_LOGGING_MODULE_ALLOWLIST."""
     from kedro.framework.project import _ProjectLogging
 
+    filter_class = f"{__name__}.KeepOnlyFilter"
+    logging_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "filters": {"keep_only": {"class": filter_class}},
+        "handlers": {
+            "stream": {
+                "class": "logging.StreamHandler",
+                "filters": ["keep_only"],
+            }
+        },
+        "root": {"handlers": ["stream"], "level": "INFO"},
+    }
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="is not permitted"):
+        logging_instance.configure(logging_config)
+
+
+def test_configure_logging_passes_custom_filter_constructor_parameters(monkeypatch):
+    from kedro.framework.project import _ProjectLogging
+
+    monkeypatch.setenv("KEDRO_LOGGING_MODULE_ALLOWLIST", __name__)
     stream = io.StringIO()
     filter_class = f"{__name__}.KeepOnlyFilter"
     logging_config = {
@@ -538,9 +626,10 @@ def test_configure_logging_passes_custom_filter_constructor_parameters():
     }
 
 
-def test_configure_logging_reuses_validated_filter_class():
+def test_configure_logging_reuses_validated_filter_class(monkeypatch):
     from kedro.framework.project import _ProjectLogging
 
+    monkeypatch.setenv("KEDRO_LOGGING_MODULE_ALLOWLIST", __name__)
     filter_class = f"{__name__}.KeepOnlyFilter"
     logging_config = {
         "version": 1,
@@ -664,7 +753,7 @@ def test_validate_config_blocks_rce_via_class():
     }
 
     logging_instance = _ProjectLogging()
-    with pytest.raises(ValueError, match="Invalid logging class"):
+    with pytest.raises(ValueError, match="is not permitted"):
         logging_instance.configure(malicious_config)
 
 

--- a/tests/framework/project/test_logging.py
+++ b/tests/framework/project/test_logging.py
@@ -462,6 +462,17 @@ def test_validate_logging_class_blocks_nonexistent_module():
         logging_instance._validate_logging_class("totally.fake.module.Handler")
 
 
+def test_validate_logging_class_blocks_unimportable_allowlisted_module():
+    """An allowlisted but nonexistent module must still fail with a clear import error."""
+    from kedro.framework.project import _ProjectLogging
+
+    logging_instance = _ProjectLogging()
+    with pytest.raises(ValueError, match="Cannot import module"):
+        logging_instance._validate_logging_class(
+            "logging.nonexistent_submodule.Handler"
+        )
+
+
 def test_validate_logging_class_blocks_import_before_validation(tmp_path, monkeypatch):
     """Regression test: an attacker-named module must never be imported to validate it."""
     from kedro.framework.project import _ProjectLogging


### PR DESCRIPTION
## Description

Hardened validation of custom classes in `conf/logging.yml`: modules are now checked against an allowlist before import. `logging`, `logging.handlers`, and `kedro.logging` are trusted by default. Set `KEDRO_LOGGING_MODULE_ALLOWLIST` to allow additional modules. 

## Development notes

- Updated `_ProjectLogging` to include `KEDRO_LOGGING_MODULE_ALLOWLIST` validation before module import

**NOTE:** Deferred this **Fix the identical import-before-validate ordering in load_obj/_load_obj (kedro/utils.py / kedro/io/core.py) in the same PR, since it is the same root cause the reporter flagged.** as this might break genuine catalog imports

## Developer Certificate of Origin

All commits must be signed off to comply with the [DCO](https://developercertificate.org/). If your PR is blocked due to unsigned commits, follow the instructions under "Rebase the branch" on the GitHub Checks page for your PR.

## Checklist

- [x] Read the [contributing](https://github.com/kedro-org/kedro/blob/main/CONTRIBUTING.md) guidelines
- [ ] Linked to a relevant GitHub issue
- [x] Signed off each commit with a [DCO](https://developercertificate.org/)
- [x] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [x] Updated the documentation to reflect the code changes
- [x] Added a description of this change in the [`RELEASE.md`](https://github.com/kedro-org/kedro/blob/main/RELEASE.md) file
- [x] Added tests to cover my changes
